### PR TITLE
feat: edit/redact file before upload and add JSON pretty-print and key sorting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,6 +1450,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ crossterm = "0.29"
 dirs = "6"
 ratatui = "0.30"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde_json = { version = "1", features = ["preserve_order"] }
 sha2 = "0.11"
 similar = "3"
 toml = "1.1"

--- a/README.md
+++ b/README.md
@@ -93,7 +93,10 @@ selected gist instead. Browse with `Tab` (switch pane), `Up`/`Down` (move), and
   written directly; an existing one is shown as a diff and overwritten only after a `y`/`n`
   confirmation.
 - `u` (on a gist) — upload the selected local file into the gist under the local file's
-  name (added directly, or diff + `y`/`n` if it would overwrite a same-named gist file).
+  name (shows a confirmation screen with unified diff). From there:
+  - `y` / `n` / `Esc` — confirm and upload / cancel.
+  - `e` — edit / redact the upload content in `$EDITOR` before upload (does NOT mutate the local file).
+  - `p` / `s` — (JSON only) toggle pretty-print / recursive key sorting on the upload buffer.
 - `n` (on a local file) — create a new gist from it: type an optional description, then
   choose `s` secret or `p` public.
 - `X` (on a gist) — remove the selected file from its gist after a `y`/`n` confirmation.
@@ -134,8 +137,8 @@ the gist owning the currently selected file. From here you manage gists as a who
 
 - Downloads only ever write to `./<gist-filename>` in the current working directory.
 - An existing file (local download target or remote gist file) is never overwritten without
-  first showing its diff and a `y`/`n` confirmation. Writing something that does not yet
-  exist is direct.
+  first showing its diff and confirmation.
+- Uploads allow editing/redacting a temporary buffer in `$EDITOR` before sending, ensuring sensitive local content or credentials are not accidentally pushed to GitHub.
 - Identical files are detected: when the two sides match, upload/download are disabled.
 - Destructive remote actions each require a `y`/`n` confirmation: removing a file from a
   gist (`X` on the list) and deleting a whole gist (`X` in the gist manager).

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -110,3 +110,88 @@ mod tests {
         assert!(group_gists(&[]).is_empty());
     }
 }
+
+pub fn transform_json(
+    content: &str,
+    pretty: bool,
+    sort: bool,
+) -> Result<String, serde_json::Error> {
+    if !pretty && !sort {
+        return Ok(content.to_string());
+    }
+    let mut val: serde_json::Value = serde_json::from_str(content)?;
+    if sort {
+        val = sort_json_value(val);
+    }
+    if pretty {
+        serde_json::to_string_pretty(&val)
+    } else {
+        serde_json::to_string(&val)
+    }
+}
+
+pub fn sort_json_value(value: serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Object(map) => {
+            let mut entries: Vec<(String, serde_json::Value)> = map
+                .into_iter()
+                .map(|(k, v)| (k, sort_json_value(v)))
+                .collect();
+            entries.sort_by(|a, b| a.0.cmp(&b.0));
+            let mut sorted_map = serde_json::Map::new();
+            for (k, v) in entries {
+                sorted_map.insert(k, v);
+            }
+            serde_json::Value::Object(sorted_map)
+        }
+        serde_json::Value::Array(arr) => {
+            serde_json::Value::Array(arr.into_iter().map(sort_json_value).collect())
+        }
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod json_tests {
+    use super::*;
+
+    #[test]
+    fn test_transform_json_noop() {
+        let input = r#"{"z":1,"a":2}"#;
+        let output = transform_json(input, false, false).unwrap();
+        assert_eq!(output, input);
+    }
+
+    #[test]
+    fn test_transform_json_pretty_only() {
+        let input = r#"{"z":1,"a":2}"#;
+        let output = transform_json(input, true, false).unwrap();
+        // Should be formatted, but preserve original key order ("z" then "a")
+        let expected = "{\n  \"z\": 1,\n  \"a\": 2\n}";
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn test_transform_json_sort_only() {
+        let input = r#"{"z":1,"a":2}"#;
+        let output = transform_json(input, false, true).unwrap();
+        // Should be compact, but sorted keys ("a" then "z")
+        assert_eq!(output, r#"{"a":2,"z":1}"#);
+    }
+
+    #[test]
+    fn test_transform_json_pretty_and_sort() {
+        let input = r#"{"z":1,"a":{"y":3,"x":4}}"#;
+        let output = transform_json(input, true, true).unwrap();
+        // Should be formatted, and keys sorted recursively ("a" then "z", and "x" then "y")
+        let expected = "{\n  \"a\": {\n    \"x\": 4,\n    \"y\": 3\n  },\n  \"z\": 1\n}";
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn test_transform_json_invalid() {
+        let input = r#"{"z":1,"a":}"#;
+        let result = transform_json(input, true, true);
+        assert!(result.is_err());
+    }
+}

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -219,6 +219,7 @@ pub enum KeyOutcome {
     OpenBrowser,
     OpenRepoBrowser,
     EditLocal,
+    EditUpload,
     ExecuteDelete,
     ExecuteRemoveFile,
     ApplyDescription,
@@ -274,6 +275,13 @@ pub struct AppState {
     pub description_input: String,
     pub bg_task_msg: Option<String>,
     pub help_scroll: u16,
+    pub upload_original_content: String,
+    pub upload_edited_content: Option<String>,
+    pub upload_json_pretty: bool,
+    pub upload_json_sort: bool,
+    pub upload_remote_content: Option<String>,
+    pub upload_local_label: Option<String>,
+    pub upload_gist_label: Option<String>,
 }
 
 fn unranked_gists(gists: Vec<GistFile>) -> Vec<RankedGistFile> {
@@ -300,6 +308,63 @@ fn unranked_locals(locals: &[LocalCandidate]) -> Vec<RankedLocal> {
 }
 
 impl AppState {
+    pub fn upload_local_path(&self) -> Option<std::path::PathBuf> {
+        match &self.pending_action {
+            Some(PendingAction::Upload { local_path, .. }) => Some(local_path.clone()),
+            _ => None,
+        }
+    }
+
+    pub fn content_to_upload(&self) -> String {
+        let base = self
+            .upload_edited_content
+            .as_ref()
+            .unwrap_or(&self.upload_original_content);
+        if let Some(local_path) = self.upload_local_path() {
+            if is_json_file(&local_path) {
+                if let Ok(transformed) = crate::domain::transform_json(
+                    base,
+                    self.upload_json_pretty,
+                    self.upload_json_sort,
+                ) {
+                    return transformed;
+                }
+            }
+        }
+        base.clone()
+    }
+
+    pub fn update_upload_diff(&mut self) {
+        let local_content = self.content_to_upload();
+        let remote = self
+            .upload_remote_content
+            .as_ref()
+            .cloned()
+            .unwrap_or_default();
+        let local_label = self.upload_local_label.clone().unwrap_or_default();
+        let gist_label = self.upload_gist_label.clone().unwrap_or_default();
+
+        let diff = crate::diff::unified_diff(&gist_label, &remote, &local_label, &local_content);
+        self.diff_text = diff;
+    }
+
+    pub fn init_upload_state(
+        &mut self,
+        local_path: &std::path::Path,
+        remote_content: Option<String>,
+        local_label: String,
+        gist_label: String,
+    ) {
+        self.upload_original_content = std::fs::read_to_string(local_path).unwrap_or_default();
+        self.upload_edited_content = None;
+        self.upload_json_pretty = false;
+        self.upload_json_sort = false;
+        self.upload_remote_content = remote_content;
+        self.upload_local_label = Some(local_label);
+        self.upload_gist_label = Some(gist_label);
+        self.update_upload_diff();
+    }
+
     pub fn ranked_gists(&self) -> Vec<RankedGistFile> {
         let query = self.filter_query.to_lowercase();
         let gists: Vec<GistFile> = self
@@ -999,11 +1064,20 @@ impl AppState {
                 }
                 _ => {}
             },
-            Some(PendingAction::Upload { .. }) => match code {
+            Some(PendingAction::Upload { ref local_path, .. }) => match code {
                 KeyCode::Char('y') => return KeyOutcome::Upload,
                 KeyCode::Char('n') | KeyCode::Char('q') | KeyCode::Esc => {
                     self.pending_action = None;
                     self.screen = Screen::List;
+                }
+                KeyCode::Char('e') => return KeyOutcome::EditUpload,
+                KeyCode::Char('p') if is_json_file(local_path) => {
+                    self.upload_json_pretty = !self.upload_json_pretty;
+                    self.update_upload_diff();
+                }
+                KeyCode::Char('s') if is_json_file(local_path) => {
+                    self.upload_json_sort = !self.upload_json_sort;
+                    self.update_upload_diff();
                 }
                 _ => {}
             },
@@ -1070,11 +1144,6 @@ enum BgTaskOutcome {
         target: PathBuf,
         local_label: String,
         gist_label: String,
-    },
-    UploadAdd {
-        result: std::result::Result<(), String>,
-        local_path: PathBuf,
-        gist_id: String,
     },
     UploadPreview {
         result: std::result::Result<String, String>,
@@ -1161,6 +1230,13 @@ pub fn initial_state() -> AppState {
         description_input: String::new(),
         bg_task_msg: None,
         help_scroll: 0,
+        upload_original_content: String::new(),
+        upload_edited_content: None,
+        upload_json_pretty: false,
+        upload_json_sort: false,
+        upload_remote_content: None,
+        upload_local_label: None,
+        upload_gist_label: None,
     }
 }
 
@@ -1363,28 +1439,6 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
                         }
                         Err(error) => state.set_status(format!("fetch failed: {error}")),
                     },
-                    BgTaskOutcome::UploadAdd {
-                        result,
-                        local_path,
-                        gist_id,
-                    } => match result {
-                        Ok(_) => {
-                            if let Some(filename) = upload_local_filename(&local_path) {
-                                state
-                                    .gist_content_cache
-                                    .remove(&(gist_id.clone(), filename));
-                            }
-                            state.set_status(format!(
-                                "Uploaded {} to gist {}",
-                                local_path.display(),
-                                gist_id
-                            ));
-                            state.back_to_list();
-                            state.loading = true;
-                            gist_rx = Some(spawn_gist_fetch());
-                        }
-                        Err(error) => state.set_status(format!("upload failed: {error}")),
-                    },
                     BgTaskOutcome::UploadPreview {
                         result,
                         gist_id,
@@ -1394,22 +1448,19 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
                         gist_label,
                     } => match result {
                         Ok(remote) => {
-                            let local_content =
-                                std::fs::read_to_string(&local_path).unwrap_or_default();
-                            let diff = crate::diff::unified_diff(
-                                &gist_label,
-                                &remote,
-                                &local_label,
-                                &local_content,
-                            );
-                            state.diff_text = diff;
-                            state.diff_scroll = 0;
-                            state.diff_hscroll = 0;
                             state.pending_action = Some(PendingAction::Upload {
                                 gist_id,
                                 filename,
-                                local_path,
+                                local_path: local_path.clone(),
                             });
+                            state.init_upload_state(
+                                &local_path,
+                                Some(remote),
+                                local_label,
+                                gist_label,
+                            );
+                            state.diff_scroll = 0;
+                            state.diff_hscroll = 0;
                             state.status = None;
                             state.screen = Screen::Confirm;
                         }
@@ -1590,21 +1641,26 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
                     };
                     let local_path = local.path.clone();
                     let gist_id = gist.file.gist_id.clone();
-                    let plan = crate::actions::upload_add_command(&local_path, &gist_id);
+                    let Some(filename) = upload_local_filename(&local_path) else {
+                        state.set_status("local file has no name");
+                        continue;
+                    };
 
-                    state.bg_task_msg = Some("Uploading…".to_string());
-                    let (tx, rx) = std::sync::mpsc::channel();
-                    bg_rx = Some(rx);
-                    std::thread::spawn(move || {
-                        let result = crate::actions::execute_command(&plan)
-                            .map(|_| ())
-                            .map_err(|e| e.to_string());
-                        let _ = tx.send(BgTaskOutcome::UploadAdd {
-                            result,
-                            local_path,
-                            gist_id,
-                        });
+                    state.pending_action = Some(PendingAction::Upload {
+                        gist_id,
+                        filename: filename.clone(),
+                        local_path: local_path.clone(),
                     });
+
+                    let local_label = format!("local: {}", local_path.display());
+                    let gist_label = "(new file)".to_string();
+                    state.init_upload_state(
+                        &local_path,
+                        Some(String::new()),
+                        local_label,
+                        gist_label,
+                    );
+                    state.screen = Screen::Confirm;
                 }
                 KeyOutcome::UploadPreview => {
                     let (Some(local), Some(gist)) = (state.selected_local(), state.selected_gist())
@@ -1640,21 +1696,53 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
                     let Some(PendingAction::Upload {
                         gist_id,
                         filename,
-                        local_path,
+                        local_path: _,
                     }) = state.pending_action.clone()
                     else {
                         continue;
                     };
-                    let target = GistFile {
-                        gist_id: gist_id.clone(),
-                        description: String::new(),
-                        filename: filename.clone(),
-                        public: false,
-                        updated_at: String::new(),
-                        created_at: String::new(),
-                    };
-                    let plan = crate::actions::upload_command(&local_path, &target);
 
+                    let upload_content = state.content_to_upload();
+
+                    // Generate unique temp directory in workspace
+                    let timestamp = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_nanos())
+                        .unwrap_or(0);
+                    let temp_dir = state.cwd.join(format!(".gistui_upload_{timestamp}"));
+
+                    if let Err(e) = std::fs::create_dir_all(&temp_dir) {
+                        state.set_status(format!("failed to create temp dir: {e}"));
+                        continue;
+                    }
+
+                    let temp_file_path = temp_dir.join(&filename);
+                    if let Err(e) = std::fs::write(&temp_file_path, &upload_content) {
+                        state.set_status(format!("failed to write temp file: {e}"));
+                        let _ = std::fs::remove_dir_all(&temp_dir);
+                        continue;
+                    }
+
+                    let has_same_name = state
+                        .gists
+                        .iter()
+                        .any(|g| g.gist_id == gist_id && g.filename == filename);
+
+                    let plan = if has_same_name {
+                        let target = GistFile {
+                            gist_id: gist_id.clone(),
+                            description: String::new(),
+                            filename: filename.clone(),
+                            public: false,
+                            updated_at: String::new(),
+                            created_at: String::new(),
+                        };
+                        crate::actions::upload_command(&temp_file_path, &target)
+                    } else {
+                        crate::actions::upload_add_command(&temp_file_path, &gist_id)
+                    };
+
+                    state.back_to_list();
                     state.bg_task_msg = Some("Uploading…".to_string());
                     let (tx, rx) = std::sync::mpsc::channel();
                     bg_rx = Some(rx);
@@ -1662,12 +1750,18 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
                         let result = crate::actions::execute_command(&plan)
                             .map(|_| ())
                             .map_err(|e| e.to_string());
+
+                        let _ = std::fs::remove_dir_all(&temp_dir);
+
                         let _ = tx.send(BgTaskOutcome::UploadReplace {
                             result,
                             gist_id,
                             filename,
                         });
                     });
+                }
+                KeyOutcome::EditUpload => {
+                    edit_upload_buffer(terminal, &mut state)?;
                 }
                 KeyOutcome::Create(public) => {
                     let Some(PendingAction::Create { local_path }) = state.pending_action.clone()
@@ -1988,6 +2082,68 @@ fn edit_local(
     Ok(())
 }
 
+fn edit_upload_buffer(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    state: &mut AppState,
+) -> Result<()> {
+    let Some(local_path) = state.upload_local_path() else {
+        return Ok(());
+    };
+    let Some(filename) = local_path.file_name().and_then(|n| n.to_str()) else {
+        return Ok(());
+    };
+
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let temp_file_path = state
+        .cwd
+        .join(format!(".gistui_redact_{timestamp}_{filename}"));
+
+    let current_content = state.content_to_upload();
+    if let Err(e) = std::fs::write(&temp_file_path, &current_content) {
+        state.set_status(format!("failed to write temp file: {e}"));
+        return Ok(());
+    }
+
+    let editor = std::env::var("VISUAL")
+        .or_else(|_| std::env::var("EDITOR"))
+        .unwrap_or_else(|_| "vi".to_string());
+    let mut parts = editor.split_whitespace();
+    let Some(program) = parts.next() else {
+        state.set_status("no editor configured (set $EDITOR)");
+        let _ = std::fs::remove_file(&temp_file_path);
+        return Ok(());
+    };
+    let args: Vec<&str> = parts.collect();
+
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    let result = std::process::Command::new(program)
+        .args(&args)
+        .arg(&temp_file_path)
+        .status();
+    enable_raw_mode()?;
+    execute!(terminal.backend_mut(), EnterAlternateScreen)?;
+    terminal.clear()?;
+
+    match result {
+        Ok(_) => match std::fs::read_to_string(&temp_file_path) {
+            Ok(edited_content) => {
+                state.upload_edited_content = Some(edited_content);
+                state.update_upload_diff();
+                state.set_status("Edited redact buffer");
+            }
+            Err(e) => state.set_status(format!("failed to read edited file: {e}")),
+        },
+        Err(error) => state.set_status(format!("editor failed: {error}")),
+    }
+
+    let _ = std::fs::remove_file(&temp_file_path);
+    Ok(())
+}
+
 fn download(state: &mut AppState) {
     let target = state.download_target.clone();
     let content = state.preview_remote.clone();
@@ -2140,6 +2296,13 @@ Actions (on the selected local file + gist)
   X          remove the selected file from its gist (y/n confirm)
   g          open the gist manager (edit description, delete gist)
   e          edit the local file in $EDITOR
+
+Upload Confirmation screen (u)
+  y          confirm and execute the upload
+  n / Esc    cancel the upload
+  e          edit / redact the upload content in $EDITOR before upload
+  p          (JSON only) toggle pretty-print formatting
+  s          (JSON only) toggle recursive key sorting
 
 Gist manager (g)
   Up/Down    move between gists
@@ -2791,9 +2954,30 @@ fn render_diff(frame: &mut Frame, state: &AppState, confirming: bool) {
                 )
             }
             Some(PendingAction::Upload {
-                gist_id, filename, ..
+                gist_id,
+                filename,
+                local_path,
             }) => {
-                format!("Upload {} to gist {}? (y/n)", filename, gist_id)
+                let edited_status = if state.upload_edited_content.is_some() {
+                    " [edited]"
+                } else {
+                    ""
+                };
+                let mut opts = format!("y yes  n/Esc cancel  e edit{edited_status}");
+                if is_json_file(local_path) {
+                    let pretty_status = if state.upload_json_pretty {
+                        " [on]"
+                    } else {
+                        " [off]"
+                    };
+                    let sort_status = if state.upload_json_sort {
+                        " [on]"
+                    } else {
+                        " [off]"
+                    };
+                    opts.push_str(&format!("  p pretty{pretty_status}  s sort{sort_status}"));
+                }
+                format!("Upload {filename} to gist {gist_id}?  ·  {opts}")
             }
             Some(PendingAction::Delete { gist_id, label }) => {
                 format!("Permanently delete \"{label}\" ({gist_id})? (y/n)")
@@ -2878,6 +3062,13 @@ fn render_diff(frame: &mut Frame, state: &AppState, confirming: bool) {
         ),
         chunks[1],
     );
+}
+
+fn is_json_file(path: &std::path::Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.eq_ignore_ascii_case("json"))
+        .unwrap_or(false)
 }
 
 #[cfg(test)]
@@ -4078,6 +4269,43 @@ mod tests {
         });
         state.screen = Screen::Confirm;
         assert_eq!(state.handle_key(KeyCode::Char('y')), KeyOutcome::Upload);
+    }
+
+    #[test]
+    fn confirm_upload_e_returns_edit_upload() {
+        let mut state = initial_state();
+        state.pending_action = Some(PendingAction::Upload {
+            gist_id: "a".into(),
+            filename: "settings.json".into(),
+            local_path: PathBuf::from("/tmp/settings.json"),
+        });
+        state.screen = Screen::Confirm;
+        assert_eq!(state.handle_key(KeyCode::Char('e')), KeyOutcome::EditUpload);
+    }
+
+    #[test]
+    fn confirm_upload_json_toggles() {
+        let mut state = initial_state();
+        state.pending_action = Some(PendingAction::Upload {
+            gist_id: "a".into(),
+            filename: "settings.json".into(),
+            local_path: PathBuf::from("/tmp/settings.json"),
+        });
+        state.screen = Screen::Confirm;
+        assert!(!state.upload_json_pretty);
+        assert!(!state.upload_json_sort);
+
+        // Toggle pretty
+        assert_eq!(state.handle_key(KeyCode::Char('p')), KeyOutcome::None);
+        assert!(state.upload_json_pretty);
+
+        // Toggle sort
+        assert_eq!(state.handle_key(KeyCode::Char('s')), KeyOutcome::None);
+        assert!(state.upload_json_sort);
+
+        // Toggle pretty off
+        assert_eq!(state.handle_key(KeyCode::Char('p')), KeyOutcome::None);
+        assert!(!state.upload_json_pretty);
     }
 
     #[test]


### PR DESCRIPTION
This PR implements issue #39 ('Edit/redact file content before upload, with JSON pretty-print and key sorting').

### Changes:
- Enabled the `preserve_order` feature of `serde_json` to preserve original JSON structure by default.
- Implemented pure JSON transformation functions (`transform_json`, `sort_json_value`) and tests.
- Modified `handle_key_confirm` to support editing with `e`, and toggling JSON transformation with `p`/`s`.
- Integrated `$EDITOR` edit loop in `run_loop` via `edit_upload_buffer` which spawns the external editor on a temp file.
- Handled upload path isolation by copying to a temp directory inside the workspace before uploading to retain the original filename.

Closes #39