### PR TITLE
ci: categorize release notes by PR label

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+# Categories for GitHub's auto-generated release notes. The release workflow sets
+# `generate_release_notes: true`, so merged PRs are grouped by the labels below —
+# every PR should carry exactly one category label (see CONTRIBUTING.md).
+# Docs: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+  categories:
+    - title: Features
+      labels:
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: Other Changes
+      labels:
+        - "*"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Pure, testable domain logic is kept separate from impure shell/filesystem adapte
 
 - Commit messages: Conventional Commits, in English (e.g. `feat:`, `docs:`, `fix:`).
 - Fold same-scope follow-up fixes into the original commit (amend) rather than adding `fix typo` / `review fix` commits.
+- Every PR MUST carry a release-note category label (`enhancement`, `bug`, `documentation`, `dependencies`, or `skip-changelog`) — GitHub groups auto-generated release notes by these via `.github/release.yml`.
 
 ## Claude Code compatibility
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,7 @@ Key points:
 1. Fork and create a branch (`feat/my-feature` or `fix/issue-123`).
 2. Keep commits focused; follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `chore:`).
 3. Open a PR against `main`; the CI gate must be green.
+4. **Label the PR** so it lands in the right release-note section (`.github/release.yml`): `enhancement` (Features), `bug` (Bug Fixes), `documentation` (Documentation), `dependencies`, or `skip-changelog` to omit it. Unlabeled PRs fall under "Other Changes".
 
 ## Reporting Issues
 


### PR DESCRIPTION
## What

Group GitHub's auto-generated release notes by PR label, and require every PR to carry a category label.

- **`.github/release.yml`** — maps PR labels to release-note sections: Features (`enhancement`), Bug Fixes (`bug`), Documentation (`documentation`), Dependencies (`dependencies`), Other Changes (`*`); `skip-changelog` opts a PR out. Works with the existing `generate_release_notes: true` in `release.yml` — no workflow change needed.
- **CONTRIBUTING.md / AGENTS.md** — document the PR-labeling requirement.
- New `skip-changelog` repo label.

## Why

Resolves #35. We decided against a hand-maintained CHANGELOG.md (gistui is a binary, not a depended-on crate — it would only duplicate the already-auto-generated GitHub Release notes) and against release-drafter (overlaps with `generate_release_notes`). This keeps the native generator and just categorizes its output.

## Notes

- Only affects **PR-based** merges; direct-to-`main` commits won't be categorized.
- This PR is labeled `skip-changelog` (release-tooling meta, not a user-facing change).

Closes #35