### PR TITLE
feat: toggle recursive local file discovery with r key

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ Pure, testable domain logic is kept separate from impure shell/filesystem adapte
 
 - Tests must never call the real `gh` or the network. `gh` JSON parsing is tested against fixtures in `tests/fixtures/gh/`; IO functions are left as thin untested boundaries.
 - Downloads only write to `cwd/<gist-filename>`. The overwrite gate is the invariant to preserve: an *existing* target is never overwritten without first showing its diff and a `y/n` confirmation (`Screen::ConfirmOverwrite`); writing a path that does not yet exist is allowed directly (no diff forced). Do not add a write path that overwrites an existing file without that diff+confirm.
-- No GitHub tokens are stored by the app, and gist *content* is never written to the config file (`~/.config/gistui/config.toml`, XDG-aware) — only path↔gist mappings.
+- No GitHub tokens are stored by the app, and gist *content* is never written to the config file (`~/.config/gistui/config.toml`, XDG-aware). The config holds only `pinned` mappings and `skip_dirs`. See `config.example.toml` for the annotated schema.
 - Use `frame.area()` (not `frame.size()`, which was removed in ratatui 0.28). The project now pins ratatui 0.30.
 - `Rect::inner` takes `Margin` by value (not `&Margin`) since ratatui 0.28.
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,25 @@ unranked so you can still preview and download into the current directory.
 - No GitHub token is stored by the app, and gist content is never written to the config
   file — only path↔gist pin mappings are persisted.
 
+## Configuration
+
+The config file lives at `~/.config/gistui/config.toml` (or
+`$XDG_CONFIG_HOME/gistui/config.toml` if that variable is set). It is created
+automatically the first time you pin a file. All fields are optional.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `skip_dirs` | `[string]` | Directory names skipped during recursive discovery (`r` key). Defaults to common build/dependency dirs (`node_modules`, `target`, …). Hidden dirs (`.`-prefix) are always skipped. |
+| `[[pinned]]` | table array | Local-file ↔ gist mappings managed by the `p` key. Can also be edited by hand. |
+
+Copy [`config.example.toml`](config.example.toml) from the repo for an annotated
+starting point:
+
+```bash
+mkdir -p ~/.config/gistui
+cp config.example.toml ~/.config/gistui/config.toml
+```
+
 ## Building a release
 
 ```bash

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,0 +1,35 @@
+# gistui configuration — copy to ~/.config/gistui/config.toml
+# (or $XDG_CONFIG_HOME/gistui/config.toml if XDG_CONFIG_HOME is set)
+# All fields are optional; omitting a field uses the built-in default.
+
+# Maximum directory depth for recursive file discovery (r key).
+# Depth 0 = cwd only, 1 = one level deep, 2 = two levels deep, etc.
+scan_depth = 2
+
+# Directories skipped when recursive local file discovery is active (r key).
+# Hidden directories (names starting with ".") are always skipped regardless
+# of this list. Add project-specific build output dirs here as needed.
+skip_dirs = [
+  "node_modules",
+  "target",       # Rust
+  "dist",
+  "build",
+  ".next",        # Next.js
+  "__pycache__",  # Python
+  "vendor",
+  ".cache",
+  "venv",
+  ".venv",
+  "env",
+  ".tox",
+  "coverage",
+]
+
+# Pinned local-file ↔ gist mappings are managed by the app via the p key;
+# you can also edit them here directly. Each entry requires local_path and
+# gist_id; the other fields are optional.
+#
+# [[pinned]]
+# local_path  = "~/.zshrc"
+# gist_id     = "abc123def456"
+# gist_filename = ".zshrc"    # defaults to the local filename if omitted

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,10 +4,51 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+fn default_scan_depth() -> u32 {
+    2
+}
+
+fn default_skip_dirs() -> Vec<String> {
+    [
+        "node_modules",
+        "target",
+        "dist",
+        "build",
+        ".next",
+        "__pycache__",
+        "vendor",
+        ".cache",
+        "venv",
+        ".venv",
+        "env",
+        ".tox",
+        "coverage",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect()
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AppConfig {
     #[serde(default)]
     pub pinned: Vec<PinnedMapping>,
+    /// Directory names skipped during recursive local file discovery.
+    #[serde(default = "default_skip_dirs")]
+    pub skip_dirs: Vec<String>,
+    /// Maximum directory depth for recursive local file discovery (r key).
+    #[serde(default = "default_scan_depth")]
+    pub scan_depth: u32,
+}
+
+impl Default for AppConfig {
+    fn default() -> Self {
+        Self {
+            pinned: Vec::new(),
+            skip_dirs: default_skip_dirs(),
+            scan_depth: default_scan_depth(),
+        }
+    }
 }
 
 pub fn normalize_path(path: &Path) -> Result<PathBuf> {
@@ -107,6 +148,8 @@ mod tests {
                 direction: Some(SyncDirection::Upload),
                 last_seen_hash: Some("hash".into()),
             }],
+            skip_dirs: default_skip_dirs(),
+            scan_depth: default_scan_depth(),
         };
 
         save_config(&path, &config).unwrap();

--- a/src/local.rs
+++ b/src/local.rs
@@ -3,20 +3,29 @@ use anyhow::Result;
 use std::fs;
 use std::path::Path;
 
-/// Lists the files in `cwd` as local candidates. Discovery is scoped to the
-/// current working directory only; `pinned` is used solely to mark which of those
-/// files already have a saved gist mapping (it does not pull in out-of-cwd paths).
+/// Lists local file candidates under `cwd`.
+///
+/// When `recursive` is false only the immediate children of `cwd` are
+/// returned (original behaviour). When `recursive` is true the tree is
+/// walked up to 10 levels deep; hidden directories (name starts with `.`)
+/// and names in `skip_dirs` are skipped.
 pub fn discover_local_candidates(
     cwd: &Path,
     pinned: &[PinnedMapping],
+    recursive: bool,
+    skip_dirs: &[String],
+    max_depth: u32,
 ) -> Result<Vec<LocalCandidate>> {
     let mut paths = Vec::new();
 
-    for entry in fs::read_dir(cwd)? {
-        let entry = entry?;
-        let path = entry.path();
-        if path.is_file() {
-            paths.push(path);
+    if recursive {
+        walk_recursive(cwd, &mut paths, 0, skip_dirs, max_depth);
+    } else {
+        for entry in fs::read_dir(cwd)? {
+            let path = entry?.path();
+            if path.is_file() {
+                paths.push(path);
+            }
         }
     }
 
@@ -35,6 +44,36 @@ pub fn discover_local_candidates(
         .collect())
 }
 
+fn walk_recursive(
+    dir: &Path,
+    paths: &mut Vec<std::path::PathBuf>,
+    depth: u32,
+    skip_dirs: &[String],
+    max_depth: u32,
+) {
+    if depth > max_depth {
+        return;
+    }
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.filter_map(|e| e.ok()) {
+        let path = entry.path();
+        let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        if name.starts_with('.') {
+            continue;
+        }
+        if path.is_dir() {
+            if skip_dirs.iter().any(|d| d == name) {
+                continue;
+            }
+            walk_recursive(&path, paths, depth + 1, skip_dirs, max_depth);
+        } else if path.is_file() {
+            paths.push(path);
+        }
+    }
+}
+
 pub fn is_empty_candidate_mode(candidates: &[LocalCandidate]) -> bool {
     candidates.is_empty()
 }
@@ -43,6 +82,10 @@ pub fn is_empty_candidate_mode(candidates: &[LocalCandidate]) -> bool {
 mod tests {
     use super::*;
 
+    fn default_skip() -> Vec<String> {
+        crate::config::AppConfig::default().skip_dirs
+    }
+
     #[test]
     fn discovers_cwd_files_only() {
         let dir = tempfile::tempdir().unwrap();
@@ -50,7 +93,8 @@ mod tests {
         fs::write(dir.path().join("settings.json"), "{}").unwrap();
         fs::write(outside.path().join("elsewhere.json"), "{}").unwrap();
 
-        let candidates = discover_local_candidates(dir.path(), &[]).unwrap();
+        let candidates =
+            discover_local_candidates(dir.path(), &[], false, &default_skip(), 10).unwrap();
         let paths: Vec<_> = candidates.iter().map(|c| c.path.clone()).collect();
 
         assert!(paths.contains(&dir.path().join("settings.json")));
@@ -80,7 +124,8 @@ mod tests {
             },
         ];
 
-        let candidates = discover_local_candidates(dir.path(), &pinned).unwrap();
+        let candidates =
+            discover_local_candidates(dir.path(), &pinned, false, &default_skip(), 10).unwrap();
         assert_eq!(candidates.len(), 1);
         assert_eq!(candidates[0].path, cwd_file);
         assert!(candidates[0].pinned);
@@ -89,7 +134,77 @@ mod tests {
     #[test]
     fn empty_candidate_mode_when_nothing_found() {
         let dir = tempfile::tempdir().unwrap();
-        let candidates = discover_local_candidates(dir.path(), &[]).unwrap();
+        let candidates =
+            discover_local_candidates(dir.path(), &[], false, &default_skip(), 10).unwrap();
         assert!(is_empty_candidate_mode(&candidates));
+    }
+
+    #[test]
+    fn recursive_finds_nested_files() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("src/utils")).unwrap();
+        fs::write(dir.path().join("README.md"), "").unwrap();
+        fs::write(dir.path().join("src/main.rs"), "").unwrap();
+        fs::write(dir.path().join("src/utils/helpers.rs"), "").unwrap();
+
+        let candidates =
+            discover_local_candidates(dir.path(), &[], true, &default_skip(), 10).unwrap();
+        let paths: Vec<_> = candidates.iter().map(|c| c.path.clone()).collect();
+
+        assert!(paths.contains(&dir.path().join("README.md")));
+        assert!(paths.contains(&dir.path().join("src/main.rs")));
+        assert!(paths.contains(&dir.path().join("src/utils/helpers.rs")));
+    }
+
+    #[test]
+    fn recursive_skips_denied_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("node_modules/lodash")).unwrap();
+        fs::create_dir_all(dir.path().join("target/debug")).unwrap();
+        fs::write(dir.path().join("node_modules/lodash/index.js"), "").unwrap();
+        fs::write(dir.path().join("target/debug/app"), "").unwrap();
+        fs::write(dir.path().join("src.rs"), "").unwrap();
+
+        let candidates =
+            discover_local_candidates(dir.path(), &[], true, &default_skip(), 10).unwrap();
+        let paths: Vec<_> = candidates.iter().map(|c| c.path.clone()).collect();
+
+        assert!(paths.contains(&dir.path().join("src.rs")));
+        assert!(!paths
+            .iter()
+            .any(|p| p.to_string_lossy().contains("node_modules")));
+        assert!(!paths.iter().any(|p| p.to_string_lossy().contains("target")));
+    }
+
+    #[test]
+    fn recursive_skips_hidden_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(dir.path().join(".git/objects")).unwrap();
+        fs::write(dir.path().join(".git/objects/abc"), "").unwrap();
+        fs::write(dir.path().join("visible.rs"), "").unwrap();
+
+        let candidates =
+            discover_local_candidates(dir.path(), &[], true, &default_skip(), 10).unwrap();
+        let paths: Vec<_> = candidates.iter().map(|c| c.path.clone()).collect();
+
+        assert!(paths.contains(&dir.path().join("visible.rs")));
+        assert!(!paths.iter().any(|p| p.to_string_lossy().contains(".git")));
+    }
+
+    #[test]
+    fn recursive_custom_skip_dirs_are_respected() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("custom_skip")).unwrap();
+        fs::write(dir.path().join("custom_skip/file.txt"), "").unwrap();
+        fs::write(dir.path().join("visible.txt"), "").unwrap();
+
+        let skip = vec!["custom_skip".to_string()];
+        let candidates = discover_local_candidates(dir.path(), &[], true, &skip, 10).unwrap();
+        let paths: Vec<_> = candidates.iter().map(|c| c.path.clone()).collect();
+
+        assert!(paths.contains(&dir.path().join("visible.txt")));
+        assert!(!paths
+            .iter()
+            .any(|p| p.to_string_lossy().contains("custom_skip")));
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -146,6 +146,7 @@ pub enum KeyOutcome {
     EditLocal,
     DeletePreview,
     ExecuteDelete,
+    RefreshLocals,
 }
 
 #[derive(Debug, Clone)]
@@ -178,6 +179,10 @@ pub struct AppState {
     pub loading: bool,
     pub preview_title: String,
     pub gist_content_cache: std::collections::HashMap<(String, String), String>,
+    pub local_recursive: bool,
+    pub skip_dirs: Vec<String>,
+    pub scan_depth: u32,
+    pub local_scanning: bool,
 }
 
 impl AppState {
@@ -256,7 +261,7 @@ impl AppState {
             FocusPane::Local => self
                 .locals
                 .iter()
-                .map(|c| local_row_label(&c.path).chars().count())
+                .map(|c| local_row_label(&c.path, &self.cwd).chars().count())
                 .max(),
             FocusPane::Gist => self
                 .ranked_gists()
@@ -476,6 +481,12 @@ impl AppState {
                 self.gist_index = 0;
                 self.gist_hscroll = 0;
             }
+            KeyCode::Char('r') => {
+                self.local_recursive = !self.local_recursive;
+                self.local_index = 0;
+                self.local_hscroll = 0;
+                return KeyOutcome::RefreshLocals;
+            }
             KeyCode::Char('/') => self.filtering = true,
             KeyCode::Char('?') => self.screen = Screen::Help,
             KeyCode::Char('o') => {
@@ -661,6 +672,10 @@ pub fn initial_state() -> AppState {
         loading: false,
         preview_title: String::new(),
         gist_content_cache: std::collections::HashMap::new(),
+        local_recursive: false,
+        skip_dirs: crate::config::AppConfig::default().skip_dirs,
+        scan_depth: crate::config::AppConfig::default().scan_depth,
+        local_scanning: false,
     }
 }
 
@@ -671,7 +686,15 @@ pub fn load_startup_state() -> Result<AppState> {
     let cwd = std::env::current_dir()?;
 
     state.pinned = config.pinned;
-    state.locals = crate::local::discover_local_candidates(&cwd, &state.pinned)?;
+    state.skip_dirs = config.skip_dirs;
+    state.scan_depth = config.scan_depth;
+    state.locals = crate::local::discover_local_candidates(
+        &cwd,
+        &state.pinned,
+        false,
+        &state.skip_dirs,
+        state.scan_depth,
+    )?;
     state.cwd = cwd;
     // Start focused on the gist pane: the common flow is to pick a gist and pull it
     // into the cwd, and the gist list is shown even when no local file is selected.
@@ -710,6 +733,24 @@ fn spawn_gist_fetch() -> std::sync::mpsc::Receiver<Vec<GistFile>> {
     rx
 }
 
+fn spawn_local_scan(
+    cwd: std::path::PathBuf,
+    pinned: Vec<crate::domain::PinnedMapping>,
+    recursive: bool,
+    skip_dirs: Vec<String>,
+    max_depth: u32,
+) -> std::sync::mpsc::Receiver<Vec<LocalCandidate>> {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let candidates = crate::local::discover_local_candidates(
+            &cwd, &pinned, recursive, &skip_dirs, max_depth,
+        )
+        .unwrap_or_default();
+        let _ = tx.send(candidates);
+    });
+    rx
+}
+
 pub fn run() -> Result<()> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -728,6 +769,7 @@ pub fn run() -> Result<()> {
 fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()> {
     let mut state = load_startup_state()?;
     let gist_rx = spawn_gist_fetch();
+    let mut local_rx: Option<std::sync::mpsc::Receiver<Vec<LocalCandidate>>> = None;
 
     loop {
         terminal.draw(|frame| render(frame, &state))?;
@@ -744,7 +786,27 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
             }
         }
 
-        // Poll so the loop also wakes to check the background fetch, not only on input.
+        // Absorb a completed background local scan.
+        if state.local_scanning {
+            if let Some(ref rx) = local_rx {
+                if let Ok(locals) = rx.try_recv() {
+                    let selected = state.selected_local().map(|c| c.path.clone());
+                    state.locals = locals;
+                    state.local_index = selected
+                        .and_then(|path| state.locals.iter().position(|c| c.path == path))
+                        .unwrap_or(0)
+                        .min(state.locals.len().saturating_sub(1));
+                    if state.gist_index >= state.ranked_gists().len() {
+                        state.gist_index = 0;
+                    }
+                    state.local_scanning = false;
+                    state.status = None;
+                    local_rx = None;
+                }
+            }
+        }
+
+        // Poll so the loop also wakes to check the background fetches, not only on input.
         if !event::poll(std::time::Duration::from_millis(150))? {
             continue;
         }
@@ -787,6 +849,17 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
                 KeyOutcome::ExecuteDelete => {
                     draw_loading(terminal, &mut state, "Deleting gist…")?;
                     delete_gist(&mut state);
+                }
+                KeyOutcome::RefreshLocals => {
+                    draw_loading(terminal, &mut state, "Scanning files…")?;
+                    state.local_scanning = true;
+                    local_rx = Some(spawn_local_scan(
+                        state.cwd.clone(),
+                        state.pinned.clone(),
+                        state.local_recursive,
+                        state.skip_dirs.clone(),
+                        state.scan_depth,
+                    ));
                 }
                 KeyOutcome::None => {}
             }
@@ -1035,11 +1108,17 @@ fn download(state: &mut AppState) {
     }
 }
 
-/// Re-discovers the cwd file list after a write so a freshly downloaded file appears in the
-/// Local pane. The current selection is preserved by path when still present.
+/// Quick flat re-scan used after a download/upload to make the new file visible immediately.
+/// Always non-recursive since downloads only write to cwd root.
 fn refresh_locals(state: &mut AppState) {
     let selected = state.selected_local().map(|c| c.path.clone());
-    if let Ok(locals) = crate::local::discover_local_candidates(&state.cwd, &state.pinned) {
+    if let Ok(locals) = crate::local::discover_local_candidates(
+        &state.cwd,
+        &state.pinned,
+        false,
+        &state.skip_dirs,
+        state.scan_depth,
+    ) {
         state.locals = locals;
         state.local_index = selected
             .and_then(|path| state.locals.iter().position(|c| c.path == path))
@@ -1062,6 +1141,8 @@ fn pin_selected(state: &mut AppState) {
     match result {
         Ok(config) => {
             state.pinned = config.pinned;
+            state.skip_dirs = config.skip_dirs;
+            state.scan_depth = config.scan_depth;
             state.set_status(format!(
                 "Pinned {} <-> {}",
                 local.path.display(),
@@ -1083,6 +1164,8 @@ fn unpin_selected(state: &mut AppState) {
     match result {
         Ok(config) => {
             state.pinned = config.pinned;
+            state.skip_dirs = config.skip_dirs;
+            state.scan_depth = config.scan_depth;
             state.set_status(format!("Unpinned {}", local.path.display()));
         }
         Err(error) => state.set_status(format!("unpin failed: {error}")),
@@ -1262,6 +1345,7 @@ Navigation
   Left/Right scroll a long row horizontally
 
 Gist list
+  r          toggle recursive file discovery (skips hidden + configured dirs)
   /          filter by filename or description
   v          cycle visibility: all / public / secret
   s          cycle sort: match / name / recent
@@ -1321,10 +1405,8 @@ fn render_preview(frame: &mut Frame, state: &AppState) {
     );
 }
 
-fn local_row_label(path: &std::path::Path) -> String {
-    path.file_name()
-        .map(|n| n.to_string_lossy().into_owned())
-        .unwrap_or_else(|| path.display().to_string())
+fn local_row_label(path: &std::path::Path, cwd: &std::path::Path) -> String {
+    path.strip_prefix(cwd).unwrap_or(path).display().to_string()
 }
 
 fn hscroll_str(text: &str, offset: u16) -> String {
@@ -1368,7 +1450,7 @@ fn commands_hint(focus: FocusPane) -> String {
     // Focus-relevant common keys only; the full reference lives in the `?` help overlay.
     let mut items = vec!["Tab panes", "↑↓ move", "Enter diff"];
     match focus {
-        FocusPane::Local => items.extend(["e edit", "n create"]),
+        FocusPane::Local => items.extend(["r recursive", "e edit", "n create"]),
         FocusPane::Gist => items.extend([
             "Space preview",
             "d download",
@@ -1428,20 +1510,34 @@ fn render_list(frame: &mut Frame, state: &AppState) {
         .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
         .split(chunks[0]);
 
-    // Discovery is scoped to the cwd, so each candidate is a direct child; show just the
-    // file name and put the cwd in the pane title as the shared baseline.
-    let local_items: Vec<ListItem> = if state.locals.is_empty() {
+    // Show each candidate's path relative to cwd; in flat mode this is just the filename,
+    // in recursive mode it includes the subdirectory (e.g. src/utils/helpers.rs).
+    let local_items: Vec<ListItem> = if state.local_scanning && state.locals.is_empty() {
+        vec![ListItem::new("(scanning…)")]
+    } else if state.locals.is_empty() {
         vec![ListItem::new("(no files in this directory)")]
     } else {
         state
             .locals
             .iter()
-            .map(|c| ListItem::new(hscroll_str(&local_row_label(&c.path), state.local_hscroll)))
+            .map(|c| {
+                ListItem::new(hscroll_str(
+                    &local_row_label(&c.path, &state.cwd),
+                    state.local_hscroll,
+                ))
+            })
             .collect()
     };
     let local_focused = state.focus == FocusPane::Local;
     let local_selected = (!state.locals.is_empty()).then_some(state.local_index);
-    let local_title = format!("Local · {}", state.cwd.display());
+    let recursive_marker = if state.local_recursive { " [↓]" } else { "" };
+    let scanning_marker = if state.local_scanning { " …" } else { "" };
+    let local_title = format!(
+        "Local · {}{}{}",
+        state.cwd.display(),
+        recursive_marker,
+        scanning_marker
+    );
     render_pane(
         frame,
         columns[0],


### PR DESCRIPTION
## Summary

- `r` key toggles recursive file discovery in the Local pane; the title shows `[↓]` while active
- Recursive scan runs on a **background thread** via mpsc channel — the UI stays responsive while scanning; the pane title shows ` …` until results arrive
- `scan_depth` config field (default `2`) limits how many directory levels are walked, preventing runaway scans in large trees like `~/`
- Post-download flat refresh remains synchronous (always fast, downloads only write to cwd root)
- `skip_dirs` list (already configurable) and `scan_depth` are both documented in `config.example.toml`

## Test plan

- [x] Press `r` in a shallow directory — list updates immediately with nested files
- [x] Press `r` in a deep/large directory (e.g. `~/`) — UI stays interactive, pane shows `…` then updates
- [x] Set `scan_depth = 1` in config — recursive scan only goes one level deep
- [x] Download a gist while recursive mode is on — new file appears in the flat list