### PR TITLE
feat: show version and repository link in the help screen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.0"
 edition = "2021"
 license = "MIT"
 description = "A terminal UI for managing GitHub Gists"
+repository = "https://github.com/akunzai/gistui"
 
 [dependencies]
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ gistui --check    # print gh readiness, then exit (no TUI)
 ```
 
 Run `gistui` from the directory whose files you want to pair with your gists. Inside the
-TUI press `?` for the full keymap; the footer shows the keys relevant to the focused pane.
+TUI press `?` for the full keymap (it also shows the running version and the project
+repository link); the footer shows the keys relevant to the focused pane.
 
 The left pane lists the files in your current working directory; the right pane lists your
 gists, ranked against the selected local file (stronger matches are prefixed with stars:

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1763,7 +1763,12 @@ fn render(frame: &mut Frame, state: &AppState) {
 }
 
 fn render_help(frame: &mut Frame) {
-    let text = "\
+    let about = format!(
+        "gistui v{}  ·  {}",
+        env!("CARGO_PKG_VERSION"),
+        env!("CARGO_PKG_REPOSITORY")
+    );
+    let body = "\
 Navigation
   Tab        switch pane (Local / Gists)
   Up/Down    move the selection
@@ -1803,6 +1808,7 @@ General
   Esc / q    close an overlay; from the list, quit the app
   ?          show this help";
 
+    let text = format!("{about}\n\n{body}");
     frame.render_widget(
         Paragraph::new(text).block(
             Block::default()
@@ -2510,6 +2516,13 @@ fn render_diff(frame: &mut Frame, state: &AppState, confirming: bool) {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    #[test]
+    fn about_metadata_is_available_for_help() {
+        // The help/About header renders these; guard against dropping them from Cargo.toml.
+        assert!(!env!("CARGO_PKG_VERSION").is_empty());
+        assert!(env!("CARGO_PKG_REPOSITORY").contains("github.com/akunzai/gistui"));
+    }
 
     #[test]
     fn tab_switches_focus() {


### PR DESCRIPTION
Closes #40.

## What

The `?` help screen now opens with an About line — `gistui v<version>  ·  <repo url>` — sourced from `env!("CARGO_PKG_VERSION")` and `env!("CARGO_PKG_REPOSITORY")`. There was previously no in-app way to see the running version or the project link.

- Adds `repository = "https://github.com/akunzai/gistui"` to `Cargo.toml` (also useful for the future crates.io publish, #34).
- README notes that `?` now surfaces the version and repo link.
- Guard test (`about_metadata_is_available_for_help`) so the version/repo metadata can't silently disappear from `Cargo.toml`.

## Tests
Full gate green: `cargo fmt --check`, `cargo test` (147), `cargo check`, `cargo clippy --all-targets -D warnings`.

## Not covered (by design)
`render_help` itself is a render/IO boundary, exercised manually; the test guards the metadata it depends on.