### PR TITLE
feat: gistui MVP — a terminal UI for managing GitHub Gists

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: chore
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  test:
+    name: Test & Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Clippy (deny warnings)
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Test
+        run: cargo test --locked
+
+      - name: Build
+        run: cargo build --locked --release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: Test & Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-`gistui` is a Rust 2021 TUI that pairs local config files with GitHub gist files, previews diffs, and downloads/uploads through the GitHub CLI (`gh`).
+`gistui` is a Rust 2021 TUI for managing GitHub Gists — browse/diff/download/upload/create/pin gists and pair them with files in the working directory, all through the GitHub CLI (`gh`).
 
 ## Build / Test / Run
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# AGENTS.md
+
+`gistui` is a Rust 2021 TUI that pairs local config files with GitHub gist files, previews diffs, and downloads/uploads through the GitHub CLI (`gh`).
+
+## Build / Test / Run
+
+```bash
+cargo run               # launch the TUI (needs a TTY)
+cargo run -- --check    # print gh readiness, then exit (no TUI)
+cargo test              # full suite; must NOT touch the network or require gh auth
+```
+
+## Verification Gate (run before every commit)
+
+All four MUST pass — the project treats clippy warnings as errors:
+
+```bash
+cargo fmt --check
+cargo test
+cargo check
+cargo clippy --all-targets -- -D warnings
+```
+
+If `cargo fmt --check` fails, run `cargo fmt` and confirm only formatting changed.
+
+## Architecture
+
+Pure, testable domain logic is kept separate from impure shell/filesystem adapters:
+
+- Pure modules (unit-tested): `domain`, `config`, `ranking`, `local`, `diff`, and the command-planning/guard parts of `actions`.
+- Thin IO boundaries (not unit-tested by design): `gh` (`gh` subprocess calls), the `actions` execute helpers, and the IO helper fns in `tui::run_loop`.
+- `tui.rs` is a screen state machine (`Screen::{List, Diff, ConfirmOverwrite}`). `AppState::handle_key` is **pure** — it mutates state and returns a `KeyOutcome` intent; `run_loop` performs the IO for `PreviewDiff`/`Download`/`DownloadGist`. Keep new key logic in `handle_key` (testable) and new IO in `run_loop` helpers.
+- `run()` wraps `run_loop()` so terminal teardown (raw mode / alternate screen) ALWAYS runs, even on error — keep fallible startup/IO inside `run_loop`, never between `enable_raw_mode` and the teardown.
+
+## Non-Obvious Rules
+
+- Tests must never call the real `gh` or the network. `gh` JSON parsing is tested against fixtures in `tests/fixtures/gh/`; IO functions are left as thin untested boundaries.
+- Downloads only write to `cwd/<gist-filename>`. The overwrite gate is the invariant to preserve: an *existing* target is never overwritten without first showing its diff and a `y/n` confirmation (`Screen::ConfirmOverwrite`); writing a path that does not yet exist is allowed directly (no diff forced). Do not add a write path that overwrites an existing file without that diff+confirm.
+- No GitHub tokens are stored by the app, and gist *content* is never written to the config file (`~/.config/gistui/config.toml`, XDG-aware) — only path↔gist mappings.
+- `frame.size()` is correct for the pinned `ratatui` 0.26 (do not "modernize" to `frame.area()`, which is a later-version API).
+
+## Conventions
+
+- Commit messages: Conventional Commits, in English (e.g. `feat:`, `docs:`, `fix:`).
+- Fold same-scope follow-up fixes into the original commit (amend) rather than adding `fix typo` / `review fix` commits.
+
+## Claude Code compatibility
+
+`CLAUDE.md` is a symbolic link to this `AGENTS.md`, so Claude Code and any AGENTS.md-aware assistant read the same project memory. Edit `AGENTS.md`; never edit `CLAUDE.md` directly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "gistui"
 version = "0.1.0"
 edition = "2021"
 license = "MIT"
+description = "A terminal UI for managing GitHub Gists"
 
 [dependencies]
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ horizontally). Currently wired:
 - `n` (on a local file) — create a new gist from it; choose `s` secret or `p` public.
 - `p` (on a gist) — toggle a pin between the selected local file and gist (persisted to
   config; pinned pairs sort to the top with `⭐⭐⭐`).
+- `o` (on a gist) — open it on gist.github.com in your web browser.
+- `e` (on a local file) — open it in `$VISUAL`/`$EDITOR` (the TUI suspends while the editor
+  runs and restores afterwards).
 - `Enter` (on a gist) — preview the unified diff in a full-screen overlay without writing
   anything (`Up`/`Down`/`Left`/`Right` to scroll, `d` to download from there, `Esc` to go
   back).

--- a/README.md
+++ b/README.md
@@ -1,57 +1,97 @@
 # gistui
 
-`gistui` is a Rust TUI for pairing local config files with GitHub gist files.
+`gistui` is a Rust TUI for pairing local config files with GitHub gist files — browse,
+diff, download, upload, create, and pin, all through the GitHub CLI (`gh`).
 
 ## Requirements
 
-- Rust toolchain
-- GitHub CLI: `gh`
-- Existing GitHub auth: `gh auth login`
+- A Rust toolchain (to build) — <https://rustup.rs>
+- The GitHub CLI: [`gh`](https://cli.github.com), installed and on your `PATH`
+- An authenticated `gh` session: `gh auth login`
 
-## Available Actions
+`gistui` shells out to `gh` at runtime (it stores no GitHub token of its own), so `gh` must
+be installed and authenticated wherever you run `gistui`.
+
+## Installation
+
+Install the binary into `~/.cargo/bin` (make sure that directory is on your `PATH`):
+
+```bash
+cargo install --path .
+```
+
+Or build a release binary and place it yourself:
+
+```bash
+cargo build --release
+# binary is at target/release/gistui — copy or symlink it onto your PATH, e.g.
+ln -sf "$PWD/target/release/gistui" ~/.local/bin/gistui
+```
+
+## Usage
+
+```bash
+gistui            # launch the TUI (needs a TTY)
+gistui --check    # print gh readiness, then exit (no TUI)
+```
+
+Run `gistui` from the directory whose files you want to pair with your gists. Inside the
+TUI press `?` for the full keymap; the footer shows the keys relevant to the focused pane.
 
 The left pane lists the files in your current working directory; the right pane lists your
-gists, ranked against the selected local file. Stronger matches are prefixed with stars
-(⭐⭐⭐ exact-filename/pinned, ⭐⭐ path hint); weak/no matches show none. Browse both panes
-(`Tab` to switch focus, `Up`/`Down` to move, `Left`/`Right` to scroll a long row
-horizontally). Currently wired:
+gists, ranked against the selected local file (stronger matches are prefixed with stars:
+⭐⭐⭐ exact-filename/pinned, ⭐⭐ path hint). Browse with `Tab` (switch pane), `Up`/`Down`
+(move), and `Left`/`Right` (scroll a long row).
 
-- `d` (on a gist) — download it into the current working directory under the gist's own
-  filename (`./<gist-filename>`). If no such file exists yet it is written straight away; if
-  a same-named file already exists, its diff is shown first and you must confirm the
-  overwrite with `y`/`n`.
-- `u` (on a gist) — upload the selected local file into that gist under the local file's
-  name. If the gist has no file of that name it is added directly; if it already has one,
-  its diff is shown and you confirm the overwrite with `y`/`n`.
+### Actions
+
+- `Enter` (on a gist) — preview the unified diff between the selected local file and the
+  gist, with `+`/`-` colour. From there `d` downloads or `u` uploads.
+- `d` (on a gist) — download it into the cwd as `./<gist-filename>`. A brand-new file is
+  written directly; an existing one is shown as a diff and overwritten only after a `y`/`n`
+  confirmation.
+- `u` (on a gist) — upload the selected local file into the gist under the local file's
+  name (added directly, or diff + `y`/`n` if it would overwrite a same-named gist file).
 - `n` (on a local file) — create a new gist from it; choose `s` secret or `p` public.
 - `p` (on a gist) — toggle a pin between the selected local file and gist (persisted to
-  config; pinned pairs sort to the top with `⭐⭐⭐`).
-- `o` (on a gist) — open it on gist.github.com in your web browser.
-- `e` (on a local file) — open it in `$VISUAL`/`$EDITOR` (the TUI suspends while the editor
-  runs and restores afterwards).
-- `Enter` (on a gist) — preview the unified diff in a full-screen overlay without writing
-  anything (`Up`/`Down`/`Left`/`Right` to scroll, `d` to download from there, `Esc` to go
-  back).
-- `t` — toggle the gist rows between description view (`<filename> — <description>`) and id
-  view (`<gist-id> / <filename>`), the latter disambiguating same-named files.
-- `q` — quit.
+  config; pinned pairs sort to the top).
+- `o` (on a gist) — open it on gist.github.com in your browser.
+- `e` (on a local file) — open it in `$VISUAL`/`$EDITOR`.
+- `Space` (on a gist) — preview the gist's raw content in a scrollable overlay.
+- `/` filter by text · `v` cycle visibility (all/public/secret) · `s` cycle sort · `t`
+  toggle row view.
+- `Esc`/`q` — go back from an overlay; quit the app from the main list.
 
 When no local file is selected (e.g. an empty directory), the right pane lists all gists
 unranked so you can still preview and download into the current directory.
 
-## MVP Safety Rules
+## Safety rules
 
 - Downloads only ever write to `./<gist-filename>` in the current working directory.
-- An existing file at the download target is never overwritten without first showing its
-  diff and a `y/n` confirmation. (Writing a brand-new file that does not exist yet is direct.)
-- The diff shows the remote content that will be written (fetched fresh at preview time).
-- GitHub tokens are not stored by this app.
-- Gist content is not stored in config.
+- An existing file (local download target or remote gist file) is never overwritten without
+  first showing its diff and a `y`/`n` confirmation. Writing something that does not yet
+  exist is direct.
+- Identical files are detected: when the two sides match, upload/download are disabled.
+- No GitHub token is stored by the app, and gist content is never written to the config
+  file — only path↔gist pin mappings are persisted.
+
+## Building a release
+
+```bash
+cargo build --release
+```
+
+The optimized binary is `target/release/gistui`. It bundles no assets, but still requires
+the `gh` CLI on `PATH` at runtime (`gh` is not vendored). Optionally shrink it with
+`strip target/release/gistui`.
 
 ## Development
 
+All four checks must pass before committing (clippy warnings are treated as errors):
+
 ```bash
-cargo check
+cargo fmt --check
 cargo test
-cargo run -- --check
+cargo check
+cargo clippy --all-targets -- -D warnings
 ```

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ horizontally). Currently wired:
   filename (`./<gist-filename>`). If no such file exists yet it is written straight away; if
   a same-named file already exists, its diff is shown first and you must confirm the
   overwrite with `y`/`n`.
+- `u` (on a gist) — upload the selected local file into that gist under the local file's
+  name. If the gist has no file of that name it is added directly; if it already has one,
+  its diff is shown and you confirm the overwrite with `y`/`n`.
+- `n` (on a local file) — create a new gist from it; choose `s` secret or `p` public.
+- `p` (on a gist) — toggle a pin between the selected local file and gist (persisted to
+  config; pinned pairs sort to the top with `⭐⭐⭐`).
 - `Enter` (on a gist) — preview the unified diff in a full-screen overlay without writing
   anything (`Up`/`Down`/`Left`/`Right` to scroll, `d` to download from there, `Esc` to go
   back).

--- a/README.md
+++ b/README.md
@@ -8,11 +8,34 @@
 - GitHub CLI: `gh`
 - Existing GitHub auth: `gh auth login`
 
+## Available Actions
+
+The left pane lists the files in your current working directory; the right pane lists your
+gists, ranked against the selected local file. Stronger matches are prefixed with stars
+(⭐⭐⭐ exact-filename/pinned, ⭐⭐ path hint); weak/no matches show none. Browse both panes
+(`Tab` to switch focus, `Up`/`Down` to move, `Left`/`Right` to scroll a long row
+horizontally). Currently wired:
+
+- `d` (on a gist) — download it into the current working directory under the gist's own
+  filename (`./<gist-filename>`). If no such file exists yet it is written straight away; if
+  a same-named file already exists, its diff is shown first and you must confirm the
+  overwrite with `y`/`n`.
+- `Enter` (on a gist) — preview the unified diff in a full-screen overlay without writing
+  anything (`Up`/`Down`/`Left`/`Right` to scroll, `d` to download from there, `Esc` to go
+  back).
+- `t` — toggle the gist rows between description view (`<filename> — <description>`) and id
+  view (`<gist-id> / <filename>`), the latter disambiguating same-named files.
+- `q` — quit.
+
+When no local file is selected (e.g. an empty directory), the right pane lists all gists
+unranked so you can still preview and download into the current directory.
+
 ## MVP Safety Rules
 
-- Upload and download flows preview changes before writing.
-- Existing local files are not overwritten without confirmation.
-- Remote gist content is fetched again before write-like actions.
+- Downloads only ever write to `./<gist-filename>` in the current working directory.
+- An existing file at the download target is never overwritten without first showing its
+  diff and a `y/n` confirmation. (Writing a brand-new file that does not exist yet is direct.)
+- The diff shows the remote content that will be written (fetched fresh at preview time).
 - GitHub tokens are not stored by this app.
 - Gist content is not stored in config.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # gistui
 
-`gistui` is a Rust TUI for pairing local config files with GitHub gist files — browse,
-diff, download, upload, create, and pin, all through the GitHub CLI (`gh`).
+A terminal UI for managing GitHub Gists. Browse, diff, download, upload, create, and pin
+your gists — and pair them with files in your working directory — all through the GitHub
+CLI (`gh`).
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# gistui
+
+`gistui` is a Rust TUI for pairing local config files with GitHub gist files.
+
+## Requirements
+
+- Rust toolchain
+- GitHub CLI: `gh`
+- Existing GitHub auth: `gh auth login`
+
+## MVP Safety Rules
+
+- Upload and download flows preview changes before writing.
+- Existing local files are not overwritten without confirmation.
+- Remote gist content is fetched again before write-like actions.
+- GitHub tokens are not stored by this app.
+- Gist content is not stored in config.
+
+## Development
+
+```bash
+cargo check
+cargo test
+cargo run -- --check
+```

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -71,6 +71,18 @@ pub fn upload_add_command(local_path: &Path, gist_id: &str) -> CommandPlan {
     }
 }
 
+pub fn open_browser_command(gist_id: &str) -> CommandPlan {
+    CommandPlan {
+        program: "gh".into(),
+        args: vec![
+            "gist".into(),
+            "view".into(),
+            gist_id.to_string(),
+            "--web".into(),
+        ],
+    }
+}
+
 pub fn create_command(local_path: &Path, public: bool) -> CommandPlan {
     let mut args = vec![
         "gist".into(),
@@ -213,6 +225,13 @@ mod tests {
             plan.args,
             vec!["gist", "edit", "abc123", "--add", "/tmp/config.toml"]
         );
+    }
+
+    #[test]
+    fn open_browser_command_targets_gist_web_view() {
+        let plan = open_browser_command("abc123");
+        assert_eq!(plan.program, "gh");
+        assert_eq!(plan.args, vec!["gist", "view", "abc123", "--web"]);
     }
 
     #[test]

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1,3 +1,75 @@
-pub fn _module_ready() -> bool {
-    true
+use crate::domain::GistFile;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PendingAction {
+    Upload {
+        local_path: PathBuf,
+        target: GistFile,
+    },
+    Download {
+        source: GistFile,
+        local_path: PathBuf,
+    },
+    Create {
+        local_path: PathBuf,
+        filename: String,
+        public: bool,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfirmedAction {
+    pub action: PendingAction,
+}
+
+pub fn confirm_action(
+    action: Option<PendingAction>,
+    diff_previewed: bool,
+) -> Option<ConfirmedAction> {
+    if diff_previewed {
+        action.map(|action| ConfirmedAction { action })
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gist_file() -> GistFile {
+        GistFile {
+            gist_id: "abc123".into(),
+            description: "config".into(),
+            filename: "settings.json".into(),
+            public: false,
+            updated_at: "2026-06-08T00:00:00Z".into(),
+        }
+    }
+
+    #[test]
+    fn cannot_confirm_without_diff_preview() {
+        let action = PendingAction::Upload {
+            local_path: PathBuf::from("/tmp/settings.json"),
+            target: gist_file(),
+        };
+
+        assert_eq!(confirm_action(Some(action), false), None);
+    }
+
+    #[test]
+    fn can_confirm_after_diff_preview() {
+        let action = PendingAction::Download {
+            source: gist_file(),
+            local_path: PathBuf::from("/tmp/settings.json"),
+        };
+
+        assert!(confirm_action(Some(action), true).is_some());
+    }
+
+    #[test]
+    fn no_action_yields_none_even_after_preview() {
+        assert_eq!(confirm_action(None, true), None);
+    }
 }

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -58,6 +58,19 @@ pub fn upload_command(local_path: &Path, target: &GistFile) -> CommandPlan {
     }
 }
 
+pub fn upload_add_command(local_path: &Path, gist_id: &str) -> CommandPlan {
+    CommandPlan {
+        program: "gh".into(),
+        args: vec![
+            "gist".into(),
+            "edit".into(),
+            gist_id.to_string(),
+            "--add".into(),
+            local_path.display().to_string(),
+        ],
+    }
+}
+
 pub fn create_command(local_path: &Path, public: bool) -> CommandPlan {
     let mut args = vec![
         "gist".into(),
@@ -177,6 +190,16 @@ mod tests {
                 "settings.json",
                 "/tmp/settings.json"
             ]
+        );
+    }
+
+    #[test]
+    fn upload_add_command_adds_local_file_to_gist() {
+        let plan = upload_add_command(PathBuf::from("/tmp/config.toml").as_path(), "abc123");
+        assert_eq!(plan.program, "gh");
+        assert_eq!(
+            plan.args,
+            vec!["gist", "edit", "abc123", "--add", "/tmp/config.toml"]
         );
     }
 

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1,5 +1,9 @@
-use crate::domain::GistFile;
-use std::path::PathBuf;
+use crate::config::{save_config, AppConfig};
+use crate::domain::{GistFile, PinnedMapping, SyncDirection};
+use anyhow::{bail, Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PendingAction {
@@ -34,9 +38,93 @@ pub fn confirm_action(
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandPlan {
+    pub program: String,
+    pub args: Vec<String>,
+}
+
+pub fn upload_command(local_path: &Path, target: &GistFile) -> CommandPlan {
+    CommandPlan {
+        program: "gh".into(),
+        args: vec![
+            "gist".into(),
+            "edit".into(),
+            target.gist_id.clone(),
+            "--filename".into(),
+            target.filename.clone(),
+            local_path.display().to_string(),
+        ],
+    }
+}
+
+pub fn create_command(local_path: &Path, public: bool) -> CommandPlan {
+    let mut args = vec![
+        "gist".into(),
+        "create".into(),
+        local_path.display().to_string(),
+    ];
+    if public {
+        args.push("--public".into());
+    }
+    CommandPlan {
+        program: "gh".into(),
+        args,
+    }
+}
+
+pub fn execute_command(plan: &CommandPlan) -> Result<String> {
+    let output = Command::new(&plan.program)
+        .args(&plan.args)
+        .output()
+        .with_context(|| format!("run {} {}", plan.program, plan.args.join(" ")))?;
+
+    if !output.status.success() {
+        bail!("{}", String::from_utf8_lossy(&output.stderr));
+    }
+
+    Ok(String::from_utf8(output.stdout)?)
+}
+
+pub fn execute_download(local_path: &Path, content: &str, overwrite_confirmed: bool) -> Result<()> {
+    if local_path.exists() && !overwrite_confirmed {
+        bail!(
+            "refusing to overwrite {} without confirmation",
+            local_path.display()
+        );
+    }
+    if let Some(parent) = local_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(local_path, content).with_context(|| format!("write {}", local_path.display()))
+}
+
+pub fn pin_mapping(
+    config_path: &Path,
+    mut config: AppConfig,
+    local_path: &Path,
+    target: &GistFile,
+    direction: Option<SyncDirection>,
+    last_seen_hash: Option<String>,
+) -> Result<AppConfig> {
+    config
+        .pinned
+        .retain(|mapping| mapping.local_path != local_path);
+    config.pinned.push(PinnedMapping {
+        local_path: local_path.to_path_buf(),
+        gist_id: target.gist_id.clone(),
+        gist_filename: target.filename.clone(),
+        direction,
+        last_seen_hash,
+    });
+    save_config(config_path, &config)?;
+    Ok(config)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::{load_config, AppConfig};
 
     fn gist_file() -> GistFile {
         GistFile {
@@ -71,5 +159,65 @@ mod tests {
     #[test]
     fn no_action_yields_none_even_after_preview() {
         assert_eq!(confirm_action(None, true), None);
+    }
+
+    #[test]
+    fn upload_command_replaces_specific_gist_file() {
+        let target = gist_file();
+        let plan = upload_command(PathBuf::from("/tmp/settings.json").as_path(), &target);
+
+        assert_eq!(plan.program, "gh");
+        assert_eq!(
+            plan.args,
+            vec![
+                "gist",
+                "edit",
+                "abc123",
+                "--filename",
+                "settings.json",
+                "/tmp/settings.json"
+            ]
+        );
+    }
+
+    #[test]
+    fn create_command_defaults_to_secret() {
+        let plan = create_command(PathBuf::from("/tmp/settings.json").as_path(), false);
+        assert_eq!(plan.args, vec!["gist", "create", "/tmp/settings.json"]);
+        assert!(!plan.args.contains(&"--public".to_string()));
+    }
+
+    #[test]
+    fn download_refuses_unconfirmed_overwrite() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(&path, "old").unwrap();
+
+        let err = execute_download(&path, "new", false).unwrap_err();
+        assert!(err.to_string().contains("refusing to overwrite"));
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "old");
+    }
+
+    #[test]
+    fn pin_mapping_replaces_existing_local_mapping() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+        let local_path = dir.path().join("settings.json");
+        let target = gist_file();
+
+        let config = pin_mapping(
+            &config_path,
+            AppConfig::default(),
+            &local_path,
+            &target,
+            Some(crate::domain::SyncDirection::Upload),
+            Some("hash".into()),
+        )
+        .unwrap();
+
+        assert_eq!(config.pinned.len(), 1);
+        let loaded = load_config(&config_path).unwrap();
+        assert_eq!(loaded.pinned[0].local_path, local_path);
+        assert_eq!(loaded.pinned[0].gist_id, "abc123");
     }
 }

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -134,6 +134,18 @@ pub fn pin_mapping(
     Ok(config)
 }
 
+pub fn unpin_mapping(
+    config_path: &Path,
+    mut config: AppConfig,
+    local_path: &Path,
+) -> Result<AppConfig> {
+    config
+        .pinned
+        .retain(|mapping| mapping.local_path != local_path);
+    save_config(config_path, &config)?;
+    Ok(config)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -219,6 +231,30 @@ mod tests {
         let err = execute_download(&path, "new", false).unwrap_err();
         assert!(err.to_string().contains("refusing to overwrite"));
         assert_eq!(std::fs::read_to_string(&path).unwrap(), "old");
+    }
+
+    #[test]
+    fn unpin_mapping_removes_mapping_for_local_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+        let local_path = dir.path().join("settings.json");
+        let target = gist_file();
+
+        let config = pin_mapping(
+            &config_path,
+            AppConfig::default(),
+            &local_path,
+            &target,
+            None,
+            None,
+        )
+        .unwrap();
+        assert_eq!(config.pinned.len(), 1);
+
+        let config = unpin_mapping(&config_path, config, &local_path).unwrap();
+        assert!(config.pinned.is_empty());
+        let loaded = load_config(&config_path).unwrap();
+        assert!(loaded.pinned.is_empty());
     }
 
     #[test]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,74 @@
+use crate::domain::GistFile;
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Location of the on-disk gist-list cache (`$XDG_CACHE_HOME/gistui/gists.json`).
+pub fn cache_path() -> Result<PathBuf> {
+    let dir = dirs::cache_dir().context("locate cache directory")?;
+    Ok(dir.join("gistui").join("gists.json"))
+}
+
+/// Loads the cached gist list. The cache is best-effort: any missing file or parse error
+/// yields an empty list rather than failing startup.
+pub fn load_cached_gists(path: &Path) -> Vec<GistFile> {
+    fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+        .unwrap_or_default()
+}
+
+/// Writes the gist list to the cache, best-effort. Errors (e.g. missing cache dir) are
+/// swallowed so a failed cache write never disrupts the app.
+pub fn save_cached_gists(path: &Path, gists: &[GistFile]) {
+    if let Some(parent) = path.parent() {
+        if fs::create_dir_all(parent).is_err() {
+            return;
+        }
+    }
+    if let Ok(json) = serde_json::to_string(gists) {
+        let _ = fs::write(path, json);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gist(id: &str, filename: &str) -> GistFile {
+        GistFile {
+            gist_id: id.into(),
+            description: "desc".into(),
+            filename: filename.into(),
+            public: false,
+            updated_at: "2026-06-09T00:00:00Z".into(),
+        }
+    }
+
+    #[test]
+    fn save_then_load_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("gistui").join("gists.json");
+        let gists = vec![gist("a", "one.txt"), gist("b", "two.txt")];
+
+        save_cached_gists(&path, &gists);
+        let loaded = load_cached_gists(&path);
+
+        assert_eq!(loaded, gists);
+    }
+
+    #[test]
+    fn load_missing_file_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("does-not-exist.json");
+        assert!(load_cached_gists(&path).is_empty());
+    }
+
+    #[test]
+    fn load_corrupt_file_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("gists.json");
+        fs::write(&path, "not json").unwrap();
+        assert!(load_cached_gists(&path).is_empty());
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,192 @@
-pub fn _module_ready() -> bool {
-    true
+use crate::domain::PinnedMapping;
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AppConfig {
+    #[serde(default)]
+    pub pinned: Vec<PinnedMapping>,
+}
+
+pub fn normalize_path(path: &Path) -> Result<PathBuf> {
+    let expanded = if let Ok(stripped) = path.strip_prefix("~") {
+        dirs::home_dir()
+            .context("home directory not found")?
+            .join(stripped)
+    } else {
+        path.to_path_buf()
+    };
+
+    if expanded.is_absolute() {
+        Ok(expanded)
+    } else {
+        Ok(std::env::current_dir()?.join(expanded))
+    }
+}
+
+pub fn config_path() -> Result<PathBuf> {
+    let base = std::env::var_os("XDG_CONFIG_HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .map(Ok)
+        .unwrap_or_else(|| {
+            dirs::home_dir()
+                .context("home directory not found")
+                .map(|home| home.join(".config"))
+        })?;
+    Ok(base.join("gistui").join("config.toml"))
+}
+
+pub fn load_config(path: &Path) -> Result<AppConfig> {
+    if !path.exists() {
+        return Ok(AppConfig::default());
+    }
+    let raw = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+    toml::from_str(&raw).with_context(|| format!("parse {}", path.display()))
+}
+
+pub fn save_config(path: &Path, config: &AppConfig) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let raw = toml::to_string_pretty(config)?;
+    fs::write(path, raw).with_context(|| format!("write {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{PinnedMapping, SyncDirection};
+    use std::env;
+    use std::ffi::OsString;
+    use std::sync::Mutex;
+
+    static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+    struct EnvVarRestore {
+        name: &'static str,
+        value: Option<OsString>,
+    }
+
+    impl EnvVarRestore {
+        fn new(name: &'static str) -> Self {
+            Self {
+                name,
+                value: env::var_os(name),
+            }
+        }
+    }
+
+    impl Drop for EnvVarRestore {
+        fn drop(&mut self) {
+            match &self.value {
+                Some(value) => env::set_var(self.name, value),
+                None => env::remove_var(self.name),
+            }
+        }
+    }
+
+    #[test]
+    fn missing_config_loads_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = load_config(&dir.path().join("missing.toml")).unwrap();
+        assert!(config.pinned.is_empty());
+    }
+
+    #[test]
+    fn saves_and_loads_pinned_mapping() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let config = AppConfig {
+            pinned: vec![PinnedMapping {
+                local_path: PathBuf::from("/tmp/settings.json"),
+                gist_id: "abc123".into(),
+                gist_filename: "settings.json".into(),
+                direction: Some(SyncDirection::Upload),
+                last_seen_hash: Some("hash".into()),
+            }],
+        };
+
+        save_config(&path, &config).unwrap();
+        assert_eq!(load_config(&path).unwrap(), config);
+    }
+
+    #[test]
+    fn config_path_uses_xdg_config_home_when_set() {
+        let _guard = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _restore = EnvVarRestore::new("XDG_CONFIG_HOME");
+        let dir = tempfile::tempdir().unwrap();
+
+        env::set_var("XDG_CONFIG_HOME", dir.path());
+        let path = config_path().unwrap();
+
+        assert_eq!(path, dir.path().join("gistui").join("config.toml"));
+    }
+
+    #[test]
+    fn config_path_falls_back_to_home_config_when_xdg_config_home_is_unset() {
+        let _guard = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _restore = EnvVarRestore::new("XDG_CONFIG_HOME");
+
+        env::remove_var("XDG_CONFIG_HOME");
+        let path = config_path().unwrap();
+
+        assert_eq!(
+            path,
+            dirs::home_dir()
+                .unwrap()
+                .join(".config")
+                .join("gistui")
+                .join("config.toml")
+        );
+    }
+
+    #[test]
+    fn config_path_falls_back_to_home_config_when_xdg_config_home_is_empty() {
+        let _guard = ENV_MUTEX
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let _restore = EnvVarRestore::new("XDG_CONFIG_HOME");
+
+        env::set_var("XDG_CONFIG_HOME", "");
+        let path = config_path().unwrap();
+
+        assert_eq!(
+            path,
+            dirs::home_dir()
+                .unwrap()
+                .join(".config")
+                .join("gistui")
+                .join("config.toml")
+        );
+    }
+
+    #[test]
+    fn normalize_path_joins_relative_path_to_current_dir() {
+        let relative = PathBuf::from("settings.json");
+        assert_eq!(
+            normalize_path(&relative).unwrap(),
+            env::current_dir().unwrap().join(relative)
+        );
+    }
+
+    #[test]
+    fn normalize_path_expands_home_prefix() {
+        assert_eq!(
+            normalize_path(Path::new("~/settings.json")).unwrap(),
+            dirs::home_dir().unwrap().join("settings.json")
+        );
+    }
+
+    #[test]
+    fn normalize_path_preserves_absolute_path() {
+        let absolute = PathBuf::from("/tmp/settings.json");
+        assert_eq!(normalize_path(&absolute).unwrap(), absolute);
+    }
 }

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,3 +1,43 @@
-pub fn _module_ready() -> bool {
-    true
+use sha2::{Digest, Sha256};
+use similar::{ChangeTag, TextDiff};
+
+pub fn sha256_hex(content: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(content.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+pub fn unified_diff(old_label: &str, old: &str, new_label: &str, new: &str) -> String {
+    let diff = TextDiff::from_lines(old, new);
+    let mut out = format!("--- {old_label}\n+++ {new_label}\n");
+
+    for change in diff.iter_all_changes() {
+        let sign = match change.tag() {
+            ChangeTag::Delete => "-",
+            ChangeTag::Insert => "+",
+            ChangeTag::Equal => " ",
+        };
+        out.push_str(sign);
+        out.push_str(change.value());
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_is_stable() {
+        assert_eq!(sha256_hex("abc"), sha256_hex("abc"));
+        assert_ne!(sha256_hex("abc"), sha256_hex("abcd"));
+    }
+
+    #[test]
+    fn diff_shows_insert_and_delete() {
+        let diff = unified_diff("gist", "a\nb\n", "local", "a\nc\n");
+        assert!(diff.contains("-b\n"));
+        assert!(diff.contains("+c\n"));
+    }
 }

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -1,3 +1,33 @@
-pub fn _module_ready() -> bool {
-    true
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PinnedMapping {
+    pub local_path: PathBuf,
+    pub gist_id: String,
+    pub gist_filename: String,
+    pub direction: Option<SyncDirection>,
+    pub last_seen_hash: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SyncDirection {
+    Upload,
+    Download,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalCandidate {
+    pub path: PathBuf,
+    pub pinned: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GistFile {
+    pub gist_id: String,
+    pub description: String,
+    pub filename: String,
+    pub public: bool,
+    pub updated_at: String,
 }

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -23,7 +23,7 @@ pub struct LocalCandidate {
     pub pinned: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GistFile {
     pub gist_id: String,
     pub description: String,

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -1,7 +1,122 @@
-pub fn check_gh_ready() -> anyhow::Result<()> {
+use crate::domain::GistFile;
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use std::collections::BTreeMap;
+use std::process::Command;
+
+#[derive(Debug, Deserialize)]
+struct GhGist {
+    id: String,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    public: bool,
+    #[serde(default)]
+    updated_at: String,
+    // The REST API returns `files` as an object keyed by filename. BTreeMap keeps
+    // the order deterministic (by filename) for stable display and tests.
+    #[serde(default)]
+    files: BTreeMap<String, GhGistFile>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhGistFile {
+    filename: String,
+}
+
+pub fn check_gh_ready() -> Result<()> {
+    let version = Command::new("gh")
+        .arg("--version")
+        .output()
+        .context("run gh --version")?;
+    if !version.status.success() {
+        bail!("gh is installed but did not run successfully");
+    }
+
+    let auth = Command::new("gh")
+        .args(["auth", "status"])
+        .output()
+        .context("run gh auth status")?;
+    if !auth.status.success() {
+        bail!("gh auth status failed; run gh auth login");
+    }
+
     Ok(())
 }
 
-pub fn _module_ready() -> bool {
-    true
+pub fn parse_gist_list_json(raw: &str) -> Result<Vec<GistFile>> {
+    let gists: Vec<GhGist> = serde_json::from_str(raw).context("parse gh gist list JSON")?;
+    let mut files = Vec::new();
+
+    for gist in gists {
+        let description = gist.description.unwrap_or_default();
+        for file in gist.files.into_values() {
+            files.push(GistFile {
+                gist_id: gist.id.clone(),
+                description: description.clone(),
+                filename: file.filename,
+                public: gist.public,
+                updated_at: gist.updated_at.clone(),
+            });
+        }
+    }
+
+    Ok(files)
+}
+
+pub fn fetch_gist_list_json() -> Result<String> {
+    // `gh gist list` has no `--json` flag; the REST API returns the structured
+    // shape parsed by `parse_gist_list_json` (files keyed by name, snake_case fields).
+    let output = Command::new("gh")
+        .args(["api", "/gists?per_page=100"])
+        .output()
+        .context("run gh api /gists")?;
+
+    if !output.status.success() {
+        bail!("{}", String::from_utf8_lossy(&output.stderr));
+    }
+
+    Ok(String::from_utf8(output.stdout)?)
+}
+
+pub fn fetch_gist_file_content(gist_id: &str, filename: &str) -> Result<String> {
+    let output = Command::new("gh")
+        .args(["gist", "view", gist_id, "--filename", filename, "--raw"])
+        .output()
+        .context("run gh gist view")?;
+
+    if !output.status.success() {
+        bail!("{}", String::from_utf8_lossy(&output.stderr));
+    }
+
+    Ok(String::from_utf8(output.stdout)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_gist_list_into_file_rows() {
+        let raw = include_str!("../tests/fixtures/gh/gist-list.json");
+        let files = parse_gist_list_json(raw).unwrap();
+
+        assert_eq!(files.len(), 3);
+        // Files within a gist are ordered deterministically by filename.
+        assert_eq!(files[0].gist_id, "abc123");
+        assert_eq!(files[0].filename, "settings.json");
+        assert_eq!(files[0].description, "claude config");
+        assert!(!files[0].public);
+        assert_eq!(files[1].filename, "statusline.sh");
+    }
+
+    #[test]
+    fn null_description_parses_as_empty_string() {
+        let raw = include_str!("../tests/fixtures/gh/gist-list.json");
+        let files = parse_gist_list_json(raw).unwrap();
+
+        let notes = files.iter().find(|f| f.filename == "notes.md").unwrap();
+        assert_eq!(notes.description, "");
+        assert!(notes.public);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod actions;
+pub mod cache;
 pub mod config;
 pub mod diff;
 pub mod domain;

--- a/src/local.rs
+++ b/src/local.rs
@@ -1,21 +1,13 @@
 use crate::domain::{LocalCandidate, PinnedMapping};
 use anyhow::Result;
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
-pub fn known_config_paths(home: &Path) -> Vec<PathBuf> {
-    vec![
-        home.join(".zshrc"),
-        home.join(".gemini/antigravity-cli/settings.json"),
-        home.join(".config/opencode/opencode.json"),
-        home.join(".claude/settings.json"),
-        home.join(".claude/statusline.sh"),
-    ]
-}
-
+/// Lists the files in `cwd` as local candidates. Discovery is scoped to the
+/// current working directory only; `pinned` is used solely to mark which of those
+/// files already have a saved gist mapping (it does not pull in out-of-cwd paths).
 pub fn discover_local_candidates(
     cwd: &Path,
-    home: &Path,
     pinned: &[PinnedMapping],
 ) -> Result<Vec<LocalCandidate>> {
     let mut paths = Vec::new();
@@ -25,18 +17,6 @@ pub fn discover_local_candidates(
         let path = entry.path();
         if path.is_file() {
             paths.push(path);
-        }
-    }
-
-    for path in known_config_paths(home) {
-        if path.is_file() {
-            paths.push(path);
-        }
-    }
-
-    for mapping in pinned {
-        if mapping.local_path.is_file() {
-            paths.push(mapping.local_path.clone());
         }
     }
 
@@ -64,25 +44,52 @@ mod tests {
     use super::*;
 
     #[test]
-    fn discovers_cwd_files_and_known_configs() {
+    fn discovers_cwd_files_only() {
         let dir = tempfile::tempdir().unwrap();
-        let home = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
         fs::write(dir.path().join("settings.json"), "{}").unwrap();
-        fs::create_dir_all(home.path().join(".claude")).unwrap();
-        fs::write(home.path().join(".claude/settings.json"), "{}").unwrap();
+        fs::write(outside.path().join("elsewhere.json"), "{}").unwrap();
 
-        let candidates = discover_local_candidates(dir.path(), home.path(), &[]).unwrap();
+        let candidates = discover_local_candidates(dir.path(), &[]).unwrap();
         let paths: Vec<_> = candidates.iter().map(|c| c.path.clone()).collect();
 
         assert!(paths.contains(&dir.path().join("settings.json")));
-        assert!(paths.contains(&home.path().join(".claude/settings.json")));
+        assert!(!paths.contains(&outside.path().join("elsewhere.json")));
+    }
+
+    #[test]
+    fn marks_pinned_cwd_files_without_pulling_outside_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let cwd_file = dir.path().join("settings.json");
+        fs::write(&cwd_file, "{}").unwrap();
+        let outside = dir.path().join("nope/elsewhere.json");
+        let pinned = vec![
+            PinnedMapping {
+                local_path: cwd_file.clone(),
+                gist_id: "a".into(),
+                gist_filename: "settings.json".into(),
+                direction: None,
+                last_seen_hash: None,
+            },
+            PinnedMapping {
+                local_path: outside,
+                gist_id: "b".into(),
+                gist_filename: "x".into(),
+                direction: None,
+                last_seen_hash: None,
+            },
+        ];
+
+        let candidates = discover_local_candidates(dir.path(), &pinned).unwrap();
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].path, cwd_file);
+        assert!(candidates[0].pinned);
     }
 
     #[test]
     fn empty_candidate_mode_when_nothing_found() {
         let dir = tempfile::tempdir().unwrap();
-        let home = tempfile::tempdir().unwrap();
-        let candidates = discover_local_candidates(dir.path(), home.path(), &[]).unwrap();
+        let candidates = discover_local_candidates(dir.path(), &[]).unwrap();
         assert!(is_empty_candidate_mode(&candidates));
     }
 }

--- a/src/local.rs
+++ b/src/local.rs
@@ -1,3 +1,88 @@
-pub fn _module_ready() -> bool {
-    true
+use crate::domain::{LocalCandidate, PinnedMapping};
+use anyhow::Result;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub fn known_config_paths(home: &Path) -> Vec<PathBuf> {
+    vec![
+        home.join(".zshrc"),
+        home.join(".gemini/antigravity-cli/settings.json"),
+        home.join(".config/opencode/opencode.json"),
+        home.join(".claude/settings.json"),
+        home.join(".claude/statusline.sh"),
+    ]
+}
+
+pub fn discover_local_candidates(
+    cwd: &Path,
+    home: &Path,
+    pinned: &[PinnedMapping],
+) -> Result<Vec<LocalCandidate>> {
+    let mut paths = Vec::new();
+
+    for entry in fs::read_dir(cwd)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_file() {
+            paths.push(path);
+        }
+    }
+
+    for path in known_config_paths(home) {
+        if path.is_file() {
+            paths.push(path);
+        }
+    }
+
+    for mapping in pinned {
+        if mapping.local_path.is_file() {
+            paths.push(mapping.local_path.clone());
+        }
+    }
+
+    paths.sort();
+    paths.dedup();
+
+    Ok(paths
+        .into_iter()
+        .map(|path| {
+            let pinned_match = pinned.iter().any(|m| m.local_path == path);
+            LocalCandidate {
+                path,
+                pinned: pinned_match,
+            }
+        })
+        .collect())
+}
+
+pub fn is_empty_candidate_mode(candidates: &[LocalCandidate]) -> bool {
+    candidates.is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discovers_cwd_files_and_known_configs() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("settings.json"), "{}").unwrap();
+        fs::create_dir_all(home.path().join(".claude")).unwrap();
+        fs::write(home.path().join(".claude/settings.json"), "{}").unwrap();
+
+        let candidates = discover_local_candidates(dir.path(), home.path(), &[]).unwrap();
+        let paths: Vec<_> = candidates.iter().map(|c| c.path.clone()).collect();
+
+        assert!(paths.contains(&dir.path().join("settings.json")));
+        assert!(paths.contains(&home.path().join(".claude/settings.json")));
+    }
+
+    #[test]
+    fn empty_candidate_mode_when_nothing_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let candidates = discover_local_candidates(dir.path(), home.path(), &[]).unwrap();
+        assert!(is_empty_candidate_mode(&candidates));
+    }
 }

--- a/src/ranking.rs
+++ b/src/ranking.rs
@@ -1,3 +1,192 @@
-pub fn _module_ready() -> bool {
-    true
+use crate::domain::{GistFile, PinnedMapping};
+use std::collections::HashSet;
+use std::path::Component;
+use std::path::Path;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RankedGistFile {
+    pub file: GistFile,
+    pub score: u16,
+    pub reasons: Vec<MatchReason>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MatchReason {
+    Pinned,
+    ExactFilename,
+    PathSegment,
+    Recent,
+}
+
+pub fn rank_gist_files(
+    local_path: &Path,
+    gist_files: &[GistFile],
+    pinned: &[PinnedMapping],
+) -> Vec<RankedGistFile> {
+    let local_filename = local_path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or_default();
+    let local_tokens = meaningful_path_tokens(local_path);
+
+    let mut ranked: Vec<_> = gist_files
+        .iter()
+        .cloned()
+        .map(|file| {
+            let mut score = 0;
+            let mut reasons = Vec::new();
+
+            if pinned.iter().any(|m| {
+                m.local_path == local_path
+                    && m.gist_id == file.gist_id
+                    && m.gist_filename == file.filename
+            }) {
+                score += 10_000;
+                reasons.push(MatchReason::Pinned);
+            }
+
+            if file.filename == local_filename {
+                score += 1_000;
+                reasons.push(MatchReason::ExactFilename);
+            }
+
+            let gist_tokens = text_tokens(&format!("{} {}", file.description, file.filename));
+            if local_tokens.iter().any(|token| gist_tokens.contains(token)) {
+                score += 250;
+                reasons.push(MatchReason::PathSegment);
+            }
+
+            if !file.updated_at.is_empty() {
+                score += 1;
+                reasons.push(MatchReason::Recent);
+            }
+
+            RankedGistFile {
+                file,
+                score,
+                reasons,
+            }
+        })
+        .collect();
+
+    ranked.sort_by(|a, b| {
+        b.score
+            .cmp(&a.score)
+            .then(a.file.filename.cmp(&b.file.filename))
+    });
+    ranked
+}
+
+fn meaningful_path_tokens(path: &Path) -> HashSet<String> {
+    path.components()
+        .filter_map(|component| match component {
+            Component::Normal(value) => value.to_str(),
+            Component::CurDir
+            | Component::ParentDir
+            | Component::RootDir
+            | Component::Prefix(_) => None,
+        })
+        .flat_map(|component| text_tokens(component.trim_start_matches('.')))
+        .filter(|token| !is_common_container_dir(token))
+        .collect()
+}
+
+fn text_tokens(text: &str) -> HashSet<String> {
+    text.to_ascii_lowercase()
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|token| token.len() >= 3)
+        .map(String::from)
+        .collect()
+}
+
+fn is_common_container_dir(token: &str) -> bool {
+    matches!(token, "users" | "home" | "tmp" | "var" | "private")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn gist(id: &str, description: &str, filename: &str) -> GistFile {
+        GistFile {
+            gist_id: id.into(),
+            description: description.into(),
+            filename: filename.into(),
+            public: false,
+            updated_at: "2026-06-08T00:00:00Z".into(),
+        }
+    }
+
+    #[test]
+    fn pinned_mapping_wins_over_filename_match() {
+        let local = PathBuf::from("/Users/me/.claude/settings.json");
+        let files = vec![
+            gist("a", "exact filename", "settings.json"),
+            gist("b", "old pinned", "other.json"),
+        ];
+        let pinned = vec![PinnedMapping {
+            local_path: local.clone(),
+            gist_id: "b".into(),
+            gist_filename: "other.json".into(),
+            direction: None,
+            last_seen_hash: None,
+        }];
+
+        let ranked = rank_gist_files(&local, &files, &pinned);
+        assert_eq!(ranked[0].file.gist_id, "b");
+        assert!(ranked[0].reasons.contains(&MatchReason::Pinned));
+    }
+
+    #[test]
+    fn exact_filename_beats_path_hint() {
+        let local = PathBuf::from("/Users/me/.claude/settings.json");
+        let files = vec![
+            gist("a", "claude config", "other.json"),
+            gist("b", "misc", "settings.json"),
+        ];
+
+        let ranked = rank_gist_files(&local, &files, &[]);
+        assert_eq!(ranked[0].file.gist_id, "b");
+    }
+
+    #[test]
+    fn dot_prefixed_config_directory_can_match_path_segment() {
+        let local = PathBuf::from("/Users/me/.claude/settings.json");
+        let files = vec![gist("a", "claude config", "other.json")];
+
+        let ranked = rank_gist_files(&local, &files, &[]);
+        assert!(ranked[0].reasons.contains(&MatchReason::PathSegment));
+    }
+
+    #[test]
+    fn short_ancestor_token_does_not_match_unrelated_words() {
+        let local = PathBuf::from("/Users/me/project/config.json");
+        let files = vec![gist("a", "theme notes", "readme.md")];
+
+        let ranked = rank_gist_files(&local, &files, &[]);
+        assert!(!ranked[0].reasons.contains(&MatchReason::PathSegment));
+    }
+
+    #[test]
+    fn filename_tie_break_ascending_when_scores_are_equal() {
+        let local = PathBuf::from("/Users/me/project/config.json");
+        let files = vec![
+            gist("a", "unrelated", "zeta.txt"),
+            gist("b", "unrelated", "alpha.txt"),
+        ];
+
+        let ranked = rank_gist_files(&local, &files, &[]);
+        assert_eq!(ranked[0].file.filename, "alpha.txt");
+        assert_eq!(ranked[1].file.filename, "zeta.txt");
+    }
+
+    #[test]
+    fn no_path_segment_reason_for_unrelated_tokens() {
+        let local = PathBuf::from("/Users/me/.claude/settings.json");
+        let files = vec![gist("a", "editor theme", "readme.md")];
+
+        let ranked = rank_gist_files(&local, &files, &[]);
+        assert!(!ranked[0].reasons.contains(&MatchReason::PathSegment));
+    }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1074,7 +1074,7 @@ fn gist_row_label(g: &RankedGistFile, view: GistView) -> String {
 fn render_list(frame: &mut Frame, state: &AppState) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Min(5), Constraint::Length(3)])
+        .constraints([Constraint::Min(5), Constraint::Length(4)])
         .split(frame.size());
     let columns = Layout::default()
         .direction(Direction::Horizontal)
@@ -1141,10 +1141,11 @@ fn render_list(frame: &mut Frame, state: &AppState) {
     } else {
         match &state.status {
             Some(message) => message.clone(),
-            None => {
-                "Tab  ↑↓←→  Enter diff  Space preview  d download  u upload  n create  p pin  t view  v type  s sort  / filter  q quit"
-                    .to_string()
-            }
+            None => concat!(
+                "Tab switch pane   ↑↓ move   ←→ scroll   Enter diff   Space preview\n",
+                "d download  u upload  n create  p pin   t view  v type  s sort  / filter   q quit"
+            )
+            .to_string(),
         }
     };
     frame.render_widget(

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -161,6 +161,7 @@ pub struct AppState {
     pub diff_text: String,
     pub diff_scroll: u16,
     pub diff_hscroll: u16,
+    pub diff_identical: bool,
     pub preview_remote: String,
     pub preview_local: PathBuf,
     pub download_target: PathBuf,
@@ -294,6 +295,7 @@ impl AppState {
         self.diff_previewed = true;
         self.diff_scroll = 0;
         self.diff_hscroll = 0;
+        self.diff_identical = false;
         self.status = None;
         self.screen = Screen::Diff;
     }
@@ -307,6 +309,7 @@ impl AppState {
         self.download_target = PathBuf::new();
         self.diff_scroll = 0;
         self.diff_hscroll = 0;
+        self.diff_identical = false;
         self.diff_previewed = false;
     }
 
@@ -525,7 +528,8 @@ impl AppState {
             KeyCode::Up => self.scroll_diff_up(),
             KeyCode::Right => self.scroll_diff_right(),
             KeyCode::Left => self.scroll_diff_left(),
-            KeyCode::Char('d') => {
+            // Identical files have nothing to sync, so download/upload are not offered.
+            KeyCode::Char('d') if !self.diff_identical => {
                 if self.download_target.exists() {
                     self.pending_action = Some(PendingAction::Download);
                     self.screen = Screen::Confirm;
@@ -533,7 +537,7 @@ impl AppState {
                     return KeyOutcome::Download;
                 }
             }
-            KeyCode::Char('u') => return self.upload_intent(),
+            KeyCode::Char('u') if !self.diff_identical => return self.upload_intent(),
             _ => {}
         }
         KeyOutcome::None
@@ -618,6 +622,7 @@ pub fn initial_state() -> AppState {
         diff_text: String::new(),
         diff_scroll: 0,
         diff_hscroll: 0,
+        diff_identical: false,
         preview_remote: String::new(),
         preview_local: PathBuf::new(),
         download_target: PathBuf::new(),
@@ -843,7 +848,9 @@ fn preview_diff(state: &mut AppState) {
             // Download saves the gist into the current working directory under the
             // gist's own filename, leaving the compared local file untouched.
             let target = state.cwd.join(&gist.filename);
+            let identical = local_content == remote;
             state.enter_diff(diff, remote, local_path.unwrap_or_default(), target);
+            state.diff_identical = identical;
         }
         Err(error) => state.set_status(format!("fetch failed: {error}")),
     }
@@ -890,7 +897,9 @@ fn download_selected(state: &mut AppState) {
                 let (local_label, gist_label) = diff_labels(Some(&target), &gist);
                 let diff =
                     crate::diff::unified_diff(&local_label, &local_content, &gist_label, &remote);
+                let identical = local_content == remote;
                 state.enter_diff(diff, remote, target.clone(), target);
+                state.diff_identical = identical;
             } else {
                 // No collision: download straight into the cwd without forcing a diff.
                 match crate::actions::execute_download(&target, &remote, false) {
@@ -1457,13 +1466,18 @@ fn render_diff(frame: &mut Frame, state: &AppState, confirming: bool) {
             format!("Create gist from {}", local_path.display())
         }
         _ => {
+            let label = if state.diff_identical {
+                "Diff (identical)"
+            } else {
+                "Diff"
+            };
             if state.preview_local.as_os_str().is_empty()
                 || state.preview_local == state.download_target
             {
-                format!("Diff → {}", state.download_target.display())
+                format!("{label} → {}", state.download_target.display())
             } else {
                 format!(
-                    "Diff: {} → {}",
+                    "{label}: {} → {}",
                     state.preview_local.display(),
                     state.download_target.display()
                 )
@@ -1495,6 +1509,8 @@ fn render_diff(frame: &mut Frame, state: &AppState, confirming: bool) {
             }
             _ => format!("Overwrite {}? (y/n)", state.download_target.display()),
         }
+    } else if state.diff_identical {
+        "Files are identical — nothing to sync  ·  ↑↓←→ scroll  ·  Esc back  ·  q quit".to_string()
     } else {
         "↑↓←→ scroll  ·  d download  ·  u upload  ·  Esc back  ·  q quit".to_string()
     };
@@ -2149,6 +2165,23 @@ mod tests {
         assert_eq!(state.diff_scroll, 2);
         state.handle_key(KeyCode::Up);
         assert_eq!(state.diff_scroll, 1);
+    }
+
+    #[test]
+    fn identical_diff_disables_download_and_upload() {
+        let mut state = initial_state();
+        state.enter_diff(
+            "d".into(),
+            "r".into(),
+            PathBuf::from("/tmp/x"),
+            PathBuf::from("/tmp/x"),
+        );
+        state.diff_identical = true;
+        assert_eq!(state.handle_key(KeyCode::Char('d')), KeyOutcome::None);
+        assert_eq!(state.handle_key(KeyCode::Char('u')), KeyOutcome::None);
+        // Scrolling and leaving still work.
+        assert_eq!(state.handle_key(KeyCode::Esc), KeyOutcome::None);
+        assert_eq!(state.screen, Screen::List);
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1279,21 +1279,18 @@ fn gist_row_label(g: &RankedGistFile, view: GistView) -> String {
     }
 }
 
-/// The full command hint as one responsive line; the footer word-wraps it to the
-/// terminal width (one line when wide, more when narrow).
-fn commands_hint() -> String {
-    // Only the common keys; the full reference lives in the `?` help overlay.
-    [
-        "Tab panes",
-        "↑↓ move",
-        "Enter diff",
-        "Space preview",
-        "d download",
-        "u upload",
-        "? help",
-        "Esc/q quit",
-    ]
-    .join("  ·  ")
+/// Command hint tailored to the focused pane: local-file actions on the left, gist actions
+/// on the right, plus the always-available navigation/help/quit keys. The footer word-wraps
+/// it to the terminal width.
+fn commands_hint(focus: FocusPane) -> String {
+    // Focus-relevant common keys only; the full reference lives in the `?` help overlay.
+    let mut items = vec!["Tab panes", "↑↓ move", "Enter diff"];
+    match focus {
+        FocusPane::Local => items.extend(["e edit", "n create"]),
+        FocusPane::Gist => items.extend(["Space preview", "d download", "u upload", "o browser"]),
+    }
+    items.extend(["? help", "Esc/q quit"]);
+    items.join("  ·  ")
 }
 
 /// Greedy word-wrap line count, matching how `Paragraph` with `Wrap { trim: true }` breaks
@@ -1329,7 +1326,7 @@ fn render_list(frame: &mut Frame, state: &AppState) {
     } else {
         match &state.status {
             Some(message) => message.clone(),
-            None => commands_hint(),
+            None => commands_hint(state.focus),
         }
     };
     // Width inside the footer block: minus 2 borders and 2 horizontal padding columns.
@@ -1901,6 +1898,25 @@ mod tests {
         );
         assert_eq!(gist_time_label(""), "unknown");
         assert_eq!(gist_time_label("short"), "short");
+    }
+
+    #[test]
+    fn commands_hint_is_focus_aware() {
+        let local = commands_hint(FocusPane::Local);
+        assert!(local.contains("e edit"));
+        assert!(local.contains("n create"));
+        assert!(!local.contains("d download"));
+
+        let gist = commands_hint(FocusPane::Gist);
+        assert!(gist.contains("d download"));
+        assert!(gist.contains("o browser"));
+        assert!(!gist.contains("e edit"));
+
+        // Always-available keys appear in both.
+        for hint in [local, gist] {
+            assert!(hint.contains("? help"));
+            assert!(hint.contains("Esc/q quit"));
+        }
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -130,6 +130,7 @@ pub enum KeyOutcome {
     UploadAdd,
     UploadPreview,
     Upload,
+    Create(bool),
 }
 
 #[derive(Debug, Clone)]
@@ -420,6 +421,16 @@ impl AppState {
                     KeyOutcome::UploadAdd
                 };
             }
+            KeyCode::Char('n') => {
+                let Some(local) = self.selected_local().cloned() else {
+                    self.status = Some("select a local file to create a gist".into());
+                    return KeyOutcome::None;
+                };
+                self.pending_action = Some(PendingAction::Create {
+                    local_path: local.path,
+                });
+                self.screen = Screen::Confirm;
+            }
             _ => {}
         }
         KeyOutcome::None
@@ -461,6 +472,15 @@ impl AppState {
             },
             Some(PendingAction::Upload { .. }) => match code {
                 KeyCode::Char('y') => return KeyOutcome::Upload,
+                KeyCode::Char('n') | KeyCode::Esc => {
+                    self.pending_action = None;
+                    self.screen = Screen::List;
+                }
+                _ => {}
+            },
+            Some(PendingAction::Create { .. }) => match code {
+                KeyCode::Char('s') => return KeyOutcome::Create(false),
+                KeyCode::Char('p') => return KeyOutcome::Create(true),
                 KeyCode::Char('n') | KeyCode::Esc => {
                     self.pending_action = None;
                     self.screen = Screen::List;
@@ -561,6 +581,7 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
                 KeyOutcome::UploadAdd => upload_add(&mut state),
                 KeyOutcome::UploadPreview => upload_preview(&mut state),
                 KeyOutcome::Upload => upload_replace(&mut state),
+                KeyOutcome::Create(public) => create_gist(&mut state, public),
                 KeyOutcome::None => {}
             }
         }
@@ -777,6 +798,30 @@ fn refresh_gists(state: &mut AppState) {
         state.gists = gists;
         if state.gist_index >= state.ranked_gists().len() {
             state.gist_index = 0;
+        }
+    }
+}
+
+fn create_gist(state: &mut AppState, public: bool) {
+    let Some(PendingAction::Create { local_path }) = state.pending_action.clone() else {
+        return;
+    };
+    let plan = crate::actions::create_command(&local_path, public);
+    match crate::actions::execute_command(&plan) {
+        Ok(_) => {
+            let visibility = if public { "public" } else { "secret" };
+            state.set_status(format!(
+                "Created {} gist from {}",
+                visibility,
+                local_path.display()
+            ));
+            state.back_to_list();
+            refresh_gists(state);
+        }
+        Err(error) => {
+            state.set_status(format!("create failed: {error}"));
+            state.screen = Screen::List;
+            state.pending_action = None;
         }
     }
 }
@@ -1672,5 +1717,63 @@ mod tests {
         });
         state.screen = Screen::Confirm;
         assert_eq!(state.handle_key(KeyCode::Char('y')), KeyOutcome::Upload);
+    }
+
+    #[test]
+    fn n_opens_create_confirm() {
+        let mut state = initial_state();
+        state.locals = vec![LocalCandidate {
+            path: PathBuf::from("/tmp/config.toml"),
+            pinned: false,
+        }];
+        assert_eq!(state.handle_key(KeyCode::Char('n')), KeyOutcome::None);
+        assert_eq!(state.screen, Screen::Confirm);
+        assert_eq!(
+            state.pending_action,
+            Some(PendingAction::Create {
+                local_path: PathBuf::from("/tmp/config.toml")
+            })
+        );
+    }
+
+    #[test]
+    fn n_without_local_is_noop() {
+        let mut state = initial_state();
+        assert_eq!(state.handle_key(KeyCode::Char('n')), KeyOutcome::None);
+        assert_eq!(state.screen, Screen::List);
+    }
+
+    #[test]
+    fn create_confirm_s_and_p_choose_visibility() {
+        let mut state = initial_state();
+        state.pending_action = Some(PendingAction::Create {
+            local_path: PathBuf::from("/tmp/config.toml"),
+        });
+        state.screen = Screen::Confirm;
+        assert_eq!(
+            state.handle_key(KeyCode::Char('s')),
+            KeyOutcome::Create(false)
+        );
+
+        state.pending_action = Some(PendingAction::Create {
+            local_path: PathBuf::from("/tmp/config.toml"),
+        });
+        state.screen = Screen::Confirm;
+        assert_eq!(
+            state.handle_key(KeyCode::Char('p')),
+            KeyOutcome::Create(true)
+        );
+    }
+
+    #[test]
+    fn create_confirm_esc_cancels() {
+        let mut state = initial_state();
+        state.pending_action = Some(PendingAction::Create {
+            local_path: PathBuf::from("/tmp/config.toml"),
+        });
+        state.screen = Screen::Confirm;
+        assert_eq!(state.handle_key(KeyCode::Esc), KeyOutcome::None);
+        assert_eq!(state.screen, Screen::List);
+        assert_eq!(state.pending_action, None);
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -8,9 +8,10 @@ use crossterm::{
 };
 use ratatui::{
     backend::CrosstermBackend,
-    layout::{Constraint, Direction, Layout},
-    widgets::{Block, Borders, List, ListItem, Paragraph},
-    Terminal,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
+    Frame, Terminal,
 };
 use std::io;
 use std::path::PathBuf;
@@ -29,11 +30,18 @@ pub enum Screen {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GistView {
+    Description,
+    Id,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KeyOutcome {
     None,
     Quit,
     PreviewDiff,
     Download,
+    DownloadGist,
 }
 
 #[derive(Debug, Clone)]
@@ -44,19 +52,36 @@ pub struct AppState {
     pub focus: FocusPane,
     pub local_index: usize,
     pub gist_index: usize,
+    pub local_hscroll: u16,
+    pub gist_hscroll: u16,
     pub screen: Screen,
+    pub gist_view: GistView,
     pub diff_previewed: bool,
     pub diff_text: String,
     pub diff_scroll: u16,
+    pub diff_hscroll: u16,
     pub preview_remote: String,
     pub preview_local: PathBuf,
+    pub download_target: PathBuf,
+    pub cwd: PathBuf,
     pub status: Option<String>,
 }
 
 impl AppState {
     pub fn ranked_gists(&self) -> Vec<RankedGistFile> {
         let Some(local) = self.locals.get(self.local_index) else {
-            return Vec::new();
+            // No local selected (e.g. an empty directory): list every gist
+            // unranked so the user can still preview and download into the cwd.
+            return self
+                .gists
+                .iter()
+                .cloned()
+                .map(|file| RankedGistFile {
+                    file,
+                    score: 0,
+                    reasons: Vec::new(),
+                })
+                .collect();
         };
         rank_gist_files(&local.path, &self.gists, &self.pinned)
     }
@@ -69,12 +94,60 @@ impl AppState {
         self.ranked_gists().into_iter().nth(self.gist_index)
     }
 
-    pub fn enter_diff(&mut self, diff_text: String, remote: String, local: PathBuf) {
+    /// Highest horizontal-scroll offset for the focused pane, based on its longest row
+    /// (viewport width is unknown to the pure key logic, mirroring the diff scroll cap).
+    fn focused_hscroll_max(&self) -> u16 {
+        let longest = match self.focus {
+            FocusPane::Local => self
+                .locals
+                .iter()
+                .map(|c| local_row_label(&c.path).chars().count())
+                .max(),
+            FocusPane::Gist => self
+                .ranked_gists()
+                .iter()
+                .map(|g| gist_row_label(g, self.gist_view).chars().count())
+                .max(),
+        };
+        longest
+            .unwrap_or(0)
+            .saturating_sub(1)
+            .min(u16::MAX as usize) as u16
+    }
+
+    fn scroll_focused_right(&mut self) {
+        let max = self.focused_hscroll_max();
+        let scroll = match self.focus {
+            FocusPane::Local => &mut self.local_hscroll,
+            FocusPane::Gist => &mut self.gist_hscroll,
+        };
+        if *scroll < max {
+            *scroll += 1;
+        }
+    }
+
+    fn scroll_focused_left(&mut self) {
+        let scroll = match self.focus {
+            FocusPane::Local => &mut self.local_hscroll,
+            FocusPane::Gist => &mut self.gist_hscroll,
+        };
+        *scroll = scroll.saturating_sub(1);
+    }
+
+    pub fn enter_diff(
+        &mut self,
+        diff_text: String,
+        remote: String,
+        local: PathBuf,
+        target: PathBuf,
+    ) {
         self.diff_text = diff_text;
         self.preview_remote = remote;
         self.preview_local = local;
+        self.download_target = target;
         self.diff_previewed = true;
         self.diff_scroll = 0;
+        self.diff_hscroll = 0;
         self.status = None;
         self.screen = Screen::Diff;
     }
@@ -84,7 +157,9 @@ impl AppState {
         self.diff_text.clear();
         self.preview_remote.clear();
         self.preview_local = PathBuf::new();
+        self.download_target = PathBuf::new();
         self.diff_scroll = 0;
+        self.diff_hscroll = 0;
         self.diff_previewed = false;
     }
 
@@ -108,6 +183,24 @@ impl AppState {
         self.diff_scroll = self.diff_scroll.saturating_sub(1);
     }
 
+    pub fn scroll_diff_right(&mut self) {
+        let max = self
+            .diff_text
+            .lines()
+            .map(|line| line.chars().count())
+            .max()
+            .unwrap_or(0)
+            .saturating_sub(1)
+            .min(u16::MAX as usize) as u16;
+        if self.diff_hscroll < max {
+            self.diff_hscroll += 1;
+        }
+    }
+
+    pub fn scroll_diff_left(&mut self) {
+        self.diff_hscroll = self.diff_hscroll.saturating_sub(1);
+    }
+
     pub fn handle_key(&mut self, code: KeyCode) -> KeyOutcome {
         match self.screen {
             Screen::List => self.handle_key_list(code),
@@ -117,6 +210,9 @@ impl AppState {
     }
 
     fn handle_key_list(&mut self, code: KeyCode) -> KeyOutcome {
+        // Any key dismisses a lingering status message (e.g. "Downloaded …"). A new
+        // status may be set afterwards by the run_loop IO helper for this key.
+        self.status = None;
         match code {
             KeyCode::Char('q') => return KeyOutcome::Quit,
             KeyCode::Tab => {
@@ -129,9 +225,12 @@ impl AppState {
                 FocusPane::Local if self.local_index + 1 < self.locals.len() => {
                     self.local_index += 1;
                     self.gist_index = 0;
+                    self.local_hscroll = 0;
+                    self.gist_hscroll = 0;
                 }
                 FocusPane::Gist if self.gist_index + 1 < self.ranked_gists().len() => {
-                    self.gist_index += 1
+                    self.gist_index += 1;
+                    self.gist_hscroll = 0;
                 }
                 _ => {}
             },
@@ -139,14 +238,30 @@ impl AppState {
                 FocusPane::Local if self.local_index > 0 => {
                     self.local_index -= 1;
                     self.gist_index = 0;
+                    self.local_hscroll = 0;
+                    self.gist_hscroll = 0;
                 }
-                FocusPane::Gist if self.gist_index > 0 => self.gist_index -= 1,
+                FocusPane::Gist if self.gist_index > 0 => {
+                    self.gist_index -= 1;
+                    self.gist_hscroll = 0;
+                }
                 _ => {}
             },
+            KeyCode::Right => self.scroll_focused_right(),
+            KeyCode::Left => self.scroll_focused_left(),
+            KeyCode::Char('t') => {
+                self.gist_view = match self.gist_view {
+                    GistView::Description => GistView::Id,
+                    GistView::Id => GistView::Description,
+                };
+            }
+            KeyCode::Char('d')
+                if self.focus == FocusPane::Gist && self.gist_index < self.ranked_gists().len() =>
+            {
+                return KeyOutcome::DownloadGist;
+            }
             KeyCode::Enter
-                if self.focus == FocusPane::Gist
-                    && self.selected_local().is_some()
-                    && self.gist_index < self.ranked_gists().len() =>
+                if self.focus == FocusPane::Gist && self.gist_index < self.ranked_gists().len() =>
             {
                 return KeyOutcome::PreviewDiff;
             }
@@ -161,8 +276,10 @@ impl AppState {
             KeyCode::Esc => self.back_to_list(),
             KeyCode::Down => self.scroll_diff_down(),
             KeyCode::Up => self.scroll_diff_up(),
+            KeyCode::Right => self.scroll_diff_right(),
+            KeyCode::Left => self.scroll_diff_left(),
             KeyCode::Char('d') => {
-                if self.preview_local.exists() {
+                if self.download_target.exists() {
                     self.screen = Screen::ConfirmOverwrite;
                 } else {
                     return KeyOutcome::Download;
@@ -192,12 +309,18 @@ pub fn initial_state() -> AppState {
         focus: FocusPane::Local,
         local_index: 0,
         gist_index: 0,
+        local_hscroll: 0,
+        gist_hscroll: 0,
         screen: Screen::List,
+        gist_view: GistView::Description,
         diff_previewed: false,
         diff_text: String::new(),
         diff_scroll: 0,
+        diff_hscroll: 0,
         preview_remote: String::new(),
         preview_local: PathBuf::new(),
+        download_target: PathBuf::new(),
+        cwd: PathBuf::from("."),
         status: None,
     }
 }
@@ -206,11 +329,14 @@ pub fn load_startup_state() -> Result<AppState> {
     let mut state = initial_state();
     let config_path = crate::config::config_path()?;
     let config = crate::config::load_config(&config_path)?;
-    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
     let cwd = std::env::current_dir()?;
 
     state.pinned = config.pinned;
-    state.locals = crate::local::discover_local_candidates(&cwd, &home, &state.pinned)?;
+    state.locals = crate::local::discover_local_candidates(&cwd, &state.pinned)?;
+    state.cwd = cwd;
+    // Start focused on the gist pane: the common flow is to pick a gist and pull it
+    // into the cwd, and the gist list is shown even when no local file is selected.
+    state.focus = FocusPane::Gist;
 
     if crate::gh::check_gh_ready().is_ok() {
         if let Ok(gists) =
@@ -242,55 +368,14 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
     let mut state = load_startup_state()?;
 
     loop {
-        terminal.draw(|frame| {
-            let chunks = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([Constraint::Min(5), Constraint::Length(3)])
-                .split(frame.size());
-            let columns = Layout::default()
-                .direction(Direction::Horizontal)
-                .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
-                .split(chunks[0]);
-
-            let local_items: Vec<ListItem> = state
-                .locals
-                .iter()
-                .map(|c| ListItem::new(c.path.display().to_string()))
-                .collect();
-            frame.render_widget(
-                List::new(local_items).block(Block::default().title("Local").borders(Borders::ALL)),
-                columns[0],
-            );
-
-            let gist_items: Vec<ListItem> = state
-                .ranked_gists()
-                .into_iter()
-                .map(|g| {
-                    ListItem::new(format!(
-                        "{} / {} ({})",
-                        g.file.gist_id, g.file.filename, g.score
-                    ))
-                })
-                .collect();
-            frame.render_widget(
-                List::new(gist_items).block(Block::default().title("Gists").borders(Borders::ALL)),
-                columns[1],
-            );
-
-            frame.render_widget(
-                Paragraph::new(
-                    "Tab switch  Enter diff  u upload  d download  n create  p pin  q quit",
-                )
-                .block(Block::default().title("Commands").borders(Borders::ALL)),
-                chunks[1],
-            );
-        })?;
+        terminal.draw(|frame| render(frame, &state))?;
 
         if let Event::Key(key) = event::read()? {
             match state.handle_key(key.code) {
                 KeyOutcome::Quit => break,
                 KeyOutcome::PreviewDiff => preview_diff(&mut state),
                 KeyOutcome::Download => download(&mut state),
+                KeyOutcome::DownloadGist => download_selected(&mut state),
                 KeyOutcome::None => {}
             }
         }
@@ -300,34 +385,267 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
 }
 
 fn preview_diff(state: &mut AppState) {
-    let (Some(local), Some(ranked)) = (state.selected_local().cloned(), state.selected_gist())
-    else {
+    let Some(ranked) = state.selected_gist() else {
         return;
     };
+    // A local file may not be selected (empty cwd); diff against empty content then.
+    let local_path = state.selected_local().map(|local| local.path.clone());
     let gist = ranked.file;
     match crate::gh::fetch_gist_file_content(&gist.gist_id, &gist.filename) {
         Ok(remote) => {
-            let local_content = std::fs::read_to_string(&local.path).unwrap_or_default();
+            let local_content = local_path
+                .as_ref()
+                .map(|path| std::fs::read_to_string(path).unwrap_or_default())
+                .unwrap_or_default();
             let diff = crate::diff::unified_diff("local", &local_content, "gist", &remote);
-            state.enter_diff(diff, remote, local.path.clone());
+            // Download saves the gist into the current working directory under the
+            // gist's own filename, leaving the compared local file untouched.
+            let target = state.cwd.join(&gist.filename);
+            state.enter_diff(diff, remote, local_path.unwrap_or_default(), target);
+        }
+        Err(error) => state.set_status(format!("fetch failed: {error}")),
+    }
+}
+
+fn download_selected(state: &mut AppState) {
+    let Some(ranked) = state.selected_gist() else {
+        return;
+    };
+    let gist = ranked.file;
+    let target = state.cwd.join(&gist.filename);
+    match crate::gh::fetch_gist_file_content(&gist.gist_id, &gist.filename) {
+        Ok(remote) => {
+            if target.exists() {
+                // A same-named file already exists: show its diff and require a y/n
+                // overwrite confirmation before writing.
+                let local_content = std::fs::read_to_string(&target).unwrap_or_default();
+                let diff = crate::diff::unified_diff("local", &local_content, "gist", &remote);
+                state.enter_diff(diff, remote, target.clone(), target);
+            } else {
+                // No collision: download straight into the cwd without forcing a diff.
+                match crate::actions::execute_download(&target, &remote, false) {
+                    Ok(()) => {
+                        state.set_status(format!("Downloaded {}", target.display()));
+                        refresh_locals(state);
+                    }
+                    Err(error) => state.set_status(format!("download failed: {error}")),
+                }
+            }
         }
         Err(error) => state.set_status(format!("fetch failed: {error}")),
     }
 }
 
 fn download(state: &mut AppState) {
-    let local = state.preview_local.clone();
+    let target = state.download_target.clone();
     let content = state.preview_remote.clone();
-    match crate::actions::execute_download(&local, &content, true) {
+    match crate::actions::execute_download(&target, &content, true) {
         Ok(()) => {
-            state.set_status(format!("Downloaded {}", local.display()));
+            state.set_status(format!("Downloaded {}", target.display()));
             state.back_to_list();
+            refresh_locals(state);
         }
         Err(error) => {
             state.set_status(format!("download failed: {error}"));
             state.screen = Screen::Diff;
         }
     }
+}
+
+/// Re-discovers the cwd file list after a write so a freshly downloaded file appears in the
+/// Local pane. The current selection is preserved by path when still present.
+fn refresh_locals(state: &mut AppState) {
+    let selected = state.selected_local().map(|c| c.path.clone());
+    if let Ok(locals) = crate::local::discover_local_candidates(&state.cwd, &state.pinned) {
+        state.locals = locals;
+        state.local_index = selected
+            .and_then(|path| state.locals.iter().position(|c| c.path == path))
+            .unwrap_or(0)
+            .min(state.locals.len().saturating_sub(1));
+        if state.gist_index >= state.ranked_gists().len() {
+            state.gist_index = 0;
+        }
+    }
+}
+
+fn render(frame: &mut Frame, state: &AppState) {
+    match state.screen {
+        Screen::List => render_list(frame, state),
+        Screen::Diff => render_diff(frame, state, false),
+        Screen::ConfirmOverwrite => render_diff(frame, state, true),
+    }
+}
+
+fn local_row_label(path: &std::path::Path) -> String {
+    path.file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.display().to_string())
+}
+
+fn hscroll_str(text: &str, offset: u16) -> String {
+    text.chars().skip(offset as usize).collect()
+}
+
+/// Match strength as stars. Mirrors the ranking tiers (exact-filename/pinned = 1000+,
+/// path hint = 250+); a recent-only score of 1 is too weak to be worth a star.
+fn match_stars(score: u16) -> &'static str {
+    match score {
+        s if s >= 1000 => "⭐⭐⭐",
+        s if s >= 250 => "⭐⭐",
+        s if s >= 2 => "⭐",
+        _ => "",
+    }
+}
+
+fn gist_row_label(g: &RankedGistFile, view: GistView) -> String {
+    let stars = match_stars(g.score);
+    let prefix = if stars.is_empty() {
+        String::new()
+    } else {
+        format!("{stars} ")
+    };
+    match view {
+        GistView::Description => {
+            if g.file.description.trim().is_empty() {
+                format!("{prefix}{}", g.file.filename)
+            } else {
+                format!("{prefix}{} — {}", g.file.filename, g.file.description)
+            }
+        }
+        GistView::Id => format!("{prefix}{} / {}", g.file.gist_id, g.file.filename),
+    }
+}
+
+fn render_list(frame: &mut Frame, state: &AppState) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(5), Constraint::Length(3)])
+        .split(frame.size());
+    let columns = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
+        .split(chunks[0]);
+
+    // Discovery is scoped to the cwd, so each candidate is a direct child; show just the
+    // file name and put the cwd in the pane title as the shared baseline.
+    let local_items: Vec<ListItem> = state
+        .locals
+        .iter()
+        .map(|c| ListItem::new(hscroll_str(&local_row_label(&c.path), state.local_hscroll)))
+        .collect();
+    let local_focused = state.focus == FocusPane::Local;
+    let local_selected = (!state.locals.is_empty()).then_some(state.local_index);
+    let local_title = format!("Local · {}", state.cwd.display());
+    render_pane(
+        frame,
+        columns[0],
+        &local_title,
+        local_items,
+        local_focused,
+        local_selected,
+    );
+
+    let ranked = state.ranked_gists();
+    let gist_items: Vec<ListItem> = ranked
+        .iter()
+        .map(|g| {
+            ListItem::new(hscroll_str(
+                &gist_row_label(g, state.gist_view),
+                state.gist_hscroll,
+            ))
+        })
+        .collect();
+    let gist_focused = state.focus == FocusPane::Gist;
+    let gist_selected = (!ranked.is_empty()).then_some(state.gist_index);
+    render_pane(
+        frame,
+        columns[1],
+        "Gists",
+        gist_items,
+        gist_focused,
+        gist_selected,
+    );
+
+    let footer = match &state.status {
+        Some(message) => message.clone(),
+        None => "Tab  Up/Down move  Left/Right scroll  Enter diff  d download  t view  q quit"
+            .to_string(),
+    };
+    frame.render_widget(
+        Paragraph::new(footer).block(Block::default().title("Commands").borders(Borders::ALL)),
+        chunks[1],
+    );
+}
+
+fn render_pane(
+    frame: &mut Frame,
+    area: Rect,
+    title: &str,
+    items: Vec<ListItem>,
+    focused: bool,
+    selected: Option<usize>,
+) {
+    let border_style = if focused {
+        Style::default().fg(Color::Cyan)
+    } else {
+        Style::default()
+    };
+    let highlight_style = if focused {
+        Style::default().add_modifier(Modifier::REVERSED)
+    } else {
+        Style::default().add_modifier(Modifier::BOLD)
+    };
+    let title = if focused {
+        format!("{title} [focus]")
+    } else {
+        title.to_string()
+    };
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .title(title)
+                .borders(Borders::ALL)
+                .border_style(border_style),
+        )
+        .highlight_style(highlight_style)
+        .highlight_symbol("▶ ");
+
+    let mut list_state = ListState::default();
+    list_state.select(selected);
+    frame.render_stateful_widget(list, area, &mut list_state);
+}
+
+fn render_diff(frame: &mut Frame, state: &AppState, confirming: bool) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(5), Constraint::Length(3)])
+        .split(frame.size());
+
+    let title = format!(
+        "Diff: {}  ->  {}",
+        state.preview_local.display(),
+        state.download_target.display()
+    );
+    frame.render_widget(
+        Paragraph::new(state.diff_text.clone())
+            .scroll((state.diff_scroll, state.diff_hscroll))
+            .block(Block::default().title(title).borders(Borders::ALL)),
+        chunks[0],
+    );
+
+    let footer = if confirming {
+        format!("Overwrite {}? (y/n)", state.download_target.display())
+    } else {
+        format!(
+            "Up/Down/Left/Right scroll  d download -> {}  Esc back  q quit",
+            state.download_target.display()
+        )
+    };
+    frame.render_widget(
+        Paragraph::new(footer).block(Block::default().title("Commands").borders(Borders::ALL)),
+        chunks[1],
+    );
 }
 
 #[cfg(test)]
@@ -344,9 +662,193 @@ mod tests {
     }
 
     #[test]
+    fn t_toggles_gist_view() {
+        let mut state = initial_state();
+        assert_eq!(state.gist_view, GistView::Description);
+        state.handle_key(KeyCode::Char('t'));
+        assert_eq!(state.gist_view, GistView::Id);
+        state.handle_key(KeyCode::Char('t'));
+        assert_eq!(state.gist_view, GistView::Description);
+    }
+
+    #[test]
+    fn gist_row_label_switches_with_view() {
+        let g = RankedGistFile {
+            file: GistFile {
+                gist_id: "abc".into(),
+                description: "My Ghostty config".into(),
+                filename: "config".into(),
+                public: true,
+                updated_at: "x".into(),
+            },
+            score: 1,
+            reasons: Vec::new(),
+        };
+        // A recent-only score of 1 is too weak to earn a star.
+        assert_eq!(
+            gist_row_label(&g, GistView::Description),
+            "config — My Ghostty config"
+        );
+        assert_eq!(gist_row_label(&g, GistView::Id), "abc / config");
+    }
+
+    #[test]
+    fn strong_match_prefixes_stars() {
+        let g = RankedGistFile {
+            file: GistFile {
+                gist_id: "abc".into(),
+                description: "cfg".into(),
+                filename: "config".into(),
+                public: true,
+                updated_at: "x".into(),
+            },
+            score: 1000,
+            reasons: Vec::new(),
+        };
+        assert_eq!(
+            gist_row_label(&g, GistView::Description),
+            "⭐⭐⭐ config — cfg"
+        );
+        assert_eq!(gist_row_label(&g, GistView::Id), "⭐⭐⭐ abc / config");
+    }
+
+    #[test]
+    fn match_stars_tiers() {
+        assert_eq!(match_stars(0), "");
+        assert_eq!(match_stars(1), "");
+        assert_eq!(match_stars(250), "⭐⭐");
+        assert_eq!(match_stars(1000), "⭐⭐⭐");
+        assert_eq!(match_stars(10_001), "⭐⭐⭐");
+    }
+
+    #[test]
+    fn gist_row_label_falls_back_to_filename_when_description_empty() {
+        let g = RankedGistFile {
+            file: GistFile {
+                gist_id: "abc".into(),
+                description: "  ".into(),
+                filename: "config".into(),
+                public: true,
+                updated_at: "x".into(),
+            },
+            score: 0,
+            reasons: Vec::new(),
+        };
+        assert_eq!(gist_row_label(&g, GistView::Description), "config");
+    }
+
+    #[test]
+    fn left_right_scrolls_focused_gist_pane() {
+        let mut state = initial_state();
+        state.gists = vec![GistFile {
+            gist_id: "a".into(),
+            description: "a fairly long description for scrolling".into(),
+            filename: "f.json".into(),
+            public: false,
+            updated_at: "x".into(),
+        }];
+        state.focus = FocusPane::Gist;
+        assert_eq!(state.gist_hscroll, 0);
+        state.handle_key(KeyCode::Left); // saturates at 0
+        assert_eq!(state.gist_hscroll, 0);
+        state.handle_key(KeyCode::Right);
+        state.handle_key(KeyCode::Right);
+        assert_eq!(state.gist_hscroll, 2);
+        state.handle_key(KeyCode::Left);
+        assert_eq!(state.gist_hscroll, 1);
+    }
+
+    #[test]
+    fn gist_hscroll_caps_at_longest_row() {
+        let mut state = initial_state();
+        state.gists = vec![GistFile {
+            gist_id: "a".into(),
+            description: "tiny".into(),
+            filename: "f".into(),
+            public: false,
+            updated_at: "x".into(),
+        }];
+        state.focus = FocusPane::Gist;
+        let row = gist_row_label(&state.ranked_gists()[0], state.gist_view);
+        let max = (row.chars().count() - 1) as u16;
+        for _ in 0..200 {
+            state.handle_key(KeyCode::Right);
+        }
+        assert_eq!(state.gist_hscroll, max);
+    }
+
+    #[test]
+    fn moving_gist_selection_resets_hscroll() {
+        let mut state = initial_state();
+        state.gists = vec![
+            GistFile {
+                gist_id: "a".into(),
+                description: "first long description here".into(),
+                filename: "a.json".into(),
+                public: false,
+                updated_at: "x".into(),
+            },
+            GistFile {
+                gist_id: "b".into(),
+                description: "second long description here".into(),
+                filename: "b.json".into(),
+                public: false,
+                updated_at: "x".into(),
+            },
+        ];
+        state.focus = FocusPane::Gist;
+        state.handle_key(KeyCode::Right);
+        assert_eq!(state.gist_hscroll, 1);
+        state.handle_key(KeyCode::Down);
+        assert_eq!(state.gist_hscroll, 0);
+    }
+
+    #[test]
     fn empty_state_has_no_ranked_gists() {
         let state = initial_state();
         assert!(state.ranked_gists().is_empty());
+    }
+
+    #[test]
+    fn no_local_selected_lists_all_gists_unranked() {
+        let mut state = initial_state();
+        state.gists = vec![
+            GistFile {
+                gist_id: "a".into(),
+                description: "first".into(),
+                filename: "alpha.json".into(),
+                public: false,
+                updated_at: "x".into(),
+            },
+            GistFile {
+                gist_id: "b".into(),
+                description: "second".into(),
+                filename: "beta.json".into(),
+                public: false,
+                updated_at: "x".into(),
+            },
+        ];
+        let ranked = state.ranked_gists();
+        assert_eq!(ranked.len(), 2);
+        // Order preserved (unranked) and no scoring applied.
+        assert_eq!(ranked[0].file.filename, "alpha.json");
+        assert_eq!(ranked[0].score, 0);
+        assert!(ranked[0].reasons.is_empty());
+    }
+
+    #[test]
+    fn enter_with_no_local_but_gist_selected_returns_preview() {
+        let mut state = initial_state();
+        state.gists = vec![GistFile {
+            gist_id: "a".into(),
+            description: "first".into(),
+            filename: "alpha.json".into(),
+            public: false,
+            updated_at: "x".into(),
+        }];
+        state.focus = FocusPane::Gist;
+        assert!(state.locals.is_empty());
+        assert_eq!(state.handle_key(KeyCode::Enter), KeyOutcome::PreviewDiff);
     }
 
     #[test]
@@ -426,24 +928,32 @@ mod tests {
             "the diff".into(),
             "remote body".into(),
             PathBuf::from("/tmp/x"),
+            PathBuf::from("/tmp/cwd/x"),
         );
         assert_eq!(state.screen, Screen::Diff);
         assert!(state.diff_previewed);
         assert_eq!(state.preview_remote, "remote body");
         assert_eq!(state.preview_local, PathBuf::from("/tmp/x"));
+        assert_eq!(state.download_target, PathBuf::from("/tmp/cwd/x"));
         assert_eq!(state.diff_scroll, 0);
     }
 
     #[test]
     fn back_to_list_clears_preview() {
         let mut state = initial_state();
-        state.enter_diff("d".into(), "r".into(), PathBuf::from("/tmp/x"));
+        state.enter_diff(
+            "d".into(),
+            "r".into(),
+            PathBuf::from("/tmp/x"),
+            PathBuf::from("/tmp/x"),
+        );
         state.back_to_list();
         assert_eq!(state.screen, Screen::List);
         assert!(!state.diff_previewed);
         assert!(state.diff_text.is_empty());
         assert!(state.preview_remote.is_empty());
         assert_eq!(state.preview_local, PathBuf::new());
+        assert_eq!(state.download_target, PathBuf::new());
     }
 
     #[test]
@@ -460,6 +970,33 @@ mod tests {
     }
 
     #[test]
+    fn d_in_gist_focus_returns_download_gist() {
+        let mut state = state_with_selection();
+        assert_eq!(
+            state.handle_key(KeyCode::Char('d')),
+            KeyOutcome::DownloadGist
+        );
+    }
+
+    #[test]
+    fn d_in_local_focus_is_noop() {
+        let mut state = state_with_selection();
+        state.focus = FocusPane::Local;
+        assert_eq!(state.handle_key(KeyCode::Char('d')), KeyOutcome::None);
+    }
+
+    #[test]
+    fn d_without_gists_is_noop() {
+        let mut state = initial_state();
+        state.locals = vec![LocalCandidate {
+            path: PathBuf::from("/tmp/x"),
+            pinned: false,
+        }];
+        state.focus = FocusPane::Gist;
+        assert_eq!(state.handle_key(KeyCode::Char('d')), KeyOutcome::None);
+    }
+
+    #[test]
     fn enter_without_gists_is_noop() {
         let mut state = initial_state();
         state.locals = vec![LocalCandidate {
@@ -473,7 +1010,12 @@ mod tests {
     #[test]
     fn diff_scroll_respects_bounds() {
         let mut state = initial_state();
-        state.enter_diff("l1\nl2\nl3".into(), "r".into(), PathBuf::from("/tmp/x"));
+        state.enter_diff(
+            "l1\nl2\nl3".into(),
+            "r".into(),
+            PathBuf::from("/tmp/x"),
+            PathBuf::from("/tmp/x"),
+        );
         assert_eq!(state.diff_scroll, 0);
         state.handle_key(KeyCode::Up); // stays at 0
         assert_eq!(state.diff_scroll, 0);
@@ -488,9 +1030,35 @@ mod tests {
     }
 
     #[test]
+    fn diff_hscroll_respects_bounds() {
+        let mut state = initial_state();
+        // Longest line is "abcd" (4 chars) -> max offset 3.
+        state.enter_diff(
+            "abcd\nab".into(),
+            "r".into(),
+            PathBuf::from("/tmp/x"),
+            PathBuf::from("/tmp/x"),
+        );
+        assert_eq!(state.diff_hscroll, 0);
+        state.handle_key(KeyCode::Left); // stays at 0
+        assert_eq!(state.diff_hscroll, 0);
+        for _ in 0..10 {
+            state.handle_key(KeyCode::Right);
+        }
+        assert_eq!(state.diff_hscroll, 3);
+        state.handle_key(KeyCode::Left);
+        assert_eq!(state.diff_hscroll, 2);
+    }
+
+    #[test]
     fn esc_in_diff_returns_to_list() {
         let mut state = initial_state();
-        state.enter_diff("d".into(), "r".into(), PathBuf::from("/tmp/x"));
+        state.enter_diff(
+            "d".into(),
+            "r".into(),
+            PathBuf::from("/tmp/x"),
+            PathBuf::from("/tmp/x"),
+        );
         assert_eq!(state.handle_key(KeyCode::Esc), KeyOutcome::None);
         assert_eq!(state.screen, Screen::List);
         assert!(!state.diff_previewed);
@@ -501,7 +1069,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let missing = dir.path().join("does-not-exist.json");
         let mut state = initial_state();
-        state.enter_diff("d".into(), "r".into(), missing);
+        state.enter_diff("d".into(), "r".into(), PathBuf::from("/tmp/local"), missing);
         assert_eq!(state.handle_key(KeyCode::Char('d')), KeyOutcome::Download);
     }
 
@@ -511,7 +1079,12 @@ mod tests {
         let existing = dir.path().join("exists.json");
         std::fs::write(&existing, "old").unwrap();
         let mut state = initial_state();
-        state.enter_diff("d".into(), "r".into(), existing);
+        state.enter_diff(
+            "d".into(),
+            "r".into(),
+            PathBuf::from("/tmp/local"),
+            existing,
+        );
         assert_eq!(state.handle_key(KeyCode::Char('d')), KeyOutcome::None);
         assert_eq!(state.screen, Screen::ConfirmOverwrite);
     }
@@ -519,7 +1092,12 @@ mod tests {
     #[test]
     fn confirm_y_returns_download() {
         let mut state = initial_state();
-        state.enter_diff("d".into(), "r".into(), PathBuf::from("/tmp/x"));
+        state.enter_diff(
+            "d".into(),
+            "r".into(),
+            PathBuf::from("/tmp/x"),
+            PathBuf::from("/tmp/x"),
+        );
         state.screen = Screen::ConfirmOverwrite;
         assert_eq!(state.handle_key(KeyCode::Char('y')), KeyOutcome::Download);
     }
@@ -527,7 +1105,12 @@ mod tests {
     #[test]
     fn confirm_n_returns_to_diff() {
         let mut state = initial_state();
-        state.enter_diff("d".into(), "r".into(), PathBuf::from("/tmp/x"));
+        state.enter_diff(
+            "d".into(),
+            "r".into(),
+            PathBuf::from("/tmp/x"),
+            PathBuf::from("/tmp/x"),
+        );
         state.screen = Screen::ConfirmOverwrite;
         assert_eq!(state.handle_key(KeyCode::Char('n')), KeyOutcome::None);
         assert_eq!(state.screen, Screen::Diff);
@@ -536,7 +1119,12 @@ mod tests {
     #[test]
     fn q_in_diff_quits() {
         let mut state = initial_state();
-        state.enter_diff("d".into(), "r".into(), PathBuf::from("/tmp/x"));
+        state.enter_diff(
+            "d".into(),
+            "r".into(),
+            PathBuf::from("/tmp/x"),
+            PathBuf::from("/tmp/x"),
+        );
         assert_eq!(state.handle_key(KeyCode::Char('q')), KeyOutcome::Quit);
     }
 
@@ -549,7 +1137,12 @@ mod tests {
     #[test]
     fn q_in_confirm_quits() {
         let mut state = initial_state();
-        state.enter_diff("d".into(), "r".into(), PathBuf::from("/tmp/x"));
+        state.enter_diff(
+            "d".into(),
+            "r".into(),
+            PathBuf::from("/tmp/x"),
+            PathBuf::from("/tmp/x"),
+        );
         state.screen = Screen::ConfirmOverwrite;
         assert_eq!(state.handle_key(KeyCode::Char('q')), KeyOutcome::Quit);
     }
@@ -557,7 +1150,12 @@ mod tests {
     #[test]
     fn confirm_esc_returns_to_diff() {
         let mut state = initial_state();
-        state.enter_diff("d".into(), "r".into(), PathBuf::from("/tmp/x"));
+        state.enter_diff(
+            "d".into(),
+            "r".into(),
+            PathBuf::from("/tmp/x"),
+            PathBuf::from("/tmp/x"),
+        );
         state.screen = Screen::ConfirmOverwrite;
         assert_eq!(state.handle_key(KeyCode::Esc), KeyOutcome::None);
         assert_eq!(state.screen, Screen::Diff);

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -604,8 +604,19 @@ pub fn load_startup_state() -> Result<AppState> {
     state.focus = FocusPane::Gist;
     // The gist list is fetched off-thread by run_loop so the TUI appears instantly.
     state.loading = true;
+    // Show last-known gists immediately from the on-disk cache; the background fetch
+    // refreshes them once it completes.
+    if let Ok(path) = crate::cache::cache_path() {
+        state.gists = crate::cache::load_cached_gists(&path);
+    }
 
     Ok(state)
+}
+
+fn cache_gists(gists: &[GistFile]) {
+    if let Ok(path) = crate::cache::cache_path() {
+        crate::cache::save_cached_gists(&path, gists);
+    }
 }
 
 /// Fetches the gist list on a background thread so startup does not block on `gh`.
@@ -650,6 +661,7 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
         // Absorb the background gist list once it arrives.
         if state.loading {
             if let Ok(gists) = gist_rx.try_recv() {
+                cache_gists(&gists);
                 state.gists = gists;
                 state.loading = false;
                 if state.gist_index >= state.ranked_gists().len() {
@@ -938,6 +950,7 @@ fn refresh_gists(state: &mut AppState) {
     if let Ok(gists) =
         crate::gh::fetch_gist_list_json().and_then(|raw| crate::gh::parse_gist_list_json(&raw))
     {
+        cache_gists(&gists);
         state.gists = gists;
         if state.gist_index >= state.ranked_gists().len() {
             state.gist_index = 0;

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1429,12 +1429,16 @@ fn render_pane(
     }
 }
 
-/// Renders a unified diff with per-line colour: additions green, deletions red, the
-/// `---`/`+++` file headers bold. Context lines keep the default style.
-fn colorize_diff(text: &str) -> Text<'static> {
+/// Builds the visible, coloured slice of a unified diff (additions green, deletions red,
+/// `---`/`+++` headers bold). Scrolling is applied here by hand — skip `vscroll` lines and
+/// drop `hscroll` leading chars per line — rather than via `Paragraph::scroll`, whose
+/// styled-line handling leaves redraw artifacts in ratatui 0.26.
+fn diff_view(text: &str, vscroll: u16, hscroll: u16) -> Text<'static> {
     let lines: Vec<Line> = text
         .lines()
+        .skip(vscroll as usize)
         .map(|line| {
+            // Colour from the original prefix even when horizontal scroll hides it.
             let style = if line.starts_with("+++") || line.starts_with("---") {
                 Style::default().add_modifier(Modifier::BOLD)
             } else if line.starts_with('+') {
@@ -1444,7 +1448,8 @@ fn colorize_diff(text: &str) -> Text<'static> {
             } else {
                 Style::default()
             };
-            Line::styled(line.to_string(), style)
+            let visible: String = line.chars().skip(hscroll as usize).collect();
+            Line::styled(visible, style)
         })
         .collect();
     Text::from(lines)
@@ -1485,14 +1490,17 @@ fn render_diff(frame: &mut Frame, state: &AppState, confirming: bool) {
         }
     };
     frame.render_widget(
-        Paragraph::new(colorize_diff(&state.diff_text))
-            .scroll((state.diff_scroll, state.diff_hscroll))
-            .block(
-                Block::default()
-                    .title(title)
-                    .borders(Borders::ALL)
-                    .padding(Padding::horizontal(1)),
-            ),
+        Paragraph::new(diff_view(
+            &state.diff_text,
+            state.diff_scroll,
+            state.diff_hscroll,
+        ))
+        .block(
+            Block::default()
+                .title(title)
+                .borders(Borders::ALL)
+                .padding(Padding::horizontal(1)),
+        ),
         chunks[0],
     );
 
@@ -1812,6 +1820,14 @@ mod tests {
         let mut state = initial_state();
         state.screen = Screen::Help;
         assert_eq!(state.handle_key(KeyCode::Char('q')), KeyOutcome::Quit);
+    }
+
+    #[test]
+    fn diff_view_applies_vertical_and_horizontal_scroll() {
+        let text = "--- a\n+++ b\nabcdef\n more";
+        let v = diff_view(text, 2, 2); // skip 2 lines, drop 2 leading chars
+        assert_eq!(v.lines.len(), 2);
+        assert_eq!(v.lines[0].spans[0].content, "cdef");
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -32,6 +32,7 @@ pub enum Screen {
     Diff,
     Confirm,
     Preview,
+    Help,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -354,6 +355,17 @@ impl AppState {
             Screen::Diff => self.handle_key_diff(code),
             Screen::Confirm => self.handle_key_confirm(code),
             Screen::Preview => self.handle_key_preview(code),
+            Screen::Help => self.handle_key_help(code),
+        }
+    }
+
+    fn handle_key_help(&mut self, code: KeyCode) -> KeyOutcome {
+        match code {
+            KeyCode::Char('q') => KeyOutcome::Quit,
+            _ => {
+                self.screen = Screen::List;
+                KeyOutcome::None
+            }
         }
     }
 
@@ -457,6 +469,7 @@ impl AppState {
                 self.gist_hscroll = 0;
             }
             KeyCode::Char('/') => self.filtering = true,
+            KeyCode::Char('?') => self.screen = Screen::Help,
             KeyCode::Char(' ') if self.selected_gist().is_some() => {
                 return KeyOutcome::PreviewContent;
             }
@@ -1015,7 +1028,44 @@ fn render(frame: &mut Frame, state: &AppState) {
         Screen::Diff => render_diff(frame, state, false),
         Screen::Confirm => render_diff(frame, state, true),
         Screen::Preview => render_preview(frame, state),
+        Screen::Help => render_help(frame),
     }
+}
+
+fn render_help(frame: &mut Frame) {
+    let text = "\
+Navigation
+  Tab        switch pane (Local / Gists)
+  Up/Down    move the selection
+  Left/Right scroll a long row horizontally
+
+Gist list
+  /          filter by filename or description
+  v          cycle visibility: all / public / secret
+  s          cycle sort: match / name / recent
+  t          toggle row view: description / id
+
+Actions (on the selected local file + gist)
+  Enter      diff the local file against the gist
+  Space      preview the gist file's content
+  d          download the gist into the cwd
+  u          upload the local file into the gist
+  n          create a new gist from the local file
+  p          pin / unpin the local <-> gist pair
+
+General
+  ?          show this help
+  q          quit";
+
+    frame.render_widget(
+        Paragraph::new(text).block(
+            Block::default()
+                .title("Help — press any key to close")
+                .borders(Borders::ALL)
+                .padding(Padding::horizontal(1)),
+        ),
+        frame.size(),
+    );
 }
 
 fn render_preview(frame: &mut Frame, state: &AppState) {
@@ -1098,6 +1148,7 @@ fn commands_hint() -> String {
         "v type",
         "s sort",
         "/ filter",
+        "? help",
         "q quit",
     ]
     .join("  ·  ")
@@ -1620,6 +1671,22 @@ mod tests {
         assert_eq!(state.diff_scroll, 1);
         state.handle_key(KeyCode::Up);
         assert_eq!(state.diff_scroll, 0);
+    }
+
+    #[test]
+    fn question_opens_help_and_any_key_closes_it() {
+        let mut state = initial_state();
+        state.handle_key(KeyCode::Char('?'));
+        assert_eq!(state.screen, Screen::Help);
+        assert_eq!(state.handle_key(KeyCode::Char('x')), KeyOutcome::None);
+        assert_eq!(state.screen, Screen::List);
+    }
+
+    #[test]
+    fn q_in_help_quits() {
+        let mut state = initial_state();
+        state.screen = Screen::Help;
+        assert_eq!(state.handle_key(KeyCode::Char('q')), KeyOutcome::Quit);
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -27,6 +27,7 @@ pub enum Screen {
     List,
     Diff,
     Confirm,
+    Preview,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -131,6 +132,7 @@ pub enum KeyOutcome {
     UploadPreview,
     Upload,
     Create(bool),
+    PreviewContent,
 }
 
 #[derive(Debug, Clone)]
@@ -160,6 +162,8 @@ pub struct AppState {
     pub cwd: PathBuf,
     pub status: Option<String>,
     pub loading: bool,
+    pub preview_title: String,
+    pub gist_content_cache: std::collections::HashMap<(String, String), String>,
 }
 
 impl AppState {
@@ -315,7 +319,25 @@ impl AppState {
             Screen::List => self.handle_key_list(code),
             Screen::Diff => self.handle_key_diff(code),
             Screen::Confirm => self.handle_key_confirm(code),
+            Screen::Preview => self.handle_key_preview(code),
         }
+    }
+
+    fn handle_key_preview(&mut self, code: KeyCode) -> KeyOutcome {
+        match code {
+            KeyCode::Char('q') => return KeyOutcome::Quit,
+            KeyCode::Esc => {
+                self.screen = Screen::List;
+                self.diff_text.clear();
+                self.preview_title.clear();
+            }
+            KeyCode::Down => self.scroll_diff_down(),
+            KeyCode::Up => self.scroll_diff_up(),
+            KeyCode::Right => self.scroll_diff_right(),
+            KeyCode::Left => self.scroll_diff_left(),
+            _ => {}
+        }
+        KeyOutcome::None
     }
 
     fn handle_key_filter(&mut self, code: KeyCode) -> KeyOutcome {
@@ -401,6 +423,9 @@ impl AppState {
                 self.gist_hscroll = 0;
             }
             KeyCode::Char('/') => self.filtering = true,
+            KeyCode::Char(' ') if self.selected_gist().is_some() => {
+                return KeyOutcome::PreviewContent;
+            }
             KeyCode::Char('d')
                 if self.focus == FocusPane::Gist && self.gist_index < self.ranked_gists().len() =>
             {
@@ -560,6 +585,8 @@ pub fn initial_state() -> AppState {
         cwd: PathBuf::from("."),
         status: None,
         loading: false,
+        preview_title: String::new(),
+        gist_content_cache: std::collections::HashMap::new(),
     }
 }
 
@@ -650,6 +677,7 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
                     draw_loading(terminal, &mut state)?;
                     create_gist(&mut state, public);
                 }
+                KeyOutcome::PreviewContent => fetch_then(terminal, &mut state, preview_content)?,
                 KeyOutcome::None => {}
             }
         }
@@ -700,6 +728,32 @@ fn preview_diff(state: &mut AppState) {
         }
         Err(error) => state.set_status(format!("fetch failed: {error}")),
     }
+}
+
+fn preview_content(state: &mut AppState) {
+    let Some(gist) = state.selected_gist() else {
+        return;
+    };
+    let key = (gist.file.gist_id.clone(), gist.file.filename.clone());
+    let content = match state.gist_content_cache.get(&key) {
+        Some(cached) => cached.clone(),
+        None => match crate::gh::fetch_gist_file_content(&gist.file.gist_id, &gist.file.filename) {
+            Ok(content) => {
+                state.gist_content_cache.insert(key, content.clone());
+                content
+            }
+            Err(error) => {
+                state.set_status(format!("fetch failed: {error}"));
+                return;
+            }
+        },
+    };
+    state.preview_title = format!("Preview: {} / {}", gist.file.gist_id, gist.file.filename);
+    state.diff_text = content;
+    state.diff_scroll = 0;
+    state.diff_hscroll = 0;
+    state.status = None;
+    state.screen = Screen::Preview;
 }
 
 fn download_selected(state: &mut AppState) {
@@ -920,7 +974,31 @@ fn render(frame: &mut Frame, state: &AppState) {
         Screen::List => render_list(frame, state),
         Screen::Diff => render_diff(frame, state, false),
         Screen::Confirm => render_diff(frame, state, true),
+        Screen::Preview => render_preview(frame, state),
     }
+}
+
+fn render_preview(frame: &mut Frame, state: &AppState) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(5), Constraint::Length(3)])
+        .split(frame.size());
+
+    frame.render_widget(
+        Paragraph::new(state.diff_text.clone())
+            .scroll((state.diff_scroll, state.diff_hscroll))
+            .block(
+                Block::default()
+                    .title(state.preview_title.clone())
+                    .borders(Borders::ALL),
+            ),
+        chunks[0],
+    );
+    frame.render_widget(
+        Paragraph::new("Up/Down/Left/Right scroll  Esc back  q quit")
+            .block(Block::default().title("Commands").borders(Borders::ALL)),
+        chunks[1],
+    );
 }
 
 fn local_row_label(path: &std::path::Path) -> String {
@@ -1034,7 +1112,7 @@ fn render_list(frame: &mut Frame, state: &AppState) {
         match &state.status {
             Some(message) => message.clone(),
             None => {
-                "Tab  ↑↓ move  ←→ scroll  Enter diff  d download  u upload  n create  p pin  t view  v type  s sort  / filter  q quit"
+                "Tab  ↑↓←→  Enter diff  Space preview  d download  u upload  n create  p pin  t view  v type  s sort  / filter  q quit"
                     .to_string()
             }
         }
@@ -1348,6 +1426,44 @@ mod tests {
         state.handle_key(KeyCode::Char('y'));
         state.handle_key(KeyCode::Backspace);
         assert_eq!(state.filter_query, "x");
+    }
+
+    #[test]
+    fn space_on_selected_gist_returns_preview_content() {
+        let mut state = state_with_two_gists();
+        assert_eq!(
+            state.handle_key(KeyCode::Char(' ')),
+            KeyOutcome::PreviewContent
+        );
+    }
+
+    #[test]
+    fn space_without_gist_is_noop() {
+        let mut state = initial_state();
+        assert_eq!(state.handle_key(KeyCode::Char(' ')), KeyOutcome::None);
+    }
+
+    #[test]
+    fn esc_in_preview_returns_to_list_and_clears() {
+        let mut state = initial_state();
+        state.screen = Screen::Preview;
+        state.diff_text = "raw content".into();
+        state.preview_title = "Preview: a / x".into();
+        assert_eq!(state.handle_key(KeyCode::Esc), KeyOutcome::None);
+        assert_eq!(state.screen, Screen::List);
+        assert!(state.diff_text.is_empty());
+        assert!(state.preview_title.is_empty());
+    }
+
+    #[test]
+    fn preview_scrolls_with_arrows() {
+        let mut state = initial_state();
+        state.screen = Screen::Preview;
+        state.diff_text = "l1\nl2\nl3".into();
+        state.handle_key(KeyCode::Down);
+        assert_eq!(state.diff_scroll, 1);
+        state.handle_key(KeyCode::Up);
+        assert_eq!(state.diff_scroll, 0);
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -287,13 +287,47 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
         })?;
 
         if let Event::Key(key) = event::read()? {
-            if state.handle_key(key.code) == KeyOutcome::Quit {
-                break;
+            match state.handle_key(key.code) {
+                KeyOutcome::Quit => break,
+                KeyOutcome::PreviewDiff => preview_diff(&mut state),
+                KeyOutcome::Download => download(&mut state),
+                KeyOutcome::None => {}
             }
         }
     }
 
     Ok(())
+}
+
+fn preview_diff(state: &mut AppState) {
+    let (Some(local), Some(ranked)) = (state.selected_local().cloned(), state.selected_gist())
+    else {
+        return;
+    };
+    let gist = ranked.file;
+    match crate::gh::fetch_gist_file_content(&gist.gist_id, &gist.filename) {
+        Ok(remote) => {
+            let local_content = std::fs::read_to_string(&local.path).unwrap_or_default();
+            let diff = crate::diff::unified_diff("local", &local_content, "gist", &remote);
+            state.enter_diff(diff, remote, local.path.clone());
+        }
+        Err(error) => state.set_status(format!("fetch failed: {error}")),
+    }
+}
+
+fn download(state: &mut AppState) {
+    let local = state.preview_local.clone();
+    let content = state.preview_remote.clone();
+    match crate::actions::execute_download(&local, &content, true) {
+        Ok(()) => {
+            state.set_status(format!("Downloaded {}", local.display()));
+            state.back_to_list();
+        }
+        Err(error) => {
+            state.set_status(format!("download failed: {error}"));
+            state.screen = Screen::Diff;
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -431,9 +431,9 @@ impl AppState {
             {
                 return KeyOutcome::DownloadGist;
             }
-            KeyCode::Enter
-                if self.focus == FocusPane::Gist && self.gist_index < self.ranked_gists().len() =>
-            {
+            // Enter works from either pane: it diffs the selected local file against the
+            // selected gist (the top match when focus is on the local pane).
+            KeyCode::Enter if self.gist_index < self.ranked_gists().len() => {
                 return KeyOutcome::PreviewDiff;
             }
             KeyCode::Char('p') => {
@@ -1759,8 +1759,19 @@ mod tests {
     }
 
     #[test]
-    fn enter_in_local_focus_is_noop() {
+    fn enter_in_local_focus_previews_top_gist() {
         let mut state = state_with_selection();
+        state.focus = FocusPane::Local;
+        assert_eq!(state.handle_key(KeyCode::Enter), KeyOutcome::PreviewDiff);
+    }
+
+    #[test]
+    fn enter_with_no_gists_is_noop_in_local_focus() {
+        let mut state = initial_state();
+        state.locals = vec![LocalCandidate {
+            path: PathBuf::from("/tmp/x"),
+            pinned: false,
+        }];
         state.focus = FocusPane::Local;
         assert_eq!(state.handle_key(KeyCode::Enter), KeyOutcome::None);
     }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -10,6 +10,7 @@ use ratatui::{
     backend::CrosstermBackend,
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
+    text::{Line, Text},
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
     Frame, Terminal,
 };
@@ -1193,6 +1194,27 @@ fn render_pane(
     frame.render_stateful_widget(list, area, &mut list_state);
 }
 
+/// Renders a unified diff with per-line colour: additions green, deletions red, the
+/// `---`/`+++` file headers bold. Context lines keep the default style.
+fn colorize_diff(text: &str) -> Text<'static> {
+    let lines: Vec<Line> = text
+        .lines()
+        .map(|line| {
+            let style = if line.starts_with("+++") || line.starts_with("---") {
+                Style::default().add_modifier(Modifier::BOLD)
+            } else if line.starts_with('+') {
+                Style::default().fg(Color::Green)
+            } else if line.starts_with('-') {
+                Style::default().fg(Color::Red)
+            } else {
+                Style::default()
+            };
+            Line::styled(line.to_string(), style)
+        })
+        .collect();
+    Text::from(lines)
+}
+
 fn render_diff(frame: &mut Frame, state: &AppState, confirming: bool) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -1205,7 +1227,7 @@ fn render_diff(frame: &mut Frame, state: &AppState, confirming: bool) {
         state.download_target.display()
     );
     frame.render_widget(
-        Paragraph::new(state.diff_text.clone())
+        Paragraph::new(colorize_diff(&state.diff_text))
             .scroll((state.diff_scroll, state.diff_hscroll))
             .block(Block::default().title(title).borders(Borders::ALL)),
         chunks[0],

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -125,6 +125,8 @@ pub enum KeyOutcome {
     PreviewDiff,
     Download,
     DownloadGist,
+    Pin,
+    Unpin,
 }
 
 #[derive(Debug, Clone)]
@@ -370,6 +372,24 @@ impl AppState {
             {
                 return KeyOutcome::PreviewDiff;
             }
+            KeyCode::Char('p') => {
+                let (Some(local), Some(gist)) =
+                    (self.selected_local().cloned(), self.selected_gist())
+                else {
+                    self.status = Some("select a local file and a gist to pin".into());
+                    return KeyOutcome::None;
+                };
+                let already = self.pinned.iter().any(|m| {
+                    m.local_path == local.path
+                        && m.gist_id == gist.file.gist_id
+                        && m.gist_filename == gist.file.filename
+                });
+                return if already {
+                    KeyOutcome::Unpin
+                } else {
+                    KeyOutcome::Pin
+                };
+            }
             _ => {}
         }
         KeyOutcome::None
@@ -498,6 +518,8 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
                 KeyOutcome::PreviewDiff => preview_diff(&mut state),
                 KeyOutcome::Download => download(&mut state),
                 KeyOutcome::DownloadGist => download_selected(&mut state),
+                KeyOutcome::Pin => pin_selected(&mut state),
+                KeyOutcome::Unpin => unpin_selected(&mut state),
                 KeyOutcome::None => {}
             }
         }
@@ -587,6 +609,44 @@ fn refresh_locals(state: &mut AppState) {
         if state.gist_index >= state.ranked_gists().len() {
             state.gist_index = 0;
         }
+    }
+}
+
+fn pin_selected(state: &mut AppState) {
+    let (Some(local), Some(gist)) = (state.selected_local().cloned(), state.selected_gist()) else {
+        return;
+    };
+    let result = crate::config::config_path().and_then(|path| {
+        let config = crate::config::load_config(&path)?;
+        crate::actions::pin_mapping(&path, config, &local.path, &gist.file, None, None)
+    });
+    match result {
+        Ok(config) => {
+            state.pinned = config.pinned;
+            state.set_status(format!(
+                "Pinned {} <-> {}",
+                local.path.display(),
+                gist.file.filename
+            ));
+        }
+        Err(error) => state.set_status(format!("pin failed: {error}")),
+    }
+}
+
+fn unpin_selected(state: &mut AppState) {
+    let Some(local) = state.selected_local().cloned() else {
+        return;
+    };
+    let result = crate::config::config_path().and_then(|path| {
+        let config = crate::config::load_config(&path)?;
+        crate::actions::unpin_mapping(&path, config, &local.path)
+    });
+    match result {
+        Ok(config) => {
+            state.pinned = config.pinned;
+            state.set_status(format!("Unpinned {}", local.path.display()));
+        }
+        Err(error) => state.set_status(format!("unpin failed: {error}")),
     }
 }
 
@@ -1404,5 +1464,25 @@ mod tests {
         assert_eq!(state.handle_key(KeyCode::Char('d')), KeyOutcome::None);
         assert_eq!(state.screen, Screen::Confirm);
         assert_eq!(state.pending_action, Some(PendingAction::Download));
+    }
+
+    #[test]
+    fn p_pins_unpinned_pair_then_unpins() {
+        let mut state = state_with_selection();
+        assert_eq!(state.handle_key(KeyCode::Char('p')), KeyOutcome::Pin);
+        state.pinned = vec![PinnedMapping {
+            local_path: PathBuf::from("/tmp/settings.json"),
+            gist_id: "a".into(),
+            gist_filename: "settings.json".into(),
+            direction: None,
+            last_seen_hash: None,
+        }];
+        assert_eq!(state.handle_key(KeyCode::Char('p')), KeyOutcome::Unpin);
+    }
+
+    #[test]
+    fn p_without_local_or_gist_is_noop() {
+        let mut state = initial_state();
+        assert_eq!(state.handle_key(KeyCode::Char('p')), KeyOutcome::None);
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -8,10 +8,13 @@ use crossterm::{
 };
 use ratatui::{
     backend::CrosstermBackend,
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::{Constraint, Direction, Layout, Margin, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Text},
-    widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
+    widgets::{
+        Block, Borders, List, ListItem, ListState, Padding, Paragraph, Scrollbar,
+        ScrollbarOrientation, ScrollbarState, Wrap,
+    },
     Frame, Terminal,
 };
 use std::io;
@@ -1148,11 +1151,15 @@ fn render_list(frame: &mut Frame, state: &AppState) {
 
     // Discovery is scoped to the cwd, so each candidate is a direct child; show just the
     // file name and put the cwd in the pane title as the shared baseline.
-    let local_items: Vec<ListItem> = state
-        .locals
-        .iter()
-        .map(|c| ListItem::new(hscroll_str(&local_row_label(&c.path), state.local_hscroll)))
-        .collect();
+    let local_items: Vec<ListItem> = if state.locals.is_empty() {
+        vec![ListItem::new("(no files in this directory)")]
+    } else {
+        state
+            .locals
+            .iter()
+            .map(|c| ListItem::new(hscroll_str(&local_row_label(&c.path), state.local_hscroll)))
+            .collect()
+    };
     let local_focused = state.focus == FocusPane::Local;
     let local_selected = (!state.locals.is_empty()).then_some(state.local_index);
     let local_title = format!("Local · {}", state.cwd.display());
@@ -1168,6 +1175,13 @@ fn render_list(frame: &mut Frame, state: &AppState) {
     let ranked = state.ranked_gists();
     let gist_items: Vec<ListItem> = if state.loading && ranked.is_empty() {
         vec![ListItem::new("Loading gists…")]
+    } else if ranked.is_empty() {
+        let message = if !state.filter_query.is_empty() {
+            "(no gists match the filter)"
+        } else {
+            "(no gists)"
+        };
+        vec![ListItem::new(message)]
     } else {
         ranked
             .iter()
@@ -1214,13 +1228,24 @@ fn render_pane(
     focused: bool,
     selected: Option<usize>,
 ) {
+    let item_count = items.len();
     let border_style = if focused {
         Style::default().fg(Color::Cyan)
     } else {
         Style::default()
     };
+    // Dim the unfocused pane so the active side is obvious at a glance.
+    let base_style = if focused {
+        Style::default()
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+    // Focused selection is a solid bar (whole row); unfocused just bolds the row.
     let highlight_style = if focused {
-        Style::default().add_modifier(Modifier::REVERSED)
+        Style::default()
+            .bg(Color::Cyan)
+            .fg(Color::Black)
+            .add_modifier(Modifier::BOLD)
     } else {
         Style::default().add_modifier(Modifier::BOLD)
     };
@@ -1231,11 +1256,13 @@ fn render_pane(
     };
 
     let list = List::new(items)
+        .style(base_style)
         .block(
             Block::default()
                 .title(title)
                 .borders(Borders::ALL)
-                .border_style(border_style),
+                .border_style(border_style)
+                .padding(Padding::horizontal(1)),
         )
         .highlight_style(highlight_style)
         .highlight_symbol("▶ ");
@@ -1243,6 +1270,22 @@ fn render_pane(
     let mut list_state = ListState::default();
     list_state.select(selected);
     frame.render_stateful_widget(list, area, &mut list_state);
+
+    // Show a scrollbar when the list overflows its viewport.
+    let viewport = area.height.saturating_sub(2) as usize;
+    if viewport > 0 && item_count > viewport {
+        let mut scrollbar_state = ScrollbarState::new(item_count).position(selected.unwrap_or(0));
+        frame.render_stateful_widget(
+            Scrollbar::new(ScrollbarOrientation::VerticalRight)
+                .begin_symbol(None)
+                .end_symbol(None),
+            area.inner(&Margin {
+                vertical: 1,
+                horizontal: 0,
+            }),
+            &mut scrollbar_state,
+        );
+    }
 }
 
 /// Renders a unified diff with per-line colour: additions green, deletions red, the

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -87,13 +87,44 @@ pub fn initial_state() -> AppState {
     }
 }
 
+pub fn load_startup_state() -> Result<AppState> {
+    let mut state = initial_state();
+    let config_path = crate::config::config_path()?;
+    let config = crate::config::load_config(&config_path)?;
+    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
+    let cwd = std::env::current_dir()?;
+
+    state.pinned = config.pinned;
+    state.locals = crate::local::discover_local_candidates(&cwd, &home, &state.pinned)?;
+
+    if crate::gh::check_gh_ready().is_ok() {
+        if let Ok(gists) =
+            crate::gh::fetch_gist_list_json().and_then(|raw| crate::gh::parse_gist_list_json(&raw))
+        {
+            state.gists = gists;
+        }
+    }
+
+    Ok(state)
+}
+
 pub fn run() -> Result<()> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen)?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
-    let mut state = initial_state();
+
+    let result = run_loop(&mut terminal);
+
+    let _ = disable_raw_mode();
+    let _ = execute!(terminal.backend_mut(), LeaveAlternateScreen);
+
+    result
+}
+
+fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()> {
+    let mut state = load_startup_state()?;
 
     loop {
         terminal.draw(|frame| {
@@ -147,8 +178,6 @@ pub fn run() -> Result<()> {
         }
     }
 
-    disable_raw_mode()?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
     Ok(())
 }
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -518,8 +518,25 @@ impl AppState {
     }
 
     fn handle_key_confirm(&mut self, code: KeyCode) -> KeyOutcome {
-        if code == KeyCode::Char('q') {
-            return KeyOutcome::Quit;
+        match code {
+            KeyCode::Char('q') => return KeyOutcome::Quit,
+            KeyCode::Down => {
+                self.scroll_diff_down();
+                return KeyOutcome::None;
+            }
+            KeyCode::Up => {
+                self.scroll_diff_up();
+                return KeyOutcome::None;
+            }
+            KeyCode::Right => {
+                self.scroll_diff_right();
+                return KeyOutcome::None;
+            }
+            KeyCode::Left => {
+                self.scroll_diff_left();
+                return KeyOutcome::None;
+            }
+            _ => {}
         }
         match self.pending_action.clone() {
             Some(PendingAction::Download) => match code {
@@ -1439,6 +1456,18 @@ mod tests {
         state.handle_key(KeyCode::Char('y'));
         state.handle_key(KeyCode::Backspace);
         assert_eq!(state.filter_query, "x");
+    }
+
+    #[test]
+    fn confirm_screen_scrolls_diff() {
+        let mut state = initial_state();
+        state.pending_action = Some(PendingAction::Download);
+        state.screen = Screen::Confirm;
+        state.diff_text = "l1\nl2\nl3".into();
+        assert_eq!(state.handle_key(KeyCode::Down), KeyOutcome::None);
+        assert_eq!(state.diff_scroll, 1);
+        state.handle_key(KeyCode::Up);
+        assert_eq!(state.diff_scroll, 0);
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -11,7 +11,7 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Text},
-    widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
     Frame, Terminal,
 };
 use std::io;
@@ -1072,11 +1072,69 @@ fn gist_row_label(g: &RankedGistFile, view: GistView) -> String {
     }
 }
 
+/// The full command hint as one responsive line; the footer word-wraps it to the
+/// terminal width (one line when wide, more when narrow).
+fn commands_hint() -> String {
+    [
+        "Tab switch pane",
+        "↑↓ move",
+        "←→ scroll",
+        "Enter diff",
+        "Space preview",
+        "d download",
+        "u upload",
+        "n create",
+        "p pin",
+        "t view",
+        "v type",
+        "s sort",
+        "/ filter",
+        "q quit",
+    ]
+    .join("  ·  ")
+}
+
+/// Greedy word-wrap line count, matching how `Paragraph` with `Wrap { trim: true }` breaks
+/// space-separated words at `width`. Used to size the footer block to its content.
+fn wrap_line_count(text: &str, width: u16) -> u16 {
+    if width == 0 {
+        return 1;
+    }
+    let width = width as usize;
+    let mut lines: u16 = 1;
+    let mut col = 0usize;
+    for word in text.split_whitespace() {
+        let w = word.chars().count();
+        if col == 0 {
+            col = w.min(width);
+        } else if col + 1 + w <= width {
+            col += 1 + w;
+        } else {
+            lines = lines.saturating_add(1);
+            col = w.min(width);
+        }
+    }
+    lines
+}
+
 fn render_list(frame: &mut Frame, state: &AppState) {
+    let area = frame.size();
+    let footer_body = if state.filtering {
+        format!(
+            "filter: {}_   (Enter apply · Esc clear)",
+            state.filter_query
+        )
+    } else {
+        match &state.status {
+            Some(message) => message.clone(),
+            None => commands_hint(),
+        }
+    };
+    let footer_lines = wrap_line_count(&footer_body, area.width.saturating_sub(2)).max(1);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Min(5), Constraint::Length(4)])
-        .split(frame.size());
+        .constraints([Constraint::Min(5), Constraint::Length(footer_lines + 2)])
+        .split(area);
     let columns = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
@@ -1134,23 +1192,10 @@ fn render_list(frame: &mut Frame, state: &AppState) {
         gist_selected,
     );
 
-    let footer = if state.filtering {
-        format!(
-            "filter: {}_   (Enter apply · Esc clear)",
-            state.filter_query
-        )
-    } else {
-        match &state.status {
-            Some(message) => message.clone(),
-            None => concat!(
-                "Tab switch pane   ↑↓ move   ←→ scroll   Enter diff   Space preview\n",
-                "d download  u upload  n create  p pin   t view  v type  s sort  / filter   q quit"
-            )
-            .to_string(),
-        }
-    };
     frame.render_widget(
-        Paragraph::new(footer).block(Block::default().title("Commands").borders(Borders::ALL)),
+        Paragraph::new(footer_body)
+            .wrap(Wrap { trim: true })
+            .block(Block::default().title("Commands").borders(Borders::ALL)),
         chunks[1],
     );
 }
@@ -1529,6 +1574,15 @@ mod tests {
         assert_eq!(state.diff_scroll, 1);
         state.handle_key(KeyCode::Up);
         assert_eq!(state.diff_scroll, 0);
+    }
+
+    #[test]
+    fn wrap_line_count_is_responsive_to_width() {
+        let text = "aaa bbb ccc";
+        assert_eq!(wrap_line_count(text, 100), 1);
+        assert_eq!(wrap_line_count(text, 7), 2);
+        assert_eq!(wrap_line_count(text, 3), 3);
+        assert_eq!(wrap_line_count(text, 0), 1);
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1282,22 +1282,14 @@ fn gist_row_label(g: &RankedGistFile, view: GistView) -> String {
 /// The full command hint as one responsive line; the footer word-wraps it to the
 /// terminal width (one line when wide, more when narrow).
 fn commands_hint() -> String {
+    // Only the common keys; the full reference lives in the `?` help overlay.
     [
-        "Tab switch pane",
+        "Tab panes",
         "↑↓ move",
-        "←→ scroll",
         "Enter diff",
         "Space preview",
         "d download",
         "u upload",
-        "n create",
-        "p pin",
-        "o browser",
-        "e edit",
-        "t view",
-        "v type",
-        "s sort",
-        "/ filter",
         "? help",
         "Esc/q quit",
     ]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -159,6 +159,7 @@ pub struct AppState {
     pub download_target: PathBuf,
     pub cwd: PathBuf,
     pub status: Option<String>,
+    pub loading: bool,
 }
 
 impl AppState {
@@ -558,6 +559,7 @@ pub fn initial_state() -> AppState {
         download_target: PathBuf::new(),
         cwd: PathBuf::from("."),
         status: None,
+        loading: false,
     }
 }
 
@@ -573,16 +575,27 @@ pub fn load_startup_state() -> Result<AppState> {
     // Start focused on the gist pane: the common flow is to pick a gist and pull it
     // into the cwd, and the gist list is shown even when no local file is selected.
     state.focus = FocusPane::Gist;
-
-    if crate::gh::check_gh_ready().is_ok() {
-        if let Ok(gists) =
-            crate::gh::fetch_gist_list_json().and_then(|raw| crate::gh::parse_gist_list_json(&raw))
-        {
-            state.gists = gists;
-        }
-    }
+    // The gist list is fetched off-thread by run_loop so the TUI appears instantly.
+    state.loading = true;
 
     Ok(state)
+}
+
+/// Fetches the gist list on a background thread so startup does not block on `gh`.
+/// Mirrors the previous graceful degradation: an empty list on any error.
+fn spawn_gist_fetch() -> std::sync::mpsc::Receiver<Vec<GistFile>> {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let gists = if crate::gh::check_gh_ready().is_ok() {
+            crate::gh::fetch_gist_list_json()
+                .and_then(|raw| crate::gh::parse_gist_list_json(&raw))
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+        let _ = tx.send(gists);
+    });
+    rx
 }
 
 pub fn run() -> Result<()> {
@@ -602,27 +615,67 @@ pub fn run() -> Result<()> {
 
 fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()> {
     let mut state = load_startup_state()?;
+    let gist_rx = spawn_gist_fetch();
 
     loop {
         terminal.draw(|frame| render(frame, &state))?;
 
+        // Absorb the background gist list once it arrives.
+        if state.loading {
+            if let Ok(gists) = gist_rx.try_recv() {
+                state.gists = gists;
+                state.loading = false;
+                if state.gist_index >= state.ranked_gists().len() {
+                    state.gist_index = 0;
+                }
+            }
+        }
+
+        // Poll so the loop also wakes to check the background fetch, not only on input.
+        if !event::poll(std::time::Duration::from_millis(150))? {
+            continue;
+        }
         if let Event::Key(key) = event::read()? {
             match state.handle_key(key.code) {
                 KeyOutcome::Quit => break,
-                KeyOutcome::PreviewDiff => preview_diff(&mut state),
+                KeyOutcome::PreviewDiff => fetch_then(terminal, &mut state, preview_diff)?,
                 KeyOutcome::Download => download(&mut state),
-                KeyOutcome::DownloadGist => download_selected(&mut state),
+                KeyOutcome::DownloadGist => fetch_then(terminal, &mut state, download_selected)?,
                 KeyOutcome::Pin => pin_selected(&mut state),
                 KeyOutcome::Unpin => unpin_selected(&mut state),
-                KeyOutcome::UploadAdd => upload_add(&mut state),
-                KeyOutcome::UploadPreview => upload_preview(&mut state),
-                KeyOutcome::Upload => upload_replace(&mut state),
-                KeyOutcome::Create(public) => create_gist(&mut state, public),
+                KeyOutcome::UploadAdd => fetch_then(terminal, &mut state, upload_add)?,
+                KeyOutcome::UploadPreview => fetch_then(terminal, &mut state, upload_preview)?,
+                KeyOutcome::Upload => fetch_then(terminal, &mut state, upload_replace)?,
+                KeyOutcome::Create(public) => {
+                    draw_loading(terminal, &mut state)?;
+                    create_gist(&mut state, public);
+                }
                 KeyOutcome::None => {}
             }
         }
     }
 
+    Ok(())
+}
+
+/// Draws a "Loading…" frame, then runs a blocking `gh` action. The action overwrites the
+/// status with its result, which the next loop iteration draws.
+fn fetch_then(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    state: &mut AppState,
+    action: fn(&mut AppState),
+) -> Result<()> {
+    draw_loading(terminal, state)?;
+    action(state);
+    Ok(())
+}
+
+fn draw_loading(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    state: &mut AppState,
+) -> Result<()> {
+    state.set_status("Loading…");
+    terminal.draw(|frame| render(frame, state))?;
     Ok(())
 }
 
@@ -940,15 +993,19 @@ fn render_list(frame: &mut Frame, state: &AppState) {
     );
 
     let ranked = state.ranked_gists();
-    let gist_items: Vec<ListItem> = ranked
-        .iter()
-        .map(|g| {
-            ListItem::new(hscroll_str(
-                &gist_row_label(g, state.gist_view),
-                state.gist_hscroll,
-            ))
-        })
-        .collect();
+    let gist_items: Vec<ListItem> = if state.loading && ranked.is_empty() {
+        vec![ListItem::new("Loading gists…")]
+    } else {
+        ranked
+            .iter()
+            .map(|g| {
+                ListItem::new(hscroll_str(
+                    &gist_row_label(g, state.gist_view),
+                    state.gist_hscroll,
+                ))
+            })
+            .collect()
+    };
     let gist_focused = state.focus == FocusPane::Gist;
     let gist_selected = (!ranked.is_empty()).then_some(state.gist_index);
     let mut gist_title = format!(

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -206,6 +206,36 @@ impl AppState {
         self.ranked_gists().into_iter().nth(self.gist_index)
     }
 
+    /// Upload intent shared by the list and the diff screen: requires a selected local file
+    /// and gist, then branches on whether the gist already holds a file of the local name
+    /// (case C: preview + confirm overwrite) or not (case B: add directly).
+    fn upload_intent(&mut self) -> KeyOutcome {
+        let (Some(local), Some(gist)) = (self.selected_local().cloned(), self.selected_gist())
+        else {
+            self.status = Some("select a local file and a gist to upload".into());
+            return KeyOutcome::None;
+        };
+        let Some(local_filename) = local
+            .path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(String::from)
+        else {
+            self.status = Some("local file has no name".into());
+            return KeyOutcome::None;
+        };
+        let gist_id = gist.file.gist_id.clone();
+        let has_same_name = self
+            .gists
+            .iter()
+            .any(|g| g.gist_id == gist_id && g.filename == local_filename);
+        if has_same_name {
+            KeyOutcome::UploadPreview
+        } else {
+            KeyOutcome::UploadAdd
+        }
+    }
+
     /// Highest horizontal-scroll offset for the focused pane, based on its longest row
     /// (viewport width is unknown to the pure key logic, mirroring the diff scroll cap).
     fn focused_hscroll_max(&self) -> u16 {
@@ -455,33 +485,7 @@ impl AppState {
                     KeyOutcome::Pin
                 };
             }
-            KeyCode::Char('u') => {
-                let (Some(local), Some(gist)) =
-                    (self.selected_local().cloned(), self.selected_gist())
-                else {
-                    self.status = Some("select a local file and a gist to upload".into());
-                    return KeyOutcome::None;
-                };
-                let Some(local_filename) = local
-                    .path
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .map(String::from)
-                else {
-                    self.status = Some("local file has no name".into());
-                    return KeyOutcome::None;
-                };
-                let gist_id = gist.file.gist_id.clone();
-                let has_same_name = self
-                    .gists
-                    .iter()
-                    .any(|g| g.gist_id == gist_id && g.filename == local_filename);
-                return if has_same_name {
-                    KeyOutcome::UploadPreview
-                } else {
-                    KeyOutcome::UploadAdd
-                };
-            }
+            KeyCode::Char('u') => return self.upload_intent(),
             KeyCode::Char('n') => {
                 let Some(local) = self.selected_local().cloned() else {
                     self.status = Some("select a local file to create a gist".into());
@@ -513,6 +517,7 @@ impl AppState {
                     return KeyOutcome::Download;
                 }
             }
+            KeyCode::Char('u') => return self.upload_intent(),
             _ => {}
         }
         KeyOutcome::None
@@ -901,6 +906,7 @@ fn upload_add(state: &mut AppState) {
                 local.path.display(),
                 gist.file.gist_id
             ));
+            state.back_to_list();
             refresh_gists(state);
         }
         Err(error) => state.set_status(format!("upload failed: {error}")),
@@ -1292,10 +1298,7 @@ fn render_diff(frame: &mut Frame, state: &AppState, confirming: bool) {
             _ => format!("Overwrite {}? (y/n)", state.download_target.display()),
         }
     } else {
-        format!(
-            "Up/Down/Left/Right scroll  d download -> {}  Esc back  q quit",
-            state.download_target.display()
-        )
+        "↑↓←→ scroll  ·  d download  ·  u upload  ·  Esc back  ·  q quit".to_string()
     };
     frame.render_widget(
         Paragraph::new(footer).block(Block::default().title("Commands").borders(Borders::ALL)),
@@ -2129,6 +2132,25 @@ mod tests {
     fn u_without_selection_is_noop() {
         let mut state = initial_state();
         assert_eq!(state.handle_key(KeyCode::Char('u')), KeyOutcome::None);
+    }
+
+    #[test]
+    fn u_in_diff_screen_returns_upload_intent() {
+        let mut state = initial_state();
+        state.locals = vec![LocalCandidate {
+            path: PathBuf::from("/tmp/config"),
+            pinned: false,
+        }];
+        state.gists = vec![GistFile {
+            gist_id: "a".into(),
+            description: "x".into(),
+            filename: "settings.json".into(),
+            public: false,
+            updated_at: "x".into(),
+        }];
+        state.screen = Screen::Diff;
+        // The gist has no "config" file -> case B -> add directly.
+        assert_eq!(state.handle_key(KeyCode::Char('u')), KeyOutcome::UploadAdd);
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,7 +1,226 @@
-pub fn run() -> anyhow::Result<()> {
+use crate::actions::PendingAction;
+use crate::domain::{GistFile, LocalCandidate, PinnedMapping};
+use crate::ranking::{rank_gist_files, RankedGistFile};
+use anyhow::Result;
+use crossterm::{
+    event::{self, Event, KeyCode},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use ratatui::{
+    backend::CrosstermBackend,
+    layout::{Constraint, Direction, Layout},
+    widgets::{Block, Borders, List, ListItem, Paragraph},
+    Terminal,
+};
+use std::io;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FocusPane {
+    Local,
+    Gist,
+}
+
+#[derive(Debug, Clone)]
+pub struct AppState {
+    pub locals: Vec<LocalCandidate>,
+    pub gists: Vec<GistFile>,
+    pub pinned: Vec<PinnedMapping>,
+    pub focus: FocusPane,
+    pub local_index: usize,
+    pub gist_index: usize,
+    pub diff_previewed: bool,
+    pub pending_action: Option<PendingAction>,
+}
+
+impl AppState {
+    pub fn ranked_gists(&self) -> Vec<RankedGistFile> {
+        let Some(local) = self.locals.get(self.local_index) else {
+            return Vec::new();
+        };
+        rank_gist_files(&local.path, &self.gists, &self.pinned)
+    }
+
+    pub fn handle_key(&mut self, code: KeyCode) -> bool {
+        match code {
+            KeyCode::Char('q') => return true,
+            KeyCode::Tab => {
+                self.focus = match self.focus {
+                    FocusPane::Local => FocusPane::Gist,
+                    FocusPane::Gist => FocusPane::Local,
+                };
+            }
+            KeyCode::Down => match self.focus {
+                FocusPane::Local if self.local_index + 1 < self.locals.len() => {
+                    self.local_index += 1;
+                    self.gist_index = 0;
+                }
+                FocusPane::Gist if self.gist_index + 1 < self.ranked_gists().len() => {
+                    self.gist_index += 1
+                }
+                _ => {}
+            },
+            KeyCode::Up => match self.focus {
+                FocusPane::Local if self.local_index > 0 => {
+                    self.local_index -= 1;
+                    self.gist_index = 0;
+                }
+                FocusPane::Gist if self.gist_index > 0 => self.gist_index -= 1,
+                _ => {}
+            },
+            _ => {}
+        }
+        false
+    }
+}
+
+pub fn initial_state() -> AppState {
+    AppState {
+        locals: Vec::new(),
+        gists: Vec::new(),
+        pinned: Vec::new(),
+        focus: FocusPane::Local,
+        local_index: 0,
+        gist_index: 0,
+        diff_previewed: false,
+        pending_action: None,
+    }
+}
+
+pub fn run() -> Result<()> {
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+    let mut state = initial_state();
+
+    loop {
+        terminal.draw(|frame| {
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Min(5), Constraint::Length(3)])
+                .split(frame.size());
+            let columns = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
+                .split(chunks[0]);
+
+            let local_items: Vec<ListItem> = state
+                .locals
+                .iter()
+                .map(|c| ListItem::new(c.path.display().to_string()))
+                .collect();
+            frame.render_widget(
+                List::new(local_items).block(Block::default().title("Local").borders(Borders::ALL)),
+                columns[0],
+            );
+
+            let gist_items: Vec<ListItem> = state
+                .ranked_gists()
+                .into_iter()
+                .map(|g| {
+                    ListItem::new(format!(
+                        "{} / {} ({})",
+                        g.file.gist_id, g.file.filename, g.score
+                    ))
+                })
+                .collect();
+            frame.render_widget(
+                List::new(gist_items).block(Block::default().title("Gists").borders(Borders::ALL)),
+                columns[1],
+            );
+
+            frame.render_widget(
+                Paragraph::new(
+                    "Tab switch  Enter diff  u upload  d download  n create  p pin  q quit",
+                )
+                .block(Block::default().title("Commands").borders(Borders::ALL)),
+                chunks[1],
+            );
+        })?;
+
+        if let Event::Key(key) = event::read()? {
+            if state.handle_key(key.code) {
+                break;
+            }
+        }
+    }
+
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
     Ok(())
 }
 
-pub fn _module_ready() -> bool {
-    true
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn tab_switches_focus() {
+        let mut state = initial_state();
+        assert_eq!(state.focus, FocusPane::Local);
+        state.handle_key(KeyCode::Tab);
+        assert_eq!(state.focus, FocusPane::Gist);
+    }
+
+    #[test]
+    fn empty_state_has_no_ranked_gists() {
+        let state = initial_state();
+        assert!(state.ranked_gists().is_empty());
+    }
+
+    #[test]
+    fn local_selection_changes_ranked_gists() {
+        let mut state = initial_state();
+        state.locals = vec![
+            LocalCandidate {
+                path: PathBuf::from("/tmp/settings.json"),
+                pinned: false,
+            },
+            LocalCandidate {
+                path: PathBuf::from("/tmp/statusline.sh"),
+                pinned: false,
+            },
+        ];
+        state.gists = vec![
+            GistFile {
+                gist_id: "a".into(),
+                description: "settings".into(),
+                filename: "settings.json".into(),
+                public: false,
+                updated_at: "x".into(),
+            },
+            GistFile {
+                gist_id: "b".into(),
+                description: "status".into(),
+                filename: "statusline.sh".into(),
+                public: false,
+                updated_at: "x".into(),
+            },
+        ];
+
+        assert_eq!(state.ranked_gists()[0].file.filename, "settings.json");
+        state.handle_key(KeyCode::Down);
+        assert_eq!(state.ranked_gists()[0].file.filename, "statusline.sh");
+    }
+
+    #[test]
+    fn changing_local_selection_resets_gist_index() {
+        let mut state = initial_state();
+        state.locals = vec![
+            LocalCandidate {
+                path: PathBuf::from("/tmp/a.json"),
+                pinned: false,
+            },
+            LocalCandidate {
+                path: PathBuf::from("/tmp/b.json"),
+                pinned: false,
+            },
+        ];
+        state.gist_index = 2;
+        state.handle_key(KeyCode::Down); // move local selection down
+        assert_eq!(state.gist_index, 0);
+    }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1190,7 +1190,8 @@ fn render_list(frame: &mut Frame, state: &AppState) {
             None => commands_hint(),
         }
     };
-    let footer_lines = wrap_line_count(&footer_body, area.width.saturating_sub(2)).max(1);
+    // Width inside the footer block: minus 2 borders and 2 horizontal padding columns.
+    let footer_lines = wrap_line_count(&footer_body, area.width.saturating_sub(4)).max(1);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(5), Constraint::Length(footer_lines + 2)])
@@ -1264,9 +1265,12 @@ fn render_list(frame: &mut Frame, state: &AppState) {
     );
 
     frame.render_widget(
-        Paragraph::new(footer_body)
-            .wrap(Wrap { trim: true })
-            .block(Block::default().title("Commands").borders(Borders::ALL)),
+        Paragraph::new(footer_body).wrap(Wrap { trim: true }).block(
+            Block::default()
+                .title("Commands")
+                .borders(Borders::ALL)
+                .padding(Padding::horizontal(1)),
+        ),
         chunks[1],
     );
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -148,6 +148,8 @@ pub struct AppState {
     pub gist_view: GistView,
     pub gist_type_filter: GistTypeFilter,
     pub gist_sort: GistSort,
+    pub filtering: bool,
+    pub filter_query: String,
     pub diff_previewed: bool,
     pub diff_text: String,
     pub diff_scroll: u16,
@@ -161,10 +163,16 @@ pub struct AppState {
 
 impl AppState {
     pub fn ranked_gists(&self) -> Vec<RankedGistFile> {
+        let query = self.filter_query.to_lowercase();
         let gists: Vec<GistFile> = self
             .gists
             .iter()
             .filter(|g| self.gist_type_filter.matches(g.public))
+            .filter(|g| {
+                query.is_empty()
+                    || g.filename.to_lowercase().contains(&query)
+                    || g.description.to_lowercase().contains(&query)
+            })
             .cloned()
             .collect();
         // No local selected (e.g. an empty directory): list every gist unranked so the
@@ -302,10 +310,35 @@ impl AppState {
 
     pub fn handle_key(&mut self, code: KeyCode) -> KeyOutcome {
         match self.screen {
+            Screen::List if self.filtering => self.handle_key_filter(code),
             Screen::List => self.handle_key_list(code),
             Screen::Diff => self.handle_key_diff(code),
             Screen::Confirm => self.handle_key_confirm(code),
         }
+    }
+
+    fn handle_key_filter(&mut self, code: KeyCode) -> KeyOutcome {
+        match code {
+            KeyCode::Esc => {
+                self.filter_query.clear();
+                self.filtering = false;
+                self.gist_index = 0;
+                self.gist_hscroll = 0;
+            }
+            KeyCode::Enter => self.filtering = false,
+            KeyCode::Backspace => {
+                self.filter_query.pop();
+                self.gist_index = 0;
+                self.gist_hscroll = 0;
+            }
+            KeyCode::Char(c) => {
+                self.filter_query.push(c);
+                self.gist_index = 0;
+                self.gist_hscroll = 0;
+            }
+            _ => {}
+        }
+        KeyOutcome::None
     }
 
     fn handle_key_list(&mut self, code: KeyCode) -> KeyOutcome {
@@ -366,6 +399,7 @@ impl AppState {
                 self.gist_index = 0;
                 self.gist_hscroll = 0;
             }
+            KeyCode::Char('/') => self.filtering = true,
             KeyCode::Char('d')
                 if self.focus == FocusPane::Gist && self.gist_index < self.ranked_gists().len() =>
             {
@@ -513,6 +547,8 @@ pub fn initial_state() -> AppState {
         gist_view: GistView::Description,
         gist_type_filter: GistTypeFilter::All,
         gist_sort: GistSort::Match,
+        filtering: false,
+        filter_query: String::new(),
         diff_previewed: false,
         diff_text: String::new(),
         diff_scroll: 0,
@@ -915,11 +951,14 @@ fn render_list(frame: &mut Frame, state: &AppState) {
         .collect();
     let gist_focused = state.focus == FocusPane::Gist;
     let gist_selected = (!ranked.is_empty()).then_some(state.gist_index);
-    let gist_title = format!(
+    let mut gist_title = format!(
         "Gists · {} · {}",
         state.gist_type_filter.label(),
         state.gist_sort.label()
     );
+    if !state.filter_query.is_empty() {
+        gist_title.push_str(&format!(" · /{}", state.filter_query));
+    }
     render_pane(
         frame,
         columns[1],
@@ -929,11 +968,18 @@ fn render_list(frame: &mut Frame, state: &AppState) {
         gist_selected,
     );
 
-    let footer = match &state.status {
-        Some(message) => message.clone(),
-        None => {
-            "Tab  ↑↓ move  ←→ scroll  Enter diff  d download  u upload  n create  p pin  t view  v type  s sort  q quit"
-                .to_string()
+    let footer = if state.filtering {
+        format!(
+            "filter: {}_   (Enter apply · Esc clear)",
+            state.filter_query
+        )
+    } else {
+        match &state.status {
+            Some(message) => message.clone(),
+            None => {
+                "Tab  ↑↓ move  ←→ scroll  Enter diff  d download  u upload  n create  p pin  t view  v type  s sort  / filter  q quit"
+                    .to_string()
+            }
         }
     };
     frame.render_widget(
@@ -1172,6 +1218,79 @@ mod tests {
         let only_secret = state.ranked_gists();
         assert_eq!(only_secret.len(), 1);
         assert_eq!(only_secret[0].file.gist_id, "sec");
+    }
+
+    fn state_with_two_gists() -> AppState {
+        let mut state = initial_state();
+        state.gists = vec![
+            GistFile {
+                gist_id: "a".into(),
+                description: "My Ghostty config".into(),
+                filename: "config.ghostty".into(),
+                public: true,
+                updated_at: "x".into(),
+            },
+            GistFile {
+                gist_id: "b".into(),
+                description: "SSH config".into(),
+                filename: "ssh_config".into(),
+                public: false,
+                updated_at: "x".into(),
+            },
+        ];
+        state.focus = FocusPane::Gist;
+        state
+    }
+
+    #[test]
+    fn slash_enters_filter_mode_and_typing_filters() {
+        let mut state = state_with_two_gists();
+        assert!(!state.filtering);
+        state.handle_key(KeyCode::Char('/'));
+        assert!(state.filtering);
+        // Type "ghostty" -> matches only the first gist (by filename + description).
+        for c in "ghostty".chars() {
+            state.handle_key(KeyCode::Char(c));
+        }
+        let ranked = state.ranked_gists();
+        assert_eq!(ranked.len(), 1);
+        assert_eq!(ranked[0].file.gist_id, "a");
+    }
+
+    #[test]
+    fn filter_matches_description_case_insensitively() {
+        let mut state = state_with_two_gists();
+        state.filter_query = "SSH".into();
+        let ranked = state.ranked_gists();
+        assert_eq!(ranked.len(), 1);
+        assert_eq!(ranked[0].file.gist_id, "b");
+    }
+
+    #[test]
+    fn filter_enter_keeps_query_esc_clears() {
+        let mut state = state_with_two_gists();
+        state.handle_key(KeyCode::Char('/'));
+        state.handle_key(KeyCode::Char('s'));
+        state.handle_key(KeyCode::Char('s'));
+        state.handle_key(KeyCode::Char('h'));
+        state.handle_key(KeyCode::Enter);
+        assert!(!state.filtering);
+        assert_eq!(state.filter_query, "ssh");
+        // Re-enter and Esc clears.
+        state.handle_key(KeyCode::Char('/'));
+        state.handle_key(KeyCode::Esc);
+        assert!(!state.filtering);
+        assert!(state.filter_query.is_empty());
+    }
+
+    #[test]
+    fn filter_backspace_deletes_last_char() {
+        let mut state = state_with_two_gists();
+        state.handle_key(KeyCode::Char('/'));
+        state.handle_key(KeyCode::Char('x'));
+        state.handle_key(KeyCode::Char('y'));
+        state.handle_key(KeyCode::Backspace);
+        assert_eq!(state.filter_query, "x");
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -931,8 +931,10 @@ fn render_list(frame: &mut Frame, state: &AppState) {
 
     let footer = match &state.status {
         Some(message) => message.clone(),
-        None => "Tab  ↑↓ move  ←→ scroll  Enter diff  d download  t view  v type  s sort  q quit"
-            .to_string(),
+        None => {
+            "Tab  ↑↓ move  ←→ scroll  Enter diff  d download  u upload  n create  p pin  t view  v type  s sort  q quit"
+                .to_string()
+        }
     };
     frame.render_widget(
         Paragraph::new(footer).block(Block::default().title("Commands").borders(Borders::ALL)),

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -42,6 +42,43 @@ pub enum GistTypeFilter {
     Secret,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GistSort {
+    Match,
+    Name,
+    Recent,
+}
+
+impl GistSort {
+    fn next(self) -> Self {
+        match self {
+            GistSort::Match => GistSort::Name,
+            GistSort::Name => GistSort::Recent,
+            GistSort::Recent => GistSort::Match,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            GistSort::Match => "match",
+            GistSort::Name => "name",
+            GistSort::Recent => "recent",
+        }
+    }
+
+    /// Re-orders ranked gists. `Match` keeps the incoming order (ranking score, or the
+    /// gh list order when no local is selected); the others override it.
+    fn apply(self, gists: &mut [RankedGistFile]) {
+        match self {
+            GistSort::Match => {}
+            GistSort::Name => gists.sort_by(|a, b| a.file.filename.cmp(&b.file.filename)),
+            GistSort::Recent => {
+                gists.sort_by(|a, b| b.file.updated_at.cmp(&a.file.updated_at));
+            }
+        }
+    }
+}
+
 impl GistTypeFilter {
     fn matches(self, public: bool) -> bool {
         match self {
@@ -90,6 +127,7 @@ pub struct AppState {
     pub screen: Screen,
     pub gist_view: GistView,
     pub gist_type_filter: GistTypeFilter,
+    pub gist_sort: GistSort,
     pub diff_previewed: bool,
     pub diff_text: String,
     pub diff_scroll: u16,
@@ -109,19 +147,21 @@ impl AppState {
             .filter(|g| self.gist_type_filter.matches(g.public))
             .cloned()
             .collect();
-        let Some(local) = self.locals.get(self.local_index) else {
-            // No local selected (e.g. an empty directory): list every gist
-            // unranked so the user can still preview and download into the cwd.
-            return gists
+        // No local selected (e.g. an empty directory): list every gist unranked so the
+        // user can still preview and download into the cwd.
+        let mut ranked = match self.locals.get(self.local_index) {
+            Some(local) => rank_gist_files(&local.path, &gists, &self.pinned),
+            None => gists
                 .into_iter()
                 .map(|file| RankedGistFile {
                     file,
                     score: 0,
                     reasons: Vec::new(),
                 })
-                .collect();
+                .collect(),
         };
-        rank_gist_files(&local.path, &gists, &self.pinned)
+        self.gist_sort.apply(&mut ranked);
+        ranked
     }
 
     pub fn selected_local(&self) -> Option<&LocalCandidate> {
@@ -299,6 +339,12 @@ impl AppState {
                 self.gist_index = 0;
                 self.gist_hscroll = 0;
             }
+            KeyCode::Char('s') => {
+                // Cycle the gist sort: match -> name -> recent -> match.
+                self.gist_sort = self.gist_sort.next();
+                self.gist_index = 0;
+                self.gist_hscroll = 0;
+            }
             KeyCode::Char('d')
                 if self.focus == FocusPane::Gist && self.gist_index < self.ranked_gists().len() =>
             {
@@ -358,6 +404,7 @@ pub fn initial_state() -> AppState {
         screen: Screen::List,
         gist_view: GistView::Description,
         gist_type_filter: GistTypeFilter::All,
+        gist_sort: GistSort::Match,
         diff_previewed: false,
         diff_text: String::new(),
         diff_scroll: 0,
@@ -602,7 +649,11 @@ fn render_list(frame: &mut Frame, state: &AppState) {
         .collect();
     let gist_focused = state.focus == FocusPane::Gist;
     let gist_selected = (!ranked.is_empty()).then_some(state.gist_index);
-    let gist_title = format!("Gists · {}", state.gist_type_filter.label());
+    let gist_title = format!(
+        "Gists · {} · {}",
+        state.gist_type_filter.label(),
+        state.gist_sort.label()
+    );
     render_pane(
         frame,
         columns[1],
@@ -614,9 +665,8 @@ fn render_list(frame: &mut Frame, state: &AppState) {
 
     let footer = match &state.status {
         Some(message) => message.clone(),
-        None => {
-            "Tab  ↑↓ move  ←→ scroll  Enter diff  d download  t view  v type  q quit".to_string()
-        }
+        None => "Tab  ↑↓ move  ←→ scroll  Enter diff  d download  t view  v type  s sort  q quit"
+            .to_string(),
     };
     frame.render_widget(
         Paragraph::new(footer).block(Block::default().title("Commands").borders(Borders::ALL)),
@@ -769,6 +819,48 @@ mod tests {
         assert_eq!(state.gist_type_filter, GistTypeFilter::Secret);
         state.handle_key(KeyCode::Char('v'));
         assert_eq!(state.gist_type_filter, GistTypeFilter::All);
+    }
+
+    #[test]
+    fn s_cycles_gist_sort() {
+        let mut state = initial_state();
+        assert_eq!(state.gist_sort, GistSort::Match);
+        state.handle_key(KeyCode::Char('s'));
+        assert_eq!(state.gist_sort, GistSort::Name);
+        state.handle_key(KeyCode::Char('s'));
+        assert_eq!(state.gist_sort, GistSort::Recent);
+        state.handle_key(KeyCode::Char('s'));
+        assert_eq!(state.gist_sort, GistSort::Match);
+    }
+
+    #[test]
+    fn sort_by_name_and_recent_reorders_gists() {
+        let mut state = initial_state();
+        state.gists = vec![
+            GistFile {
+                gist_id: "z".into(),
+                description: "".into(),
+                filename: "zeta.json".into(),
+                public: true,
+                updated_at: "2026-01-01T00:00:00Z".into(),
+            },
+            GistFile {
+                gist_id: "a".into(),
+                description: "".into(),
+                filename: "alpha.json".into(),
+                public: true,
+                updated_at: "2026-09-09T00:00:00Z".into(),
+            },
+        ];
+        // No local selected -> Match keeps gh list order (zeta, alpha).
+        assert_eq!(state.ranked_gists()[0].file.filename, "zeta.json");
+
+        state.gist_sort = GistSort::Name;
+        assert_eq!(state.ranked_gists()[0].file.filename, "alpha.json");
+
+        state.gist_sort = GistSort::Recent;
+        assert_eq!(state.ranked_gists()[0].file.filename, "alpha.json");
+        assert_eq!(state.ranked_gists()[1].file.filename, "zeta.json");
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -127,6 +127,9 @@ pub enum KeyOutcome {
     DownloadGist,
     Pin,
     Unpin,
+    UploadAdd,
+    UploadPreview,
+    Upload,
 }
 
 #[derive(Debug, Clone)]
@@ -390,6 +393,33 @@ impl AppState {
                     KeyOutcome::Pin
                 };
             }
+            KeyCode::Char('u') => {
+                let (Some(local), Some(gist)) =
+                    (self.selected_local().cloned(), self.selected_gist())
+                else {
+                    self.status = Some("select a local file and a gist to upload".into());
+                    return KeyOutcome::None;
+                };
+                let Some(local_filename) = local
+                    .path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .map(String::from)
+                else {
+                    self.status = Some("local file has no name".into());
+                    return KeyOutcome::None;
+                };
+                let gist_id = gist.file.gist_id.clone();
+                let has_same_name = self
+                    .gists
+                    .iter()
+                    .any(|g| g.gist_id == gist_id && g.filename == local_filename);
+                return if has_same_name {
+                    KeyOutcome::UploadPreview
+                } else {
+                    KeyOutcome::UploadAdd
+                };
+            }
             _ => {}
         }
         KeyOutcome::None
@@ -426,6 +456,14 @@ impl AppState {
                 KeyCode::Char('n') | KeyCode::Esc => {
                     self.pending_action = None;
                     self.screen = Screen::Diff;
+                }
+                _ => {}
+            },
+            Some(PendingAction::Upload { .. }) => match code {
+                KeyCode::Char('y') => return KeyOutcome::Upload,
+                KeyCode::Char('n') | KeyCode::Esc => {
+                    self.pending_action = None;
+                    self.screen = Screen::List;
                 }
                 _ => {}
             },
@@ -520,6 +558,9 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
                 KeyOutcome::DownloadGist => download_selected(&mut state),
                 KeyOutcome::Pin => pin_selected(&mut state),
                 KeyOutcome::Unpin => unpin_selected(&mut state),
+                KeyOutcome::UploadAdd => upload_add(&mut state),
+                KeyOutcome::UploadPreview => upload_preview(&mut state),
+                KeyOutcome::Upload => upload_replace(&mut state),
                 KeyOutcome::None => {}
             }
         }
@@ -647,6 +688,96 @@ fn unpin_selected(state: &mut AppState) {
             state.set_status(format!("Unpinned {}", local.path.display()));
         }
         Err(error) => state.set_status(format!("unpin failed: {error}")),
+    }
+}
+
+fn upload_local_filename(local: &std::path::Path) -> Option<String> {
+    local.file_name().and_then(|n| n.to_str()).map(String::from)
+}
+
+fn upload_add(state: &mut AppState) {
+    let (Some(local), Some(gist)) = (state.selected_local().cloned(), state.selected_gist()) else {
+        return;
+    };
+    let plan = crate::actions::upload_add_command(&local.path, &gist.file.gist_id);
+    match crate::actions::execute_command(&plan) {
+        Ok(_) => {
+            state.set_status(format!(
+                "Uploaded {} to gist {}",
+                local.path.display(),
+                gist.file.gist_id
+            ));
+            refresh_gists(state);
+        }
+        Err(error) => state.set_status(format!("upload failed: {error}")),
+    }
+}
+
+fn upload_preview(state: &mut AppState) {
+    let (Some(local), Some(gist)) = (state.selected_local().cloned(), state.selected_gist()) else {
+        return;
+    };
+    let Some(filename) = upload_local_filename(&local.path) else {
+        state.set_status("local file has no name");
+        return;
+    };
+    match crate::gh::fetch_gist_file_content(&gist.file.gist_id, &filename) {
+        Ok(remote) => {
+            let local_content = std::fs::read_to_string(&local.path).unwrap_or_default();
+            let diff = crate::diff::unified_diff("gist", &remote, "local", &local_content);
+            state.diff_text = diff;
+            state.diff_scroll = 0;
+            state.diff_hscroll = 0;
+            state.pending_action = Some(PendingAction::Upload {
+                gist_id: gist.file.gist_id.clone(),
+                filename,
+                local_path: local.path.clone(),
+            });
+            state.status = None;
+            state.screen = Screen::Confirm;
+        }
+        Err(error) => state.set_status(format!("fetch failed: {error}")),
+    }
+}
+
+fn upload_replace(state: &mut AppState) {
+    let Some(PendingAction::Upload {
+        gist_id,
+        filename,
+        local_path,
+    }) = state.pending_action.clone()
+    else {
+        return;
+    };
+    let target = GistFile {
+        gist_id: gist_id.clone(),
+        description: String::new(),
+        filename: filename.clone(),
+        public: false,
+        updated_at: String::new(),
+    };
+    let plan = crate::actions::upload_command(&local_path, &target);
+    match crate::actions::execute_command(&plan) {
+        Ok(_) => {
+            state.set_status(format!("Uploaded {} to gist {}", filename, gist_id));
+            state.back_to_list();
+            refresh_gists(state);
+        }
+        Err(error) => {
+            state.set_status(format!("upload failed: {error}"));
+            state.screen = Screen::Confirm;
+        }
+    }
+}
+
+fn refresh_gists(state: &mut AppState) {
+    if let Ok(gists) =
+        crate::gh::fetch_gist_list_json().and_then(|raw| crate::gh::parse_gist_list_json(&raw))
+    {
+        state.gists = gists;
+        if state.gist_index >= state.ranked_gists().len() {
+            state.gist_index = 0;
+        }
     }
 }
 
@@ -1484,5 +1615,62 @@ mod tests {
     fn p_without_local_or_gist_is_noop() {
         let mut state = initial_state();
         assert_eq!(state.handle_key(KeyCode::Char('p')), KeyOutcome::None);
+    }
+
+    #[test]
+    fn u_adds_when_gist_lacks_filename() {
+        let mut state = initial_state();
+        state.locals = vec![LocalCandidate {
+            path: PathBuf::from("/tmp/config"),
+            pinned: false,
+        }];
+        state.gists = vec![GistFile {
+            gist_id: "a".into(),
+            description: "x".into(),
+            filename: "settings.json".into(),
+            public: false,
+            updated_at: "x".into(),
+        }];
+        state.focus = FocusPane::Gist;
+        assert_eq!(state.handle_key(KeyCode::Char('u')), KeyOutcome::UploadAdd);
+    }
+
+    #[test]
+    fn u_previews_when_gist_has_same_filename() {
+        let mut state = initial_state();
+        state.locals = vec![LocalCandidate {
+            path: PathBuf::from("/tmp/settings.json"),
+            pinned: false,
+        }];
+        state.gists = vec![GistFile {
+            gist_id: "a".into(),
+            description: "x".into(),
+            filename: "settings.json".into(),
+            public: false,
+            updated_at: "x".into(),
+        }];
+        state.focus = FocusPane::Gist;
+        assert_eq!(
+            state.handle_key(KeyCode::Char('u')),
+            KeyOutcome::UploadPreview
+        );
+    }
+
+    #[test]
+    fn u_without_selection_is_noop() {
+        let mut state = initial_state();
+        assert_eq!(state.handle_key(KeyCode::Char('u')), KeyOutcome::None);
+    }
+
+    #[test]
+    fn confirm_upload_y_returns_upload() {
+        let mut state = initial_state();
+        state.pending_action = Some(PendingAction::Upload {
+            gist_id: "a".into(),
+            filename: "settings.json".into(),
+            local_path: PathBuf::from("/tmp/settings.json"),
+        });
+        state.screen = Screen::Confirm;
+        assert_eq!(state.handle_key(KeyCode::Char('y')), KeyOutcome::Upload);
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -138,6 +138,8 @@ pub enum KeyOutcome {
     Upload,
     Create(bool),
     PreviewContent,
+    OpenBrowser,
+    EditLocal,
 }
 
 #[derive(Debug, Clone)]
@@ -470,6 +472,18 @@ impl AppState {
             }
             KeyCode::Char('/') => self.filtering = true,
             KeyCode::Char('?') => self.screen = Screen::Help,
+            KeyCode::Char('o') => {
+                if self.selected_gist().is_some() {
+                    return KeyOutcome::OpenBrowser;
+                }
+                self.status = Some("select a gist to open in the browser".into());
+            }
+            KeyCode::Char('e') => {
+                if self.selected_local().is_some() {
+                    return KeyOutcome::EditLocal;
+                }
+                self.status = Some("select a local file to edit".into());
+            }
             KeyCode::Char(' ') if self.selected_gist().is_some() => {
                 return KeyOutcome::PreviewContent;
             }
@@ -730,6 +744,8 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
                     create_gist(&mut state, public);
                 }
                 KeyOutcome::PreviewContent => fetch_then(terminal, &mut state, preview_content)?,
+                KeyOutcome::OpenBrowser => open_browser(&mut state),
+                KeyOutcome::EditLocal => edit_local(terminal, &mut state)?,
                 KeyOutcome::None => {}
             }
         }
@@ -850,6 +866,54 @@ fn preview_diff(state: &mut AppState) {
         }
         Err(error) => state.set_status(format!("fetch failed: {error}")),
     }
+}
+
+fn open_browser(state: &mut AppState) {
+    let Some(gist) = state.selected_gist() else {
+        return;
+    };
+    let plan = crate::actions::open_browser_command(&gist.file.gist_id);
+    match crate::actions::execute_command(&plan) {
+        Ok(_) => state.set_status(format!("Opened gist {} in the browser", gist.file.gist_id)),
+        Err(error) => state.set_status(format!("open failed: {error}")),
+    }
+}
+
+/// Opens the selected local file in `$VISUAL`/`$EDITOR` (default `vi`). A terminal editor
+/// needs the full terminal, so the TUI leaves raw mode / the alternate screen for the
+/// duration and restores afterwards. `$EDITOR` may include flags (e.g. `code --wait`).
+fn edit_local(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    state: &mut AppState,
+) -> Result<()> {
+    let Some(local) = state.selected_local().cloned() else {
+        return Ok(());
+    };
+    let editor = std::env::var("VISUAL")
+        .or_else(|_| std::env::var("EDITOR"))
+        .unwrap_or_else(|_| "vi".to_string());
+    let mut parts = editor.split_whitespace();
+    let Some(program) = parts.next() else {
+        state.set_status("no editor configured (set $EDITOR)");
+        return Ok(());
+    };
+    let args: Vec<&str> = parts.collect();
+
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    let result = std::process::Command::new(program)
+        .args(&args)
+        .arg(&local.path)
+        .status();
+    enable_raw_mode()?;
+    execute!(terminal.backend_mut(), EnterAlternateScreen)?;
+    terminal.clear()?;
+
+    match result {
+        Ok(_) => state.set_status(format!("Edited {}", local.path.display())),
+        Err(error) => state.set_status(format!("editor failed: {error}")),
+    }
+    Ok(())
 }
 
 fn preview_content(state: &mut AppState) {
@@ -1129,6 +1193,8 @@ Actions (on the selected local file + gist)
   u          upload the local file into the gist
   n          create a new gist from the local file
   p          pin / unpin the local <-> gist pair
+  o          open the gist in your web browser
+  e          edit the local file in $EDITOR
 
 General
   Esc / q    close an overlay; from the list, quit the app
@@ -1226,6 +1292,8 @@ fn commands_hint() -> String {
         "u upload",
         "n create",
         "p pin",
+        "o browser",
+        "e edit",
         "t view",
         "v type",
         "s sort",
@@ -2421,6 +2489,37 @@ mod tests {
     fn u_without_selection_is_noop() {
         let mut state = initial_state();
         assert_eq!(state.handle_key(KeyCode::Char('u')), KeyOutcome::None);
+    }
+
+    #[test]
+    fn o_opens_browser_with_gist_selected() {
+        let mut state = state_with_two_gists();
+        assert_eq!(
+            state.handle_key(KeyCode::Char('o')),
+            KeyOutcome::OpenBrowser
+        );
+    }
+
+    #[test]
+    fn o_without_gist_is_noop() {
+        let mut state = initial_state();
+        assert_eq!(state.handle_key(KeyCode::Char('o')), KeyOutcome::None);
+    }
+
+    #[test]
+    fn e_edits_local_with_file_selected() {
+        let mut state = initial_state();
+        state.locals = vec![LocalCandidate {
+            path: PathBuf::from("/tmp/config"),
+            pinned: false,
+        }];
+        assert_eq!(state.handle_key(KeyCode::Char('e')), KeyOutcome::EditLocal);
+    }
+
+    #[test]
+    fn e_without_local_is_noop() {
+        let mut state = initial_state();
+        assert_eq!(state.handle_key(KeyCode::Char('e')), KeyOutcome::None);
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -36,6 +36,39 @@ pub enum GistView {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GistTypeFilter {
+    All,
+    Public,
+    Secret,
+}
+
+impl GistTypeFilter {
+    fn matches(self, public: bool) -> bool {
+        match self {
+            GistTypeFilter::All => true,
+            GistTypeFilter::Public => public,
+            GistTypeFilter::Secret => !public,
+        }
+    }
+
+    fn next(self) -> Self {
+        match self {
+            GistTypeFilter::All => GistTypeFilter::Public,
+            GistTypeFilter::Public => GistTypeFilter::Secret,
+            GistTypeFilter::Secret => GistTypeFilter::All,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            GistTypeFilter::All => "all",
+            GistTypeFilter::Public => "public",
+            GistTypeFilter::Secret => "secret",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KeyOutcome {
     None,
     Quit,
@@ -56,6 +89,7 @@ pub struct AppState {
     pub gist_hscroll: u16,
     pub screen: Screen,
     pub gist_view: GistView,
+    pub gist_type_filter: GistTypeFilter,
     pub diff_previewed: bool,
     pub diff_text: String,
     pub diff_scroll: u16,
@@ -69,13 +103,17 @@ pub struct AppState {
 
 impl AppState {
     pub fn ranked_gists(&self) -> Vec<RankedGistFile> {
+        let gists: Vec<GistFile> = self
+            .gists
+            .iter()
+            .filter(|g| self.gist_type_filter.matches(g.public))
+            .cloned()
+            .collect();
         let Some(local) = self.locals.get(self.local_index) else {
             // No local selected (e.g. an empty directory): list every gist
             // unranked so the user can still preview and download into the cwd.
-            return self
-                .gists
-                .iter()
-                .cloned()
+            return gists
+                .into_iter()
                 .map(|file| RankedGistFile {
                     file,
                     score: 0,
@@ -83,7 +121,7 @@ impl AppState {
                 })
                 .collect();
         };
-        rank_gist_files(&local.path, &self.gists, &self.pinned)
+        rank_gist_files(&local.path, &gists, &self.pinned)
     }
 
     pub fn selected_local(&self) -> Option<&LocalCandidate> {
@@ -255,6 +293,12 @@ impl AppState {
                     GistView::Id => GistView::Description,
                 };
             }
+            KeyCode::Char('v') => {
+                // Cycle the gist visibility filter: all -> public -> secret -> all.
+                self.gist_type_filter = self.gist_type_filter.next();
+                self.gist_index = 0;
+                self.gist_hscroll = 0;
+            }
             KeyCode::Char('d')
                 if self.focus == FocusPane::Gist && self.gist_index < self.ranked_gists().len() =>
             {
@@ -313,6 +357,7 @@ pub fn initial_state() -> AppState {
         gist_hscroll: 0,
         screen: Screen::List,
         gist_view: GistView::Description,
+        gist_type_filter: GistTypeFilter::All,
         diff_previewed: false,
         diff_text: String::new(),
         diff_scroll: 0,
@@ -557,10 +602,11 @@ fn render_list(frame: &mut Frame, state: &AppState) {
         .collect();
     let gist_focused = state.focus == FocusPane::Gist;
     let gist_selected = (!ranked.is_empty()).then_some(state.gist_index);
+    let gist_title = format!("Gists · {}", state.gist_type_filter.label());
     render_pane(
         frame,
         columns[1],
-        "Gists",
+        &gist_title,
         gist_items,
         gist_focused,
         gist_selected,
@@ -568,8 +614,9 @@ fn render_list(frame: &mut Frame, state: &AppState) {
 
     let footer = match &state.status {
         Some(message) => message.clone(),
-        None => "Tab  Up/Down move  Left/Right scroll  Enter diff  d download  t view  q quit"
-            .to_string(),
+        None => {
+            "Tab  ↑↓ move  ←→ scroll  Enter diff  d download  t view  v type  q quit".to_string()
+        }
     };
     frame.render_widget(
         Paragraph::new(footer).block(Block::default().title("Commands").borders(Borders::ALL)),
@@ -710,6 +757,50 @@ mod tests {
             "⭐⭐⭐ config — cfg"
         );
         assert_eq!(gist_row_label(&g, GistView::Id), "⭐⭐⭐ abc / config");
+    }
+
+    #[test]
+    fn v_cycles_gist_type_filter() {
+        let mut state = initial_state();
+        assert_eq!(state.gist_type_filter, GistTypeFilter::All);
+        state.handle_key(KeyCode::Char('v'));
+        assert_eq!(state.gist_type_filter, GistTypeFilter::Public);
+        state.handle_key(KeyCode::Char('v'));
+        assert_eq!(state.gist_type_filter, GistTypeFilter::Secret);
+        state.handle_key(KeyCode::Char('v'));
+        assert_eq!(state.gist_type_filter, GistTypeFilter::All);
+    }
+
+    #[test]
+    fn gist_type_filter_limits_ranked_gists() {
+        let mut state = initial_state();
+        state.gists = vec![
+            GistFile {
+                gist_id: "pub".into(),
+                description: "p".into(),
+                filename: "a.json".into(),
+                public: true,
+                updated_at: "x".into(),
+            },
+            GistFile {
+                gist_id: "sec".into(),
+                description: "s".into(),
+                filename: "b.json".into(),
+                public: false,
+                updated_at: "x".into(),
+            },
+        ];
+        assert_eq!(state.ranked_gists().len(), 2);
+
+        state.gist_type_filter = GistTypeFilter::Public;
+        let only_public = state.ranked_gists();
+        assert_eq!(only_public.len(), 1);
+        assert_eq!(only_public[0].file.gist_id, "pub");
+
+        state.gist_type_filter = GistTypeFilter::Secret;
+        let only_secret = state.ranked_gists();
+        assert_eq!(only_secret.len(), 1);
+        assert_eq!(only_secret[0].file.gist_id, "sec");
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,4 +1,3 @@
-use crate::actions::PendingAction;
 use crate::domain::{GistFile, LocalCandidate, PinnedMapping};
 use crate::ranking::{rank_gist_files, RankedGistFile};
 use anyhow::Result;
@@ -14,11 +13,27 @@ use ratatui::{
     Terminal,
 };
 use std::io;
+use std::path::PathBuf;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FocusPane {
     Local,
     Gist,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Screen {
+    List,
+    Diff,
+    ConfirmOverwrite,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyOutcome {
+    None,
+    Quit,
+    PreviewDiff,
+    Download,
 }
 
 #[derive(Debug, Clone)]
@@ -29,8 +44,13 @@ pub struct AppState {
     pub focus: FocusPane,
     pub local_index: usize,
     pub gist_index: usize,
+    pub screen: Screen,
     pub diff_previewed: bool,
-    pub pending_action: Option<PendingAction>,
+    pub diff_text: String,
+    pub diff_scroll: u16,
+    pub preview_remote: String,
+    pub preview_local: PathBuf,
+    pub status: Option<String>,
 }
 
 impl AppState {
@@ -41,9 +61,64 @@ impl AppState {
         rank_gist_files(&local.path, &self.gists, &self.pinned)
     }
 
-    pub fn handle_key(&mut self, code: KeyCode) -> bool {
+    pub fn selected_local(&self) -> Option<&LocalCandidate> {
+        self.locals.get(self.local_index)
+    }
+
+    pub fn selected_gist(&self) -> Option<RankedGistFile> {
+        self.ranked_gists().into_iter().nth(self.gist_index)
+    }
+
+    pub fn enter_diff(&mut self, diff_text: String, remote: String, local: PathBuf) {
+        self.diff_text = diff_text;
+        self.preview_remote = remote;
+        self.preview_local = local;
+        self.diff_previewed = true;
+        self.diff_scroll = 0;
+        self.status = None;
+        self.screen = Screen::Diff;
+    }
+
+    pub fn back_to_list(&mut self) {
+        self.screen = Screen::List;
+        self.diff_text.clear();
+        self.preview_remote.clear();
+        self.preview_local = PathBuf::new();
+        self.diff_scroll = 0;
+        self.diff_previewed = false;
+    }
+
+    pub fn set_status(&mut self, message: impl Into<String>) {
+        self.status = Some(message.into());
+    }
+
+    pub fn scroll_diff_down(&mut self) {
+        let max = self
+            .diff_text
+            .lines()
+            .count()
+            .saturating_sub(1)
+            .min(u16::MAX as usize) as u16;
+        if self.diff_scroll < max {
+            self.diff_scroll += 1;
+        }
+    }
+
+    pub fn scroll_diff_up(&mut self) {
+        self.diff_scroll = self.diff_scroll.saturating_sub(1);
+    }
+
+    pub fn handle_key(&mut self, code: KeyCode) -> KeyOutcome {
+        match self.screen {
+            Screen::List => self.handle_key_list(code),
+            Screen::Diff => self.handle_key_diff(code),
+            Screen::ConfirmOverwrite => self.handle_key_confirm(code),
+        }
+    }
+
+    fn handle_key_list(&mut self, code: KeyCode) -> KeyOutcome {
         match code {
-            KeyCode::Char('q') => return true,
+            KeyCode::Char('q') => return KeyOutcome::Quit,
             KeyCode::Tab => {
                 self.focus = match self.focus {
                     FocusPane::Local => FocusPane::Gist,
@@ -68,9 +143,44 @@ impl AppState {
                 FocusPane::Gist if self.gist_index > 0 => self.gist_index -= 1,
                 _ => {}
             },
+            KeyCode::Enter
+                if self.focus == FocusPane::Gist
+                    && self.selected_local().is_some()
+                    && self.gist_index < self.ranked_gists().len() =>
+            {
+                return KeyOutcome::PreviewDiff;
+            }
             _ => {}
         }
-        false
+        KeyOutcome::None
+    }
+
+    fn handle_key_diff(&mut self, code: KeyCode) -> KeyOutcome {
+        match code {
+            KeyCode::Char('q') => return KeyOutcome::Quit,
+            KeyCode::Esc => self.back_to_list(),
+            KeyCode::Down => self.scroll_diff_down(),
+            KeyCode::Up => self.scroll_diff_up(),
+            KeyCode::Char('d') => {
+                if self.preview_local.exists() {
+                    self.screen = Screen::ConfirmOverwrite;
+                } else {
+                    return KeyOutcome::Download;
+                }
+            }
+            _ => {}
+        }
+        KeyOutcome::None
+    }
+
+    fn handle_key_confirm(&mut self, code: KeyCode) -> KeyOutcome {
+        match code {
+            KeyCode::Char('q') => return KeyOutcome::Quit,
+            KeyCode::Char('y') => return KeyOutcome::Download,
+            KeyCode::Char('n') | KeyCode::Esc => self.screen = Screen::Diff,
+            _ => {}
+        }
+        KeyOutcome::None
     }
 }
 
@@ -82,8 +192,13 @@ pub fn initial_state() -> AppState {
         focus: FocusPane::Local,
         local_index: 0,
         gist_index: 0,
+        screen: Screen::List,
         diff_previewed: false,
-        pending_action: None,
+        diff_text: String::new(),
+        diff_scroll: 0,
+        preview_remote: String::new(),
+        preview_local: PathBuf::new(),
+        status: None,
     }
 }
 
@@ -172,7 +287,7 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
         })?;
 
         if let Event::Key(key) = event::read()? {
-            if state.handle_key(key.code) {
+            if state.handle_key(key.code) == KeyOutcome::Quit {
                 break;
             }
         }
@@ -251,5 +366,166 @@ mod tests {
         state.gist_index = 2;
         state.handle_key(KeyCode::Down); // move local selection down
         assert_eq!(state.gist_index, 0);
+    }
+
+    fn state_with_selection() -> AppState {
+        let mut state = initial_state();
+        state.locals = vec![LocalCandidate {
+            path: PathBuf::from("/tmp/settings.json"),
+            pinned: false,
+        }];
+        state.gists = vec![GistFile {
+            gist_id: "a".into(),
+            description: "settings".into(),
+            filename: "settings.json".into(),
+            public: false,
+            updated_at: "x".into(),
+        }];
+        state.focus = FocusPane::Gist;
+        state
+    }
+
+    #[test]
+    fn enter_diff_sets_diff_screen() {
+        let mut state = initial_state();
+        state.enter_diff(
+            "the diff".into(),
+            "remote body".into(),
+            PathBuf::from("/tmp/x"),
+        );
+        assert_eq!(state.screen, Screen::Diff);
+        assert!(state.diff_previewed);
+        assert_eq!(state.preview_remote, "remote body");
+        assert_eq!(state.preview_local, PathBuf::from("/tmp/x"));
+        assert_eq!(state.diff_scroll, 0);
+    }
+
+    #[test]
+    fn back_to_list_clears_preview() {
+        let mut state = initial_state();
+        state.enter_diff("d".into(), "r".into(), PathBuf::from("/tmp/x"));
+        state.back_to_list();
+        assert_eq!(state.screen, Screen::List);
+        assert!(!state.diff_previewed);
+        assert!(state.diff_text.is_empty());
+        assert!(state.preview_remote.is_empty());
+        assert_eq!(state.preview_local, PathBuf::new());
+    }
+
+    #[test]
+    fn enter_in_gist_focus_with_selection_returns_preview() {
+        let mut state = state_with_selection();
+        assert_eq!(state.handle_key(KeyCode::Enter), KeyOutcome::PreviewDiff);
+    }
+
+    #[test]
+    fn enter_in_local_focus_is_noop() {
+        let mut state = state_with_selection();
+        state.focus = FocusPane::Local;
+        assert_eq!(state.handle_key(KeyCode::Enter), KeyOutcome::None);
+    }
+
+    #[test]
+    fn enter_without_gists_is_noop() {
+        let mut state = initial_state();
+        state.locals = vec![LocalCandidate {
+            path: PathBuf::from("/tmp/x"),
+            pinned: false,
+        }];
+        state.focus = FocusPane::Gist;
+        assert_eq!(state.handle_key(KeyCode::Enter), KeyOutcome::None);
+    }
+
+    #[test]
+    fn diff_scroll_respects_bounds() {
+        let mut state = initial_state();
+        state.enter_diff("l1\nl2\nl3".into(), "r".into(), PathBuf::from("/tmp/x"));
+        assert_eq!(state.diff_scroll, 0);
+        state.handle_key(KeyCode::Up); // stays at 0
+        assert_eq!(state.diff_scroll, 0);
+        state.handle_key(KeyCode::Down);
+        assert_eq!(state.diff_scroll, 1);
+        state.handle_key(KeyCode::Down);
+        assert_eq!(state.diff_scroll, 2);
+        state.handle_key(KeyCode::Down); // capped at lines-1 = 2
+        assert_eq!(state.diff_scroll, 2);
+        state.handle_key(KeyCode::Up);
+        assert_eq!(state.diff_scroll, 1);
+    }
+
+    #[test]
+    fn esc_in_diff_returns_to_list() {
+        let mut state = initial_state();
+        state.enter_diff("d".into(), "r".into(), PathBuf::from("/tmp/x"));
+        assert_eq!(state.handle_key(KeyCode::Esc), KeyOutcome::None);
+        assert_eq!(state.screen, Screen::List);
+        assert!(!state.diff_previewed);
+    }
+
+    #[test]
+    fn d_in_diff_downloads_when_file_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("does-not-exist.json");
+        let mut state = initial_state();
+        state.enter_diff("d".into(), "r".into(), missing);
+        assert_eq!(state.handle_key(KeyCode::Char('d')), KeyOutcome::Download);
+    }
+
+    #[test]
+    fn d_in_diff_confirms_when_file_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let existing = dir.path().join("exists.json");
+        std::fs::write(&existing, "old").unwrap();
+        let mut state = initial_state();
+        state.enter_diff("d".into(), "r".into(), existing);
+        assert_eq!(state.handle_key(KeyCode::Char('d')), KeyOutcome::None);
+        assert_eq!(state.screen, Screen::ConfirmOverwrite);
+    }
+
+    #[test]
+    fn confirm_y_returns_download() {
+        let mut state = initial_state();
+        state.enter_diff("d".into(), "r".into(), PathBuf::from("/tmp/x"));
+        state.screen = Screen::ConfirmOverwrite;
+        assert_eq!(state.handle_key(KeyCode::Char('y')), KeyOutcome::Download);
+    }
+
+    #[test]
+    fn confirm_n_returns_to_diff() {
+        let mut state = initial_state();
+        state.enter_diff("d".into(), "r".into(), PathBuf::from("/tmp/x"));
+        state.screen = Screen::ConfirmOverwrite;
+        assert_eq!(state.handle_key(KeyCode::Char('n')), KeyOutcome::None);
+        assert_eq!(state.screen, Screen::Diff);
+    }
+
+    #[test]
+    fn q_in_diff_quits() {
+        let mut state = initial_state();
+        state.enter_diff("d".into(), "r".into(), PathBuf::from("/tmp/x"));
+        assert_eq!(state.handle_key(KeyCode::Char('q')), KeyOutcome::Quit);
+    }
+
+    #[test]
+    fn q_in_list_quits() {
+        let mut state = initial_state();
+        assert_eq!(state.handle_key(KeyCode::Char('q')), KeyOutcome::Quit);
+    }
+
+    #[test]
+    fn q_in_confirm_quits() {
+        let mut state = initial_state();
+        state.enter_diff("d".into(), "r".into(), PathBuf::from("/tmp/x"));
+        state.screen = Screen::ConfirmOverwrite;
+        assert_eq!(state.handle_key(KeyCode::Char('q')), KeyOutcome::Quit);
+    }
+
+    #[test]
+    fn confirm_esc_returns_to_diff() {
+        let mut state = initial_state();
+        state.enter_diff("d".into(), "r".into(), PathBuf::from("/tmp/x"));
+        state.screen = Screen::ConfirmOverwrite;
+        assert_eq!(state.handle_key(KeyCode::Esc), KeyOutcome::None);
+        assert_eq!(state.screen, Screen::Diff);
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -758,6 +758,72 @@ fn draw_loading(
     Ok(())
 }
 
+/// Civil date (year, month, day) from a day count since the Unix epoch — Howard Hinnant's
+/// algorithm. UTC, leap-second agnostic (fine for display).
+fn civil_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719468;
+    let era = (if z >= 0 { z } else { z - 146096 }) / 146097;
+    let doe = z - era * 146097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = (if mp < 10 { mp + 3 } else { mp - 9 }) as u32;
+    (if m <= 2 { y + 1 } else { y }, m, d)
+}
+
+fn format_unix_utc(secs: i64) -> String {
+    let (y, m, d) = civil_from_days(secs.div_euclid(86400));
+    let rem = secs.rem_euclid(86400);
+    format!(
+        "{y:04}-{m:02}-{d:02} {:02}:{:02} UTC",
+        rem / 3600,
+        rem % 3600 / 60
+    )
+}
+
+fn file_mtime_label(path: &std::path::Path) -> String {
+    std::fs::metadata(path)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| format_unix_utc(d.as_secs() as i64))
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// Normalises the gist API's RFC3339 `updated_at` (e.g. `2026-06-08T11:06:18Z`) to
+/// `2026-06-08 11:06 UTC` for display alongside the local file's mtime.
+fn gist_time_label(updated_at: &str) -> String {
+    if updated_at.is_empty() {
+        "unknown".to_string()
+    } else if updated_at.len() >= 16 {
+        format!("{} UTC", updated_at[..16].replace('T', " "))
+    } else {
+        updated_at.to_string()
+    }
+}
+
+/// Builds the `--- local` / `+++ gist` diff header labels showing each side's filename and
+/// last-modified time, plus the gist's id.
+fn diff_labels(local_path: Option<&std::path::Path>, gist: &GistFile) -> (String, String) {
+    let local_name = local_path
+        .and_then(|p| p.file_name())
+        .and_then(|n| n.to_str())
+        .unwrap_or("(none)");
+    let local_time = local_path
+        .map(file_mtime_label)
+        .unwrap_or_else(|| "—".to_string());
+    let local_label = format!("local: {local_name} ({local_time})");
+    let gist_label = format!(
+        "gist {} / {} ({})",
+        gist.gist_id,
+        gist.filename,
+        gist_time_label(&gist.updated_at)
+    );
+    (local_label, gist_label)
+}
+
 fn preview_diff(state: &mut AppState) {
     let Some(ranked) = state.selected_gist() else {
         return;
@@ -771,7 +837,9 @@ fn preview_diff(state: &mut AppState) {
                 .as_ref()
                 .map(|path| std::fs::read_to_string(path).unwrap_or_default())
                 .unwrap_or_default();
-            let diff = crate::diff::unified_diff("local", &local_content, "gist", &remote);
+            let (local_label, gist_label) = diff_labels(local_path.as_deref(), &gist);
+            let diff =
+                crate::diff::unified_diff(&local_label, &local_content, &gist_label, &remote);
             // Download saves the gist into the current working directory under the
             // gist's own filename, leaving the compared local file untouched.
             let target = state.cwd.join(&gist.filename);
@@ -819,7 +887,9 @@ fn download_selected(state: &mut AppState) {
                 // A same-named file already exists: show its diff and require a y/n
                 // overwrite confirmation before writing.
                 let local_content = std::fs::read_to_string(&target).unwrap_or_default();
-                let diff = crate::diff::unified_diff("local", &local_content, "gist", &remote);
+                let (local_label, gist_label) = diff_labels(Some(&target), &gist);
+                let diff =
+                    crate::diff::unified_diff(&local_label, &local_content, &gist_label, &remote);
                 state.enter_diff(diff, remote, target.clone(), target);
             } else {
                 // No collision: download straight into the cwd without forcing a diff.
@@ -940,7 +1010,9 @@ fn upload_preview(state: &mut AppState) {
     match crate::gh::fetch_gist_file_content(&gist.file.gist_id, &filename) {
         Ok(remote) => {
             let local_content = std::fs::read_to_string(&local.path).unwrap_or_default();
-            let diff = crate::diff::unified_diff("gist", &remote, "local", &local_content);
+            let (local_label, gist_label) = diff_labels(Some(&local.path), &gist.file);
+            let diff =
+                crate::diff::unified_diff(&gist_label, &remote, &local_label, &local_content);
             state.diff_text = diff;
             state.diff_scroll = 0;
             state.diff_hscroll = 0;
@@ -1080,13 +1152,18 @@ fn render_preview(frame: &mut Frame, state: &AppState) {
             .block(
                 Block::default()
                     .title(state.preview_title.clone())
-                    .borders(Borders::ALL),
+                    .borders(Borders::ALL)
+                    .padding(Padding::horizontal(1)),
             ),
         chunks[0],
     );
     frame.render_widget(
-        Paragraph::new("Up/Down/Left/Right scroll  Esc back  q quit")
-            .block(Block::default().title("Commands").borders(Borders::ALL)),
+        Paragraph::new("↑↓←→ scroll  ·  Esc back  ·  q quit").block(
+            Block::default()
+                .title("Commands")
+                .borders(Borders::ALL)
+                .padding(Padding::horizontal(1)),
+        ),
         chunks[1],
     );
 }
@@ -1370,15 +1447,38 @@ fn render_diff(frame: &mut Frame, state: &AppState, confirming: bool) {
         .constraints([Constraint::Min(5), Constraint::Length(3)])
         .split(frame.size());
 
-    let title = format!(
-        "Diff: {}  ->  {}",
-        state.preview_local.display(),
-        state.download_target.display()
-    );
+    // The gist id, filenames, and both sides' mtimes live in the diff's `--- / +++` header
+    // lines (see `diff_labels`); the title stays concise and avoids repeating a path.
+    let title = match &state.pending_action {
+        Some(PendingAction::Upload {
+            gist_id, filename, ..
+        }) => format!("Upload → gist {gist_id} / {filename}"),
+        Some(PendingAction::Create { local_path }) => {
+            format!("Create gist from {}", local_path.display())
+        }
+        _ => {
+            if state.preview_local.as_os_str().is_empty()
+                || state.preview_local == state.download_target
+            {
+                format!("Diff → {}", state.download_target.display())
+            } else {
+                format!(
+                    "Diff: {} → {}",
+                    state.preview_local.display(),
+                    state.download_target.display()
+                )
+            }
+        }
+    };
     frame.render_widget(
         Paragraph::new(colorize_diff(&state.diff_text))
             .scroll((state.diff_scroll, state.diff_hscroll))
-            .block(Block::default().title(title).borders(Borders::ALL)),
+            .block(
+                Block::default()
+                    .title(title)
+                    .borders(Borders::ALL)
+                    .padding(Padding::horizontal(1)),
+            ),
         chunks[0],
     );
 
@@ -1399,7 +1499,12 @@ fn render_diff(frame: &mut Frame, state: &AppState, confirming: bool) {
         "↑↓←→ scroll  ·  d download  ·  u upload  ·  Esc back  ·  q quit".to_string()
     };
     frame.render_widget(
-        Paragraph::new(footer).block(Block::default().title("Commands").borders(Borders::ALL)),
+        Paragraph::new(footer).block(
+            Block::default()
+                .title("Commands")
+                .borders(Borders::ALL)
+                .padding(Padding::horizontal(1)),
+        ),
         chunks[1],
     );
 }
@@ -1691,6 +1796,22 @@ mod tests {
         let mut state = initial_state();
         state.screen = Screen::Help;
         assert_eq!(state.handle_key(KeyCode::Char('q')), KeyOutcome::Quit);
+    }
+
+    #[test]
+    fn format_unix_utc_known_instants() {
+        assert_eq!(format_unix_utc(0), "1970-01-01 00:00 UTC");
+        assert_eq!(format_unix_utc(1_780_656_360), "2026-06-05 10:46 UTC");
+    }
+
+    #[test]
+    fn gist_time_label_normalises_rfc3339() {
+        assert_eq!(
+            gist_time_label("2026-06-08T11:06:18Z"),
+            "2026-06-08 11:06 UTC"
+        );
+        assert_eq!(gist_time_label(""), "unknown");
+        assert_eq!(gist_time_label("short"), "short");
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -362,20 +362,16 @@ impl AppState {
         }
     }
 
-    fn handle_key_help(&mut self, code: KeyCode) -> KeyOutcome {
-        match code {
-            KeyCode::Char('q') => KeyOutcome::Quit,
-            _ => {
-                self.screen = Screen::List;
-                KeyOutcome::None
-            }
-        }
+    fn handle_key_help(&mut self, _code: KeyCode) -> KeyOutcome {
+        // Any key (including q) just closes the help overlay back to the list.
+        self.screen = Screen::List;
+        KeyOutcome::None
     }
 
     fn handle_key_preview(&mut self, code: KeyCode) -> KeyOutcome {
         match code {
-            KeyCode::Char('q') => return KeyOutcome::Quit,
-            KeyCode::Esc => {
+            // In the preview, q and Esc both return to the list (no accidental app exit).
+            KeyCode::Char('q') | KeyCode::Esc => {
                 self.screen = Screen::List;
                 self.diff_text.clear();
                 self.preview_title.clear();
@@ -418,7 +414,8 @@ impl AppState {
         // status may be set afterwards by the run_loop IO helper for this key.
         self.status = None;
         match code {
-            KeyCode::Char('q') => return KeyOutcome::Quit,
+            // On the main list both q and Esc exit the app.
+            KeyCode::Char('q') | KeyCode::Esc => return KeyOutcome::Quit,
             KeyCode::Tab => {
                 self.focus = match self.focus {
                     FocusPane::Local => FocusPane::Gist,
@@ -522,8 +519,8 @@ impl AppState {
 
     fn handle_key_diff(&mut self, code: KeyCode) -> KeyOutcome {
         match code {
-            KeyCode::Char('q') => return KeyOutcome::Quit,
-            KeyCode::Esc => self.back_to_list(),
+            // In the diff, q and Esc both return to the list (no accidental app exit).
+            KeyCode::Char('q') | KeyCode::Esc => self.back_to_list(),
             KeyCode::Down => self.scroll_diff_down(),
             KeyCode::Up => self.scroll_diff_up(),
             KeyCode::Right => self.scroll_diff_right(),
@@ -545,7 +542,6 @@ impl AppState {
 
     fn handle_key_confirm(&mut self, code: KeyCode) -> KeyOutcome {
         match code {
-            KeyCode::Char('q') => return KeyOutcome::Quit,
             KeyCode::Down => {
                 self.scroll_diff_down();
                 return KeyOutcome::None;
@@ -567,7 +563,7 @@ impl AppState {
         match self.pending_action.clone() {
             Some(PendingAction::Download) => match code {
                 KeyCode::Char('y') => return KeyOutcome::Download,
-                KeyCode::Char('n') | KeyCode::Esc => {
+                KeyCode::Char('n') | KeyCode::Char('q') | KeyCode::Esc => {
                     self.pending_action = None;
                     self.screen = Screen::Diff;
                 }
@@ -575,7 +571,7 @@ impl AppState {
             },
             Some(PendingAction::Upload { .. }) => match code {
                 KeyCode::Char('y') => return KeyOutcome::Upload,
-                KeyCode::Char('n') | KeyCode::Esc => {
+                KeyCode::Char('n') | KeyCode::Char('q') | KeyCode::Esc => {
                     self.pending_action = None;
                     self.screen = Screen::List;
                 }
@@ -584,14 +580,14 @@ impl AppState {
             Some(PendingAction::Create { .. }) => match code {
                 KeyCode::Char('s') => return KeyOutcome::Create(false),
                 KeyCode::Char('p') => return KeyOutcome::Create(true),
-                KeyCode::Char('n') | KeyCode::Esc => {
+                KeyCode::Char('n') | KeyCode::Char('q') | KeyCode::Esc => {
                     self.pending_action = None;
                     self.screen = Screen::List;
                 }
                 _ => {}
             },
             _ => {
-                if matches!(code, KeyCode::Esc | KeyCode::Char('n')) {
+                if matches!(code, KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('q')) {
                     self.pending_action = None;
                     self.screen = Screen::List;
                 }
@@ -1135,8 +1131,8 @@ Actions (on the selected local file + gist)
   p          pin / unpin the local <-> gist pair
 
 General
-  ?          show this help
-  q          quit";
+  Esc / q    close an overlay; from the list, quit the app
+  ?          show this help";
 
     frame.render_widget(
         Paragraph::new(text).block(
@@ -1167,7 +1163,7 @@ fn render_preview(frame: &mut Frame, state: &AppState) {
         chunks[0],
     );
     frame.render_widget(
-        Paragraph::new("↑↓←→ scroll  ·  Esc back  ·  q quit").block(
+        Paragraph::new("↑↓←→ scroll  ·  Esc/q back").block(
             Block::default()
                 .title("Commands")
                 .borders(Borders::ALL)
@@ -1235,7 +1231,7 @@ fn commands_hint() -> String {
         "s sort",
         "/ filter",
         "? help",
-        "q quit",
+        "Esc/q quit",
     ]
     .join("  ·  ")
 }
@@ -1518,9 +1514,9 @@ fn render_diff(frame: &mut Frame, state: &AppState, confirming: bool) {
             _ => format!("Overwrite {}? (y/n)", state.download_target.display()),
         }
     } else if state.diff_identical {
-        "Files are identical — nothing to sync  ·  ↑↓←→ scroll  ·  Esc back  ·  q quit".to_string()
+        "Files are identical — nothing to sync  ·  ↑↓←→ scroll  ·  Esc/q back".to_string()
     } else {
-        "↑↓←→ scroll  ·  d download  ·  u upload  ·  Esc back  ·  q quit".to_string()
+        "↑↓←→ scroll  ·  d download  ·  u upload  ·  Esc/q back".to_string()
     };
     frame.render_widget(
         Paragraph::new(footer).block(
@@ -1816,10 +1812,11 @@ mod tests {
     }
 
     #[test]
-    fn q_in_help_quits() {
+    fn q_in_help_closes_to_list() {
         let mut state = initial_state();
         state.screen = Screen::Help;
-        assert_eq!(state.handle_key(KeyCode::Char('q')), KeyOutcome::Quit);
+        assert_eq!(state.handle_key(KeyCode::Char('q')), KeyOutcome::None);
+        assert_eq!(state.screen, Screen::List);
     }
 
     #[test]
@@ -2290,7 +2287,7 @@ mod tests {
     }
 
     #[test]
-    fn q_in_diff_quits() {
+    fn q_in_diff_returns_to_list() {
         let mut state = initial_state();
         state.enter_diff(
             "d".into(),
@@ -2298,7 +2295,8 @@ mod tests {
             PathBuf::from("/tmp/x"),
             PathBuf::from("/tmp/x"),
         );
-        assert_eq!(state.handle_key(KeyCode::Char('q')), KeyOutcome::Quit);
+        assert_eq!(state.handle_key(KeyCode::Char('q')), KeyOutcome::None);
+        assert_eq!(state.screen, Screen::List);
     }
 
     #[test]
@@ -2308,7 +2306,13 @@ mod tests {
     }
 
     #[test]
-    fn q_in_confirm_quits() {
+    fn esc_in_list_quits() {
+        let mut state = initial_state();
+        assert_eq!(state.handle_key(KeyCode::Esc), KeyOutcome::Quit);
+    }
+
+    #[test]
+    fn q_in_confirm_cancels_without_quitting() {
         let mut state = initial_state();
         state.enter_diff(
             "d".into(),
@@ -2318,7 +2322,8 @@ mod tests {
         );
         state.pending_action = Some(PendingAction::Download);
         state.screen = Screen::Confirm;
-        assert_eq!(state.handle_key(KeyCode::Char('q')), KeyOutcome::Quit);
+        assert_eq!(state.handle_key(KeyCode::Char('q')), KeyOutcome::None);
+        assert_eq!(state.screen, Screen::Diff);
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -26,7 +26,20 @@ pub enum FocusPane {
 pub enum Screen {
     List,
     Diff,
-    ConfirmOverwrite,
+    Confirm,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PendingAction {
+    Download,
+    Upload {
+        gist_id: String,
+        filename: String,
+        local_path: PathBuf,
+    },
+    Create {
+        local_path: PathBuf,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -125,6 +138,7 @@ pub struct AppState {
     pub local_hscroll: u16,
     pub gist_hscroll: u16,
     pub screen: Screen,
+    pub pending_action: Option<PendingAction>,
     pub gist_view: GistView,
     pub gist_type_filter: GistTypeFilter,
     pub gist_sort: GistSort,
@@ -232,6 +246,7 @@ impl AppState {
 
     pub fn back_to_list(&mut self) {
         self.screen = Screen::List;
+        self.pending_action = None;
         self.diff_text.clear();
         self.preview_remote.clear();
         self.preview_local = PathBuf::new();
@@ -283,7 +298,7 @@ impl AppState {
         match self.screen {
             Screen::List => self.handle_key_list(code),
             Screen::Diff => self.handle_key_diff(code),
-            Screen::ConfirmOverwrite => self.handle_key_confirm(code),
+            Screen::Confirm => self.handle_key_confirm(code),
         }
     }
 
@@ -370,7 +385,8 @@ impl AppState {
             KeyCode::Left => self.scroll_diff_left(),
             KeyCode::Char('d') => {
                 if self.download_target.exists() {
-                    self.screen = Screen::ConfirmOverwrite;
+                    self.pending_action = Some(PendingAction::Download);
+                    self.screen = Screen::Confirm;
                 } else {
                     return KeyOutcome::Download;
                 }
@@ -381,11 +397,24 @@ impl AppState {
     }
 
     fn handle_key_confirm(&mut self, code: KeyCode) -> KeyOutcome {
-        match code {
-            KeyCode::Char('q') => return KeyOutcome::Quit,
-            KeyCode::Char('y') => return KeyOutcome::Download,
-            KeyCode::Char('n') | KeyCode::Esc => self.screen = Screen::Diff,
-            _ => {}
+        if code == KeyCode::Char('q') {
+            return KeyOutcome::Quit;
+        }
+        match self.pending_action.clone() {
+            Some(PendingAction::Download) => match code {
+                KeyCode::Char('y') => return KeyOutcome::Download,
+                KeyCode::Char('n') | KeyCode::Esc => {
+                    self.pending_action = None;
+                    self.screen = Screen::Diff;
+                }
+                _ => {}
+            },
+            _ => {
+                if matches!(code, KeyCode::Esc | KeyCode::Char('n')) {
+                    self.pending_action = None;
+                    self.screen = Screen::List;
+                }
+            }
         }
         KeyOutcome::None
     }
@@ -402,6 +431,7 @@ pub fn initial_state() -> AppState {
         local_hscroll: 0,
         gist_hscroll: 0,
         screen: Screen::List,
+        pending_action: None,
         gist_view: GistView::Description,
         gist_type_filter: GistTypeFilter::All,
         gist_sort: GistSort::Match,
@@ -564,7 +594,7 @@ fn render(frame: &mut Frame, state: &AppState) {
     match state.screen {
         Screen::List => render_list(frame, state),
         Screen::Diff => render_diff(frame, state, false),
-        Screen::ConfirmOverwrite => render_diff(frame, state, true),
+        Screen::Confirm => render_diff(frame, state, true),
     }
 }
 
@@ -732,7 +762,18 @@ fn render_diff(frame: &mut Frame, state: &AppState, confirming: bool) {
     );
 
     let footer = if confirming {
-        format!("Overwrite {}? (y/n)", state.download_target.display())
+        match &state.pending_action {
+            Some(PendingAction::Create { local_path }) => format!(
+                "Create gist from {}?  s secret  p public  Esc cancel",
+                local_path.display()
+            ),
+            Some(PendingAction::Upload {
+                gist_id, filename, ..
+            }) => {
+                format!("Upload {} to gist {}? (y/n)", filename, gist_id)
+            }
+            _ => format!("Overwrite {}? (y/n)", state.download_target.display()),
+        }
     } else {
         format!(
             "Up/Down/Left/Right scroll  d download -> {}  Esc back  q quit",
@@ -1269,7 +1310,7 @@ mod tests {
             existing,
         );
         assert_eq!(state.handle_key(KeyCode::Char('d')), KeyOutcome::None);
-        assert_eq!(state.screen, Screen::ConfirmOverwrite);
+        assert_eq!(state.screen, Screen::Confirm);
     }
 
     #[test]
@@ -1281,7 +1322,8 @@ mod tests {
             PathBuf::from("/tmp/x"),
             PathBuf::from("/tmp/x"),
         );
-        state.screen = Screen::ConfirmOverwrite;
+        state.pending_action = Some(PendingAction::Download);
+        state.screen = Screen::Confirm;
         assert_eq!(state.handle_key(KeyCode::Char('y')), KeyOutcome::Download);
     }
 
@@ -1294,7 +1336,8 @@ mod tests {
             PathBuf::from("/tmp/x"),
             PathBuf::from("/tmp/x"),
         );
-        state.screen = Screen::ConfirmOverwrite;
+        state.pending_action = Some(PendingAction::Download);
+        state.screen = Screen::Confirm;
         assert_eq!(state.handle_key(KeyCode::Char('n')), KeyOutcome::None);
         assert_eq!(state.screen, Screen::Diff);
     }
@@ -1326,7 +1369,8 @@ mod tests {
             PathBuf::from("/tmp/x"),
             PathBuf::from("/tmp/x"),
         );
-        state.screen = Screen::ConfirmOverwrite;
+        state.pending_action = Some(PendingAction::Download);
+        state.screen = Screen::Confirm;
         assert_eq!(state.handle_key(KeyCode::Char('q')), KeyOutcome::Quit);
     }
 
@@ -1339,8 +1383,26 @@ mod tests {
             PathBuf::from("/tmp/x"),
             PathBuf::from("/tmp/x"),
         );
-        state.screen = Screen::ConfirmOverwrite;
+        state.pending_action = Some(PendingAction::Download);
+        state.screen = Screen::Confirm;
         assert_eq!(state.handle_key(KeyCode::Esc), KeyOutcome::None);
         assert_eq!(state.screen, Screen::Diff);
+    }
+
+    #[test]
+    fn d_in_diff_on_existing_sets_download_pending() {
+        let dir = tempfile::tempdir().unwrap();
+        let existing = dir.path().join("exists.json");
+        std::fs::write(&existing, "old").unwrap();
+        let mut state = initial_state();
+        state.enter_diff(
+            "d".into(),
+            "r".into(),
+            PathBuf::from("/tmp/local"),
+            existing,
+        );
+        assert_eq!(state.handle_key(KeyCode::Char('d')), KeyOutcome::None);
+        assert_eq!(state.screen, Screen::Confirm);
+        assert_eq!(state.pending_action, Some(PendingAction::Download));
     }
 }

--- a/tests/fixtures/gh/gist-list.json
+++ b/tests/fixtures/gh/gist-list.json
@@ -1,0 +1,21 @@
+[
+  {
+    "id": "abc123",
+    "description": "claude config",
+    "public": false,
+    "updated_at": "2026-06-08T00:00:00Z",
+    "files": {
+      "settings.json": { "filename": "settings.json", "type": "application/json" },
+      "statusline.sh": { "filename": "statusline.sh", "type": "text/x-shellscript" }
+    }
+  },
+  {
+    "id": "def456",
+    "description": null,
+    "public": true,
+    "updated_at": "2026-06-07T00:00:00Z",
+    "files": {
+      "notes.md": { "filename": "notes.md", "type": "text/markdown" }
+    }
+  }
+]


### PR DESCRIPTION
A terminal UI for managing GitHub Gists, built on `ratatui` + the GitHub CLI (`gh`).

## Features
- **Browse & rank**: cwd files on the left, your gists on the right, ranked against the selected file (star tiers for exact-name / pinned / path hints).
- **Diff** (`Enter`): coloured unified diff between a local file and a gist; identical files are detected and sync is disabled.
- **Download** (`d`) into the cwd, **upload** (`u`) into a gist, **create** (`n`) a new gist (secret/public), **pin** (`p`) a local↔gist pair.
- **Open in browser** (`o`) and **edit local in `$EDITOR`** (`e`).
- **Content preview** (`Space`), **filter** (`/`), **visibility filter** (`v`), **sort** (`s`), **row view toggle** (`t`).
- **Responsive, focus-aware footer**; **`?` help overlay**; scrollbars, padding, dim unfocused pane.
- **Fast startup**: gist list fetched off-thread with a loading indicator and an on-disk cache.

## Safety
- Writes only to `./<gist-filename>`; existing targets are never overwritten without a diff + `y/n` confirm.
- No GitHub token stored; only path↔gist pin mappings persisted (XDG config).

## Quality
- 106 unit tests; `cargo fmt`/`clippy -D warnings`/`check`/`build` all clean.
- Pure `handle_key` state machine, IO isolated in `run_loop`; `gh` calls are thin untested boundaries (tests never hit the network).

Follow-up work tracked in #1–#12.