### PR TITLE
v0.2.0: mockable gh boundary, install script, prebuilt-binary docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,7 @@ jobs:
           cp "$BIN" "$PKG/"
           cp README.md LICENSE "$PKG/"
           tar -czf "${PKG}.tar.gz" "$PKG"
+          shasum -a 256 "${PKG}.tar.gz" > "${PKG}.tar.gz.sha256"
           echo "ASSET=${PKG}.tar.gz" >> "$GITHUB_ENV"
 
       - name: Package (Windows)
@@ -82,13 +83,17 @@ jobs:
           New-Item -ItemType Directory $pkg
           Copy-Item $bin, README.md, LICENSE $pkg\
           Compress-Archive -Path $pkg -DestinationPath "${pkg}.zip"
+          $hash = (Get-FileHash -Algorithm SHA256 "${pkg}.zip").Hash.ToLower()
+          "$hash  ${pkg}.zip" | Out-File -Encoding ascii "${pkg}.zip.sha256"
           "ASSET=${pkg}.zip" | Out-File -Append $env:GITHUB_ENV
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.target }}
-          path: ${{ env.ASSET }}
+          path: |
+            ${{ env.ASSET }}
+            ${{ env.ASSET }}.sha256
 
   release:
     name: Create GitHub Release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "gistui"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gistui"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "A terminal UI for managing GitHub Gists"

--- a/README.md
+++ b/README.md
@@ -17,8 +17,21 @@ be installed and authenticated wherever you run `gistui`.
 
 ### Download a prebuilt binary (recommended)
 
-Each [release](https://github.com/akunzai/gistui/releases/latest) attaches prebuilt
-binaries — no Rust toolchain required. Pick the archive for your platform:
+Each [release](https://github.com/akunzai/gistui/releases/latest) attaches prebuilt,
+checksummed binaries — no Rust toolchain required.
+
+The install script detects your platform, downloads the matching release asset, verifies
+its SHA-256 checksum, and installs it into `~/.local/bin`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/akunzai/gistui/main/install.sh | bash
+```
+
+It supports Linux (x86-64/ARM64), macOS (Intel/Apple Silicon), and Windows (x86-64) under
+[Git Bash](https://gitforwindows.org)/MSYS2. Pass `--version <tag>` to pin a release or
+`--bin-dir <dir>` to change the install location.
+
+Prefer to install by hand? Grab the archive for your platform from the releases page:
 
 | Platform | Asset |
 |----------|-------|
@@ -28,7 +41,7 @@ binaries — no Rust toolchain required. Pick the archive for your platform:
 | Linux (ARM64) | `gistui-<version>-aarch64-unknown-linux-gnu.tar.gz` |
 | Windows (x86-64) | `gistui-<version>-x86_64-pc-windows-msvc.zip` |
 
-Extract it and put `gistui` somewhere on your `PATH`, e.g. on macOS/Linux:
+Then extract it and put `gistui` somewhere on your `PATH`, e.g. on macOS/Linux:
 
 ```bash
 tar -xzf gistui-<version>-<target>.tar.gz

--- a/README.md
+++ b/README.md
@@ -6,16 +6,39 @@ CLI (`gh`).
 
 ## Requirements
 
-- A Rust toolchain (to build) — <https://rustup.rs>
 - The GitHub CLI: [`gh`](https://cli.github.com), installed and on your `PATH`
 - An authenticated `gh` session: `gh auth login`
+- A Rust toolchain — **only if building from source** — <https://rustup.rs>
 
 `gistui` shells out to `gh` at runtime (it stores no GitHub token of its own), so `gh` must
 be installed and authenticated wherever you run `gistui`.
 
 ## Installation
 
-Install the binary into `~/.cargo/bin` (make sure that directory is on your `PATH`):
+### Download a prebuilt binary (recommended)
+
+Each [release](https://github.com/akunzai/gistui/releases/latest) attaches prebuilt
+binaries — no Rust toolchain required. Pick the archive for your platform:
+
+| Platform | Asset |
+|----------|-------|
+| macOS (Apple Silicon) | `gistui-<version>-aarch64-apple-darwin.tar.gz` |
+| macOS (Intel) | `gistui-<version>-x86_64-apple-darwin.tar.gz` |
+| Linux (x86-64) | `gistui-<version>-x86_64-unknown-linux-gnu.tar.gz` |
+| Linux (ARM64) | `gistui-<version>-aarch64-unknown-linux-gnu.tar.gz` |
+| Windows (x86-64) | `gistui-<version>-x86_64-pc-windows-msvc.zip` |
+
+Extract it and put `gistui` somewhere on your `PATH`, e.g. on macOS/Linux:
+
+```bash
+tar -xzf gistui-<version>-<target>.tar.gz
+install -m 755 gistui-<version>-<target>/gistui ~/.local/bin/gistui
+```
+
+### Build from source
+
+With a Rust toolchain, install into `~/.cargo/bin` (make sure that directory is on your
+`PATH`):
 
 ```bash
 cargo install --path .

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+#
+# gistui installer — downloads the prebuilt release binary for the current
+# platform, verifies its SHA-256 checksum, and installs it onto your PATH.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/akunzai/gistui/main/install.sh | bash
+#
+# Options (as env vars or flags when run directly):
+#   --version <tag>     install a specific release (default: latest)
+#   --bin-dir <dir>     install directory (default: ~/.local/bin)
+#
+# Supported: Linux (x86_64, aarch64), macOS (x86_64, arm64), and Windows
+# (x86_64) under Git Bash / MSYS2.
+
+set -euo pipefail
+
+REPO="akunzai/gistui"
+VERSION="${GISTUI_VERSION:-latest}"
+BIN_DIR="${GISTUI_BIN_DIR:-$HOME/.local/bin}"
+
+err() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version)
+      VERSION="${2:-}"
+      shift 2
+      ;;
+    --bin-dir)
+      BIN_DIR="${2:-}"
+      shift 2
+      ;;
+    -h | --help)
+      sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      err "unknown argument: $1"
+      ;;
+  esac
+done
+
+command -v curl >/dev/null 2>&1 || err "curl is required but was not found on PATH"
+
+# --- Detect platform → Rust target triple, archive format, binary name --------
+os="$(uname -s)"
+arch="$(uname -m)"
+bin_name="gistui"
+case "$os" in
+  Linux) plat="unknown-linux-gnu"; ext="tar.gz" ;;
+  Darwin) plat="apple-darwin"; ext="tar.gz" ;;
+  MINGW* | MSYS* | CYGWIN* | Windows_NT)
+    plat="pc-windows-msvc"
+    ext="zip"
+    bin_name="gistui.exe"
+    ;;
+  *) err "unsupported operating system: $os" ;;
+esac
+case "$arch" in
+  x86_64 | amd64) cpu="x86_64" ;;
+  arm64 | aarch64) cpu="aarch64" ;;
+  *) err "unsupported architecture: $arch" ;;
+esac
+target="${cpu}-${plat}"
+
+if [ "$plat" = "pc-windows-msvc" ] && [ "$cpu" != "x86_64" ]; then
+  err "no prebuilt Windows binary for $cpu (only x86_64 is published)"
+fi
+
+# --- Resolve the release tag --------------------------------------------------
+if [ "$VERSION" = "latest" ]; then
+  effective="$(curl -fsSLI -o /dev/null -w '%{url_effective}' \
+    "https://github.com/$REPO/releases/latest")"
+  case "$effective" in
+    */tag/*) VERSION="${effective##*/tag/}" ;;
+    *) err "could not determine the latest release from: $effective" ;;
+  esac
+fi
+
+pkg="gistui-${VERSION}-${target}"
+archive="${pkg}.${ext}"
+base_url="https://github.com/$REPO/releases/download/${VERSION}"
+
+# --- Download + verify --------------------------------------------------------
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+echo "downloading $archive ($VERSION)..."
+curl -fsSL "$base_url/$archive" -o "$tmp/$archive" \
+  || err "download failed; is $VERSION published for $target?"
+curl -fsSL "$base_url/$archive.sha256" -o "$tmp/$archive.sha256" \
+  || err "checksum download failed for $archive"
+
+echo "verifying checksum..."
+(
+  cd "$tmp"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c "$archive.sha256"
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -c "$archive.sha256"
+  else
+    err "neither sha256sum nor shasum found to verify the download"
+  fi
+) >/dev/null || err "checksum verification failed for $archive"
+
+# --- Extract ------------------------------------------------------------------
+echo "extracting..."
+case "$ext" in
+  tar.gz)
+    tar -xzf "$tmp/$archive" -C "$tmp"
+    ;;
+  zip)
+    if command -v unzip >/dev/null 2>&1; then
+      unzip -q "$tmp/$archive" -d "$tmp"
+    elif command -v powershell >/dev/null 2>&1; then
+      powershell -NoProfile -Command \
+        "Expand-Archive -Force '$(cygpath -w "$tmp/$archive")' '$(cygpath -w "$tmp")'"
+    else
+      err "need unzip or powershell to extract $archive"
+    fi
+    ;;
+esac
+
+# --- Install ------------------------------------------------------------------
+mkdir -p "$BIN_DIR"
+src="$tmp/$pkg/$bin_name"
+[ -f "$src" ] || err "binary not found in archive at $pkg/$bin_name"
+if command -v install >/dev/null 2>&1; then
+  install -m 755 "$src" "$BIN_DIR/$bin_name"
+else
+  cp "$src" "$BIN_DIR/$bin_name"
+  chmod +x "$BIN_DIR/$bin_name" 2>/dev/null || true
+fi
+
+echo "installed gistui $VERSION to $BIN_DIR/$bin_name"
+case ":$PATH:" in
+  *":$BIN_DIR:"*) ;;
+  *) echo "note: $BIN_DIR is not on your PATH — add it to use 'gistui' directly." ;;
+esac
+command -v gh >/dev/null 2>&1 \
+  || echo "note: gistui needs the GitHub CLI ('gh') at runtime — see https://cli.github.com"

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -48,6 +48,52 @@ pub struct CommandPlan {
     pub args: Vec<String>,
 }
 
+/// The captured result of running a [`CommandPlan`], independent of how it was
+/// produced. Mirrors the fields of `std::process::Output` the app actually uses.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandOutput {
+    pub success: bool,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+/// The injectable boundary for every external command (`gh`) the app shells out
+/// to. Production uses [`SystemRunner`]; tests supply a fake so integration tests
+/// exercise command planning, success/failure handling, and output parsing
+/// without touching the network or requiring `gh`.
+pub trait CommandRunner {
+    fn run(&self, plan: &CommandPlan) -> Result<CommandOutput>;
+}
+
+/// The real boundary: spawns the planned program via `std::process::Command`.
+pub struct SystemRunner;
+
+impl CommandRunner for SystemRunner {
+    fn run(&self, plan: &CommandPlan) -> Result<CommandOutput> {
+        let output = Command::new(&plan.program)
+            .args(&plan.args)
+            .output()
+            .with_context(|| format!("run {} {}", plan.program, plan.args.join(" ")))?;
+        Ok(CommandOutput {
+            success: output.status.success(),
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        })
+    }
+}
+
+/// Runs a planned command through `runner`, returning its stdout on success or
+/// the stderr as an error on a non-zero exit. This is the shared execution path
+/// for both write actions (`gh gist edit/create/delete`) and the read fetches in
+/// the `gh` module.
+pub fn run_command(runner: &dyn CommandRunner, plan: &CommandPlan) -> Result<String> {
+    let output = runner.run(plan)?;
+    if !output.success {
+        bail!("{}", output.stderr);
+    }
+    Ok(output.stdout)
+}
+
 pub fn upload_command(local_path: &Path, target: &GistFile) -> CommandPlan {
     CommandPlan {
         program: "gh".into(),
@@ -115,16 +161,7 @@ pub fn delete_command(gist_id: &str) -> CommandPlan {
 }
 
 pub fn execute_command(plan: &CommandPlan) -> Result<String> {
-    let output = Command::new(&plan.program)
-        .args(&plan.args)
-        .output()
-        .with_context(|| format!("run {} {}", plan.program, plan.args.join(" ")))?;
-
-    if !output.status.success() {
-        bail!("{}", String::from_utf8_lossy(&output.stderr));
-    }
-
-    Ok(String::from_utf8(output.stdout)?)
+    run_command(&SystemRunner, plan)
 }
 
 pub fn execute_download(local_path: &Path, content: &str, overwrite_confirmed: bool) -> Result<()> {

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -1,8 +1,8 @@
+use crate::actions::{run_command, CommandPlan, CommandRunner, SystemRunner};
 use crate::domain::GistFile;
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 use std::collections::BTreeMap;
-use std::process::Command;
 
 #[derive(Debug, Deserialize)]
 struct GhGist {
@@ -24,23 +24,64 @@ struct GhGistFile {
     filename: String,
 }
 
+/// Plan for `gh --version` (used to confirm `gh` is installed and runnable).
+pub fn gh_version_plan() -> CommandPlan {
+    CommandPlan {
+        program: "gh".into(),
+        args: vec!["--version".into()],
+    }
+}
+
+/// Plan for `gh auth status` (used to confirm an authenticated session).
+pub fn auth_status_plan() -> CommandPlan {
+    CommandPlan {
+        program: "gh".into(),
+        args: vec!["auth".into(), "status".into()],
+    }
+}
+
+/// Plan for listing every gist via the REST API.
+///
+/// `gh gist list` has no `--json` flag; use the REST API with `--paginate` so
+/// accounts with more than 100 gists are fully retrieved. gh concatenates all
+/// pages into a single JSON array, which `parse_gist_list_json` already handles.
+pub fn gist_list_plan() -> CommandPlan {
+    CommandPlan {
+        program: "gh".into(),
+        args: vec![
+            "api".into(),
+            "--paginate".into(),
+            "/gists?per_page=100".into(),
+        ],
+    }
+}
+
+/// Plan for fetching a single gist file's raw content.
+pub fn gist_view_plan(gist_id: &str, filename: &str) -> CommandPlan {
+    CommandPlan {
+        program: "gh".into(),
+        args: vec![
+            "gist".into(),
+            "view".into(),
+            gist_id.to_string(),
+            "--filename".into(),
+            filename.to_string(),
+            "--raw".into(),
+        ],
+    }
+}
+
 pub fn check_gh_ready() -> Result<()> {
-    let version = Command::new("gh")
-        .arg("--version")
-        .output()
-        .context("run gh --version")?;
-    if !version.status.success() {
+    check_gh_ready_with(&SystemRunner)
+}
+
+pub fn check_gh_ready_with(runner: &dyn CommandRunner) -> Result<()> {
+    if !runner.run(&gh_version_plan())?.success {
         bail!("gh is installed but did not run successfully");
     }
-
-    let auth = Command::new("gh")
-        .args(["auth", "status"])
-        .output()
-        .context("run gh auth status")?;
-    if !auth.status.success() {
+    if !runner.run(&auth_status_plan())?.success {
         bail!("gh auth status failed; run gh auth login");
     }
-
     Ok(())
 }
 
@@ -65,32 +106,23 @@ pub fn parse_gist_list_json(raw: &str) -> Result<Vec<GistFile>> {
 }
 
 pub fn fetch_gist_list_json() -> Result<String> {
-    // `gh gist list` has no `--json` flag; use the REST API with --paginate so
-    // accounts with more than 100 gists are fully retrieved. gh concatenates all
-    // pages into a single JSON array, which parse_gist_list_json already handles.
-    let output = Command::new("gh")
-        .args(["api", "--paginate", "/gists?per_page=100"])
-        .output()
-        .context("run gh api /gists")?;
+    fetch_gist_list_json_with(&SystemRunner)
+}
 
-    if !output.status.success() {
-        bail!("{}", String::from_utf8_lossy(&output.stderr));
-    }
-
-    Ok(String::from_utf8(output.stdout)?)
+pub fn fetch_gist_list_json_with(runner: &dyn CommandRunner) -> Result<String> {
+    run_command(runner, &gist_list_plan())
 }
 
 pub fn fetch_gist_file_content(gist_id: &str, filename: &str) -> Result<String> {
-    let output = Command::new("gh")
-        .args(["gist", "view", gist_id, "--filename", filename, "--raw"])
-        .output()
-        .context("run gh gist view")?;
+    fetch_gist_file_content_with(&SystemRunner, gist_id, filename)
+}
 
-    if !output.status.success() {
-        bail!("{}", String::from_utf8_lossy(&output.stderr));
-    }
-
-    Ok(String::from_utf8(output.stdout)?)
+pub fn fetch_gist_file_content_with(
+    runner: &dyn CommandRunner,
+    gist_id: &str,
+    filename: &str,
+) -> Result<String> {
+    run_command(runner, &gist_view_plan(gist_id, filename))
 }
 
 #[cfg(test)]

--- a/tests/gh_integration.rs
+++ b/tests/gh_integration.rs
@@ -1,0 +1,166 @@
+//! Integration tests for the `gh` command boundary.
+//!
+//! These exercise command planning, success/failure handling, and output
+//! parsing end to end through a fake [`CommandRunner`] implemented here, in a
+//! separate crate from the library — proving the boundary is genuinely
+//! injectable. No test touches the network or requires `gh` to be installed.
+
+use std::cell::RefCell;
+use std::collections::VecDeque;
+use std::path::PathBuf;
+
+use gistui::actions::{run_command, upload_command, CommandOutput, CommandPlan, CommandRunner};
+use gistui::domain::GistFile;
+use gistui::gh::{
+    auth_status_plan, check_gh_ready_with, fetch_gist_file_content_with, fetch_gist_list_json_with,
+    gh_version_plan, gist_list_plan, gist_view_plan, parse_gist_list_json,
+};
+
+/// A scripted runner: returns queued outputs in order and records every plan it
+/// received so tests can assert which `gh` command would have run.
+struct FakeRunner {
+    queue: RefCell<VecDeque<CommandOutput>>,
+    calls: RefCell<Vec<CommandPlan>>,
+}
+
+impl FakeRunner {
+    fn new(outputs: Vec<CommandOutput>) -> Self {
+        FakeRunner {
+            queue: RefCell::new(outputs.into()),
+            calls: RefCell::new(Vec::new()),
+        }
+    }
+
+    fn ok(stdout: &str) -> CommandOutput {
+        CommandOutput {
+            success: true,
+            stdout: stdout.to_string(),
+            stderr: String::new(),
+        }
+    }
+
+    fn fail(stderr: &str) -> CommandOutput {
+        CommandOutput {
+            success: false,
+            stdout: String::new(),
+            stderr: stderr.to_string(),
+        }
+    }
+}
+
+impl CommandRunner for FakeRunner {
+    fn run(&self, plan: &CommandPlan) -> anyhow::Result<CommandOutput> {
+        self.calls.borrow_mut().push(plan.clone());
+        Ok(self
+            .queue
+            .borrow_mut()
+            .pop_front()
+            .expect("FakeRunner ran out of scripted outputs"))
+    }
+}
+
+const GIST_LIST_JSON: &str = include_str!("fixtures/gh/gist-list.json");
+
+#[test]
+fn fetch_and_parse_gist_list_via_fake_runner() {
+    let runner = FakeRunner::new(vec![FakeRunner::ok(GIST_LIST_JSON)]);
+
+    let raw = fetch_gist_list_json_with(&runner).unwrap();
+    let files = parse_gist_list_json(&raw).unwrap();
+
+    assert_eq!(files.len(), 3);
+    assert_eq!(runner.calls.borrow()[0], gist_list_plan());
+}
+
+#[test]
+fn fetch_gist_list_surfaces_stderr_on_failure() {
+    let runner = FakeRunner::new(vec![FakeRunner::fail("HTTP 401: Bad credentials")]);
+
+    let err = fetch_gist_list_json_with(&runner).unwrap_err();
+    assert!(err.to_string().contains("Bad credentials"));
+}
+
+#[test]
+fn fetch_gist_file_content_returns_stdout_and_plans_view() {
+    let runner = FakeRunner::new(vec![FakeRunner::ok("hello = true\n")]);
+
+    let content = fetch_gist_file_content_with(&runner, "abc123", "config.toml").unwrap();
+
+    assert_eq!(content, "hello = true\n");
+    assert_eq!(
+        runner.calls.borrow()[0],
+        gist_view_plan("abc123", "config.toml")
+    );
+}
+
+#[test]
+fn fetch_gist_file_content_surfaces_stderr_on_failure() {
+    let runner = FakeRunner::new(vec![FakeRunner::fail("could not find gist")]);
+
+    let err = fetch_gist_file_content_with(&runner, "missing", "x").unwrap_err();
+    assert!(err.to_string().contains("could not find gist"));
+}
+
+#[test]
+fn check_gh_ready_passes_when_version_and_auth_succeed() {
+    let runner = FakeRunner::new(vec![FakeRunner::ok(""), FakeRunner::ok("")]);
+
+    assert!(check_gh_ready_with(&runner).is_ok());
+
+    let calls = runner.calls.borrow();
+    assert_eq!(calls[0], gh_version_plan());
+    assert_eq!(calls[1], auth_status_plan());
+}
+
+#[test]
+fn check_gh_ready_fails_when_gh_missing() {
+    let runner = FakeRunner::new(vec![FakeRunner::fail("command not found")]);
+
+    let err = check_gh_ready_with(&runner).unwrap_err();
+    assert!(err.to_string().contains("did not run successfully"));
+    // Auth is never probed once the version check fails.
+    assert_eq!(runner.calls.borrow().len(), 1);
+}
+
+#[test]
+fn check_gh_ready_fails_when_unauthenticated() {
+    let runner = FakeRunner::new(vec![FakeRunner::ok(""), FakeRunner::fail("not logged in")]);
+
+    let err = check_gh_ready_with(&runner).unwrap_err();
+    assert!(err.to_string().contains("gh auth login"));
+}
+
+#[test]
+fn run_command_executes_planned_write_action() {
+    let target = GistFile {
+        gist_id: "abc123".into(),
+        description: "config".into(),
+        filename: "settings.json".into(),
+        public: false,
+        updated_at: "2026-06-08T00:00:00Z".into(),
+    };
+    let plan = upload_command(PathBuf::from("/tmp/settings.json").as_path(), &target);
+    let runner = FakeRunner::new(vec![FakeRunner::ok("https://gist.github.com/abc123\n")]);
+
+    let stdout = run_command(&runner, &plan).unwrap();
+
+    assert!(stdout.contains("gist.github.com"));
+    assert_eq!(runner.calls.borrow()[0], plan);
+}
+
+#[test]
+fn run_command_surfaces_stderr_on_failure() {
+    let plan = CommandPlan {
+        program: "gh".into(),
+        args: vec![
+            "gist".into(),
+            "delete".into(),
+            "--yes".into(),
+            "nope".into(),
+        ],
+    };
+    let runner = FakeRunner::new(vec![FakeRunner::fail("gist not found")]);
+
+    let err = run_command(&runner, &plan).unwrap_err();
+    assert!(err.to_string().contains("gist not found"));
+}


### PR DESCRIPTION
Prepares the v0.2.0 release.

## Changes

### Mockable `gh` boundary + integration tests (closes #12)
- Introduce a `CommandRunner` trait (`SystemRunner` real impl) so every `gh` subprocess call routes through an injectable seam.
- `gh` read fns now build pure `CommandPlan`s and execute via `run_command`; the no-arg public fns stay as `SystemRunner` wrappers, so existing call sites are unchanged.
- New `tests/gh_integration.rs`: a `FakeRunner` implemented **outside the crate** exercises the list/view/auth/write flows and stderr error propagation — no network, no `gh` required.
- One deliberate behavior change: the exec path now uses `String::from_utf8_lossy` instead of strict `from_utf8` (more robust, no regression for valid UTF-8).

### Cross-platform install script with checksum verification
- `install.sh` detects platform (Linux/macOS + **Windows under Git Bash/MSYS2**), downloads the matching release asset, **verifies its SHA-256**, and installs onto `PATH`. Supports `--version` / `--bin-dir`.
- `release.yml` now emits a `.sha256` beside each archive and uploads both.
- README: one-line `curl … | bash` install, Git Bash note, manual-download table retained as fallback.

### Release prep
- Bump version `0.1.0` → `0.2.0`.

## Verification
- `cargo fmt --check`, `cargo check`, `cargo clippy --all-targets -- -D warnings` clean.
- `cargo test`: 117 unit + 9 integration tests pass.
- `install.sh`: `bash -n`, `shellcheck`, and `release.yml` `actionlint` all pass.

## Follow-ups (tracked)
- #32 UI polish → #33 demo GIF
- #34 crates.io / Homebrew
- #35 CHANGELOG.md