### PR TITLE
chore: bump softprops/action-gh-release to v3 (Node.js 24)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
           merge-multiple: true
 
       - name: Create release and upload assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: artifacts/*
           generate_release_notes: true


### PR DESCRIPTION
`softprops/action-gh-release@v2` triggers the Node.js 20 deprecation warning.
Latest release is v3.0.0 which supports Node.js 24.

Node.js 24 becomes the default on GitHub runners on June 16, 2026.