### PR TITLE
chore: bump upload-artifact to v7, download-artifact to v8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
           "ASSET=${pkg}.zip" | Out-File -Append $env:GITHUB_ENV
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.target }}
           path: ${{ env.ASSET }}
@@ -100,7 +100,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true


### PR DESCRIPTION
Fixes Node.js 20 deprecation warnings in the release workflow.
Node.js 24 becomes the default on GitHub runners on June 16, 2026.

- `actions/upload-artifact@v4` → `@v7`
- `actions/download-artifact@v4` → `@v8`