### PR TITLE
feat: create gist with a description (+ README/docs catch-up)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,7 @@ Pure, testable domain logic is kept separate from impure shell/filesystem adapte
 - Commit messages: Conventional Commits, in English (e.g. `feat:`, `docs:`, `fix:`).
 - Fold same-scope follow-up fixes into the original commit (amend) rather than adding `fix typo` / `review fix` commits.
 - Every PR MUST carry a release-note category label (`enhancement`, `bug`, `documentation`, `dependencies`, or `skip-changelog`) — GitHub groups auto-generated release notes by these via `.github/release.yml`.
+- When a change adds or alters a user-facing key, screen, or feature, update `README.md` (the Actions/keymap and Safety sections) and the `?` help text in `tui.rs` **in the same PR** — keep docs and behavior in lockstep.
 
 ## Claude Code compatibility
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,13 +29,13 @@ Pure, testable domain logic is kept separate from impure shell/filesystem adapte
 
 - Pure modules (unit-tested): `domain`, `config`, `ranking`, `local`, `diff`, and the command-planning/guard parts of `actions`.
 - Thin IO boundaries (not unit-tested by design): `gh` (`gh` subprocess calls), the `actions` execute helpers, and the IO helper fns in `tui::run_loop`.
-- `tui.rs` is a screen state machine (`Screen::{List, Diff, ConfirmOverwrite}`). `AppState::handle_key` is **pure** — it mutates state and returns a `KeyOutcome` intent; `run_loop` performs the IO for `PreviewDiff`/`Download`/`DownloadGist`. Keep new key logic in `handle_key` (testable) and new IO in `run_loop` helpers.
+- `tui.rs` is a screen state machine (`Screen::{List, Diff, Confirm, Preview, Help, Pins, Gists}`; `Gists` is the gist-level manager). `AppState::handle_key` is **pure** — it mutates state and returns a `KeyOutcome` intent; `run_loop` performs the IO (fetch/download/upload/create/delete/remove-file/edit-description). Keep new key logic in `handle_key` (testable) and new IO in `run_loop` helpers.
 - `run()` wraps `run_loop()` so terminal teardown (raw mode / alternate screen) ALWAYS runs, even on error — keep fallible startup/IO inside `run_loop`, never between `enable_raw_mode` and the teardown.
 
 ## Non-Obvious Rules
 
 - Tests must never call the real `gh` or the network. `gh` JSON parsing is tested against fixtures in `tests/fixtures/gh/`; IO functions are left as thin untested boundaries.
-- Downloads only write to `cwd/<gist-filename>`. The overwrite gate is the invariant to preserve: an *existing* target is never overwritten without first showing its diff and a `y/n` confirmation (`Screen::ConfirmOverwrite`); writing a path that does not yet exist is allowed directly (no diff forced). Do not add a write path that overwrites an existing file without that diff+confirm.
+- Downloads only write to `cwd/<gist-filename>`. The overwrite gate is the invariant to preserve: an *existing* target is never overwritten without first showing its diff and a `y/n` confirmation (`Screen::Confirm`); writing a path that does not yet exist is allowed directly (no diff forced). Do not add a write path that overwrites an existing file without that diff+confirm.
 - No GitHub tokens are stored by the app, and gist *content* is never written to the config file (`~/.config/gistui/config.toml`, XDG-aware). The config holds only `pinned` mappings and `skip_dirs`. See `config.example.toml` for the annotated schema.
 - Use `frame.area()` (not `frame.size()`, which was removed in ratatui 0.28). The project now pins ratatui 0.30.
 - `Rect::inner` takes `Margin` by value (not `&Margin`) since ratatui 0.28.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # gistui
 
-A terminal UI for managing GitHub Gists. Browse, diff, download, upload, create, and pin
-your gists — and pair them with files in your working directory — all through the GitHub
-CLI (`gh`).
+A terminal UI for managing GitHub Gists. Browse, diff, download, upload, create, edit, and
+pin your gists — and pair them with files in your working directory — all through the
+GitHub CLI (`gh`).
 
 ## Requirements
 
@@ -90,12 +90,16 @@ gists, ranked against the selected local file (stronger matches are prefixed wit
   confirmation.
 - `u` (on a gist) — upload the selected local file into the gist under the local file's
   name (added directly, or diff + `y`/`n` if it would overwrite a same-named gist file).
-- `n` (on a local file) — create a new gist from it; choose `s` secret or `p` public.
-- `X` (on a gist) — delete the gist after a preview + `y`/`n` confirmation.
+- `n` (on a local file) — create a new gist from it: type an optional description, then
+  choose `s` secret or `p` public.
+- `X` (on a gist) — remove the selected file from its gist after a `y`/`n` confirmation.
+  Deleting a whole gist lives in the **gist manager** (`g`); a gist's only file can't be
+  removed (delete the gist instead).
+- `g` — open the **gist manager** (gist-level view): edit descriptions, delete gists, and
+  more (see below).
 - `p` (on a gist) — toggle a pin between the selected local file and gist (persisted to
   config; pinned pairs sort to the top).
 - `P` — open the **Pins view** listing all pinned pairs; `x` unpins the selected entry.
-- `o` (on a gist) — open it on gist.github.com in your browser.
 - `e` (on a local file) — open it in `$VISUAL`/`$EDITOR`.
 - `Space` (on a gist) — preview the gist's raw content in a scrollable overlay (`R` to
   force-refresh, bypassing the session cache).
@@ -108,6 +112,18 @@ gists, ranked against the selected local file (stronger matches are prefixed wit
 When no local file is selected (e.g. an empty directory), the right pane lists all gists
 unranked so you can still preview and download into the current directory.
 
+### Gist manager (`g`)
+
+Press `g` to open the **gist manager** — a gist-level view (one row per gist) that lands on
+the gist owning the currently selected file. From here you manage gists as a whole:
+
+- `e` — edit the gist's description (type, `Enter` applies, `Esc` cancels).
+- `X` — delete the entire gist and all its files, after a `y`/`n` confirmation.
+- `o` — open the gist on gist.github.com in your browser.
+- `s` cycle sort (updated / created) · `v` cycle visibility (all/public/secret) · `/` filter
+  by description or id · `Left`/`Right` scroll a long description.
+- `q`/`Esc` — back to the list.
+
 ## Safety rules
 
 - Downloads only ever write to `./<gist-filename>` in the current working directory.
@@ -115,6 +131,8 @@ unranked so you can still preview and download into the current directory.
   first showing its diff and a `y`/`n` confirmation. Writing something that does not yet
   exist is direct.
 - Identical files are detected: when the two sides match, upload/download are disabled.
+- Destructive remote actions each require a `y`/`n` confirmation: removing a file from a
+  gist (`X` on the list) and deleting a whole gist (`X` in the gist manager).
 - No GitHub token is stored by the app, and gist content is never written to the config
   file — only path↔gist pin mappings are persisted.
 

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -133,7 +133,7 @@ pub fn open_browser_command(gist_id: &str) -> CommandPlan {
     }
 }
 
-pub fn create_command(local_path: &Path, public: bool) -> CommandPlan {
+pub fn create_command(local_path: &Path, public: bool, description: &str) -> CommandPlan {
     let mut args = vec![
         "gist".into(),
         "create".into(),
@@ -141,6 +141,10 @@ pub fn create_command(local_path: &Path, public: bool) -> CommandPlan {
     ];
     if public {
         args.push("--public".into());
+    }
+    if !description.is_empty() {
+        args.push("--desc".into());
+        args.push(description.to_string());
     }
     CommandPlan {
         program: "gh".into(),
@@ -379,9 +383,31 @@ mod tests {
 
     #[test]
     fn create_command_defaults_to_secret() {
-        let plan = create_command(PathBuf::from("/tmp/settings.json").as_path(), false);
+        let plan = create_command(PathBuf::from("/tmp/settings.json").as_path(), false, "");
         assert_eq!(plan.args, vec!["gist", "create", "/tmp/settings.json"]);
         assert!(!plan.args.contains(&"--public".to_string()));
+    }
+
+    #[test]
+    fn create_command_includes_public_and_description() {
+        let plan = create_command(PathBuf::from("/tmp/notes.md").as_path(), true, "my notes");
+        assert_eq!(
+            plan.args,
+            vec![
+                "gist",
+                "create",
+                "/tmp/notes.md",
+                "--public",
+                "--desc",
+                "my notes"
+            ]
+        );
+    }
+
+    #[test]
+    fn create_command_omits_desc_flag_when_description_empty() {
+        let plan = create_command(PathBuf::from("/tmp/notes.md").as_path(), false, "");
+        assert!(!plan.args.contains(&"--desc".to_string()));
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -809,6 +809,16 @@ impl AppState {
                     self.status = Some("select a local file to create a gist".into());
                     return KeyOutcome::None;
                 };
+                // Create is a two-step confirm: type an optional description (inline
+                // editor, shared with the gist-level view), then choose visibility.
+                self.diff_text = format!(
+                    "Create a new gist from {}.\n\nType an optional description, then choose visibility.",
+                    local.path.display()
+                );
+                self.diff_scroll = 0;
+                self.diff_hscroll = 0;
+                self.editing_description = true;
+                self.description_input.clear();
                 self.pending_action = Some(PendingAction::Create {
                     local_path: local.path,
                 });
@@ -879,12 +889,28 @@ impl AppState {
                 }
                 _ => {}
             },
+            Some(PendingAction::Create { .. }) if self.editing_description => match code {
+                // Step 1: type the optional description. Enter advances to the
+                // visibility choice; Esc cancels the whole create.
+                KeyCode::Enter => self.editing_description = false,
+                KeyCode::Esc => {
+                    self.editing_description = false;
+                    self.description_input.clear();
+                    self.back_to_list();
+                }
+                KeyCode::Backspace => {
+                    self.description_input.pop();
+                }
+                KeyCode::Char(c) => self.description_input.push(c),
+                _ => {}
+            },
             Some(PendingAction::Create { .. }) => match code {
+                // Step 2: choose visibility (the description is kept in description_input).
                 KeyCode::Char('s') => return KeyOutcome::Create(false),
                 KeyCode::Char('p') => return KeyOutcome::Create(true),
                 KeyCode::Char('n') | KeyCode::Char('q') | KeyCode::Esc => {
-                    self.pending_action = None;
-                    self.screen = Screen::List;
+                    self.description_input.clear();
+                    self.back_to_list();
                 }
                 _ => {}
             },
@@ -1642,7 +1668,8 @@ fn create_gist(state: &mut AppState, public: bool) {
     let Some(PendingAction::Create { local_path }) = state.pending_action.clone() else {
         return;
     };
-    let plan = crate::actions::create_command(&local_path, public);
+    let description = state.description_input.clone();
+    let plan = crate::actions::create_command(&local_path, public, &description);
     match crate::actions::execute_command(&plan) {
         Ok(_) => {
             let visibility = if public { "public" } else { "secret" };
@@ -1651,6 +1678,7 @@ fn create_gist(state: &mut AppState, public: bool) {
                 visibility,
                 local_path.display()
             ));
+            state.description_input.clear();
             state.back_to_list();
             refresh_gists(state);
         }
@@ -1658,6 +1686,7 @@ fn create_gist(state: &mut AppState, public: bool) {
             state.set_status(format!("create failed: {error}"));
             state.screen = Screen::List;
             state.pending_action = None;
+            state.description_input.clear();
         }
     }
 }
@@ -1752,7 +1781,7 @@ Actions (on the selected local file + gist)
   Space      preview the gist file's content (R in preview to force-refresh)
   d          download the gist into the cwd
   u          upload the local file into the gist
-  n          create a new gist from the local file
+  n          create a new gist from the local file (type a description, then s/p)
   p          pin / unpin the local <-> gist pair
   P          view / manage all pinned mappings (x to unpin)
   X          remove the selected file from its gist (y/n confirm)
@@ -2429,10 +2458,23 @@ fn render_diff(frame: &mut Frame, state: &AppState, confirming: bool) {
 
     let footer = if confirming {
         match &state.pending_action {
-            Some(PendingAction::Create { local_path }) => format!(
-                "Create gist from {}?  s secret  p public  Esc cancel",
-                local_path.display()
-            ),
+            Some(PendingAction::Create { .. }) if state.editing_description => {
+                format!(
+                    "Description (optional): {}_   ·  Enter next  ·  Esc cancel",
+                    state.description_input
+                )
+            }
+            Some(PendingAction::Create { local_path }) => {
+                let desc = if state.description_input.is_empty() {
+                    "no description".to_string()
+                } else {
+                    format!("desc: {}", state.description_input)
+                };
+                format!(
+                    "Create gist from {} ({desc})?  s secret  p public  Esc cancel",
+                    local_path.display()
+                )
+            }
             Some(PendingAction::Upload {
                 gist_id, filename, ..
             }) => {
@@ -3814,5 +3856,57 @@ mod tests {
         assert_eq!(state.handle_key(KeyCode::Esc), KeyOutcome::None);
         assert_eq!(state.screen, Screen::List);
         assert_eq!(state.pending_action, None);
+    }
+
+    fn state_ready_to_create() -> AppState {
+        let mut state = initial_state();
+        state.locals = vec![LocalCandidate {
+            path: PathBuf::from("/tmp/config.toml"),
+            pinned: false,
+        }];
+        state
+    }
+
+    #[test]
+    fn n_starts_create_in_the_description_editor() {
+        let mut state = state_ready_to_create();
+        state.handle_key(KeyCode::Char('n'));
+        assert_eq!(state.screen, Screen::Confirm);
+        assert!(state.editing_description);
+        // While editing, letters (incl. s/p) are typed into the description, not
+        // interpreted as the visibility choice.
+        for c in "notes".chars() {
+            assert_eq!(state.handle_key(KeyCode::Char(c)), KeyOutcome::None);
+        }
+        assert_eq!(state.description_input, "notes");
+    }
+
+    #[test]
+    fn create_enter_advances_to_visibility_then_s_creates() {
+        let mut state = state_ready_to_create();
+        state.handle_key(KeyCode::Char('n'));
+        state.handle_key(KeyCode::Char('h'));
+        state.handle_key(KeyCode::Char('i'));
+        // Enter ends the description step (does not create yet).
+        assert_eq!(state.handle_key(KeyCode::Enter), KeyOutcome::None);
+        assert!(!state.editing_description);
+        assert_eq!(state.description_input, "hi");
+        // Now s/p choose visibility and trigger the create.
+        assert_eq!(
+            state.handle_key(KeyCode::Char('s')),
+            KeyOutcome::Create(false)
+        );
+    }
+
+    #[test]
+    fn create_esc_while_editing_description_cancels() {
+        let mut state = state_ready_to_create();
+        state.handle_key(KeyCode::Char('n'));
+        state.handle_key(KeyCode::Char('x'));
+        assert_eq!(state.handle_key(KeyCode::Esc), KeyOutcome::None);
+        assert_eq!(state.screen, Screen::List);
+        assert_eq!(state.pending_action, None);
+        assert!(!state.editing_description);
+        assert!(state.description_input.is_empty());
     }
 }


### PR DESCRIPTION
Closes #38.

## What

Creating a gist (`n`) now lets you set a description, **and** this PR catches the docs up to the recently merged gist manager (#37).

### Feature (#38)
- `n` opens an inline **description editor** (the same widget added in #37): type an optional description, `Enter` to advance, `Esc` to cancel.
- Then choose visibility: `s` secret / `p` public.
- Passed through as `gh gist create --desc <text>` when non-empty (omitted when blank).

### Docs catch-up
README was out of sync after #37 merged; this PR fixes it (and a stale note in AGENTS.md):
- Documents the **gist manager** (`g`): edit description, delete whole gist, open in browser, sort updated/created, visibility filter, text filter, horizontal scroll.
- Corrects `X` on the main list — now **removes a single file** (whole-gist delete moved to `g`); notes the only-file guard.
- Moves `o` (browser) into the gist manager section.
- `n` create now documents the description step.
- AGENTS.md `Screen` list updated (adds Confirm/Preview/Help/Pins/Gists; `ConfirmOverwrite` → `Confirm`).

## Tests
- `create_command(local_path, public, description)`: `--desc` included when set, omitted when empty.
- New key-flow tests for the two-step create (`n` → description editor → `Enter` → `s`/`p`), plus `Esc`-cancel while editing.
- Full gate green: `cargo fmt --check`, `cargo test` (146), `cargo check`, `cargo clippy --all-targets -D warnings`.

## Not covered (by design)
The actual `gh gist create` invocation is a thin IO boundary, exercised manually.