### PR TITLE
feat: pinned one-key sync (direction by mtime, status icons, diff)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target/
 .superpowers/
+# Superpowers workflow artifacts (brainstorm specs / implementation plans) — kept local only
+/docs/superpowers/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "gistui"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gistui"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 description = "A terminal UI for managing GitHub Gists"

--- a/README.md
+++ b/README.md
@@ -107,8 +107,10 @@ selected gist instead. Browse with `Tab` (switch pane), `Up`/`Down` (move), and
 - `p` (on a gist) — toggle a pin between the selected local file and gist (persisted to
   config; pinned pairs sort to the top).
 - `P` — open the **Pins view** listing all pinned pairs with sync-status icons.
-  Each row shows one of: `✓` synced · `↑` local newer · `↓` remote newer · `?` unknown.
+  Each row shows one of: `✓` synced · `↑` local newer · `↓` remote newer · `?` unknown,
+  plus `(local <age> · gist <age>)` relative modification times.
   Keys inside the Pins view:
+  - `Enter` — diff the selected pair (read-only; `d`/`u` from the diff to pull/push; `Esc`/`q` returns to the Pins view).
   - `s` — smart-sync (newer side wins by modified time; skips if already identical).
   - `u` — force push (upload local → gist).
   - `d` — force pull (download gist → local, diff + `y`/`n` confirm).

--- a/README.md
+++ b/README.md
@@ -106,7 +106,15 @@ selected gist instead. Browse with `Tab` (switch pane), `Up`/`Down` (move), and
   more (see below).
 - `p` (on a gist) — toggle a pin between the selected local file and gist (persisted to
   config; pinned pairs sort to the top).
-- `P` — open the **Pins view** listing all pinned pairs; `x` unpins the selected entry.
+- `P` — open the **Pins view** listing all pinned pairs with sync-status icons.
+  Each row shows one of: `✓` synced · `↑` local newer · `↓` remote newer · `?` unknown.
+  Keys inside the Pins view:
+  - `s` — smart-sync (newer side wins by modified time; skips if already identical).
+  - `u` — force push (upload local → gist).
+  - `d` — force pull (download gist → local, diff + `y`/`n` confirm).
+  - `x` — unpin the selected pair.
+- `S` (on a pinned pair) — smart-sync the selected local↔gist pair from the list screen
+  (push/pull by modified time; only available when the pair is pinned).
 - `e` (on a local file) — open it in `$VISUAL`/`$EDITOR`.
 - `Space` (on a gist) — preview the gist's raw content in a scrollable overlay (`R` to
   force-refresh, bypassing the session cache).
@@ -140,6 +148,8 @@ the gist owning the currently selected file. From here you manage gists as a who
   first showing its diff and confirmation.
 - Uploads allow editing/redacting a temporary buffer in `$EDITOR` before sending, ensuring sensitive local content or credentials are not accidentally pushed to GitHub.
 - Identical files are detected: when the two sides match, upload/download are disabled.
+- Pulling a gist over an existing local file still goes through the diff + `y`/`n`
+  confirmation — one-key sync never overwrites a local file silently.
 - Destructive remote actions each require a `y`/`n` confirmation: removing a file from a
   gist (`X` on the list) and deleting a whole gist (`X` in the gist manager).
 - No GitHub token is stored by the app, and gist content is never written to the config

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -248,6 +248,29 @@ pub fn pin_mapping(
     Ok(config)
 }
 
+/// Record the result of a successful sync for the pin identified by
+/// `(local_path, gist_id, gist_filename)`: set `last_seen_hash` to the agreed
+/// content hash and `direction` to the direction performed, then persist.
+/// No-op if the pin is not found.
+pub fn record_sync(
+    config_path: &Path,
+    mut config: AppConfig,
+    local_path: &Path,
+    gist_id: &str,
+    gist_filename: &str,
+    hash: &str,
+    direction: SyncDirection,
+) -> Result<AppConfig> {
+    if let Some(mapping) = config.pinned.iter_mut().find(|m| {
+        m.local_path == local_path && m.gist_id == gist_id && m.gist_filename == gist_filename
+    }) {
+        mapping.last_seen_hash = Some(hash.to_string());
+        mapping.direction = Some(direction);
+        save_config(config_path, &config)?;
+    }
+    Ok(config)
+}
+
 pub fn unpin_mapping(
     config_path: &Path,
     mut config: AppConfig,
@@ -462,6 +485,35 @@ mod tests {
         assert!(config.pinned.is_empty());
         let loaded = load_config(&config_path).unwrap();
         assert!(loaded.pinned.is_empty());
+    }
+
+    #[test]
+    fn record_sync_updates_hash_and_direction() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg_path = dir.path().join("config.toml");
+        let mut config = AppConfig::default();
+        config.pinned.push(PinnedMapping {
+            local_path: PathBuf::from("/tmp/a.txt"),
+            gist_id: "g1".into(),
+            gist_filename: "a.txt".into(),
+            direction: None,
+            last_seen_hash: None,
+        });
+
+        let updated = record_sync(
+            &cfg_path,
+            config,
+            Path::new("/tmp/a.txt"),
+            "g1",
+            "a.txt",
+            "deadbeef",
+            SyncDirection::Upload,
+        )
+        .unwrap();
+
+        let m = &updated.pinned[0];
+        assert_eq!(m.last_seen_hash.as_deref(), Some("deadbeef"));
+        assert_eq!(m.direction, Some(SyncDirection::Upload));
     }
 
     #[test]

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,16 +1,4 @@
-use sha2::{Digest, Sha256};
 use similar::{ChangeTag, TextDiff};
-use std::fmt::Write;
-
-pub fn sha256_hex(content: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(content.as_bytes());
-    let mut hex = String::with_capacity(64);
-    for byte in hasher.finalize() {
-        write!(hex, "{byte:02x}").expect("writing to a String never fails");
-    }
-    hex
-}
 
 pub fn unified_diff(old_label: &str, old: &str, new_label: &str, new: &str) -> String {
     let diff = TextDiff::from_lines(old, new);
@@ -32,12 +20,6 @@ pub fn unified_diff(old_label: &str, old: &str, new_label: &str, new: &str) -> S
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn hash_is_stable() {
-        assert_eq!(sha256_hex("abc"), sha256_hex("abc"));
-        assert_ne!(sha256_hex("abc"), sha256_hex("abcd"));
-    }
 
     #[test]
     fn diff_shows_insert_and_delete() {

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::path::PathBuf;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -48,6 +49,20 @@ pub struct GistGroup {
     pub file_count: usize,
 }
 
+/// Lowercase hex SHA-256 of `bytes`. Used as the stable, content-only digest
+/// persisted in `PinnedMapping.last_seen_hash` (the config never stores content).
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write as _;
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
 /// Collapses the flat per-file rows into one [`GistGroup`] per gist, preserving
 /// the first-seen order of `files` (which mirrors the `gh` list order).
 pub fn group_gists(files: &[GistFile]) -> Vec<GistGroup> {
@@ -72,6 +87,18 @@ pub fn group_gists(files: &[GistFile]) -> Vec<GistGroup> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn sha256_hex_matches_known_vector() {
+        assert_eq!(
+            sha256_hex(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        assert_eq!(
+            sha256_hex(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
 
     fn file(gist_id: &str, filename: &str, desc: &str, public: bool) -> GistFile {
         GistFile {

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -63,6 +63,43 @@ pub fn sha256_hex(bytes: &[u8]) -> String {
     out
 }
 
+/// Parse the `YYYY-MM-DDThh:mm:ssZ` UTC form GitHub returns into Unix seconds.
+/// Returns `None` on any malformed component. No external date crate (days-from-civil).
+pub fn parse_rfc3339_to_unix(s: &str) -> Option<u64> {
+    let bytes = s.as_bytes();
+    if bytes.len() < 20 || bytes[4] != b'-' || bytes[7] != b'-' || bytes[10] != b'T' {
+        return None;
+    }
+    if bytes[13] != b':' || bytes[16] != b':' {
+        return None;
+    }
+    let num = |slice: &str| slice.parse::<i64>().ok();
+    let year = num(&s[0..4])?;
+    let month = num(&s[5..7])?;
+    let day = num(&s[8..10])?;
+    let hour = num(&s[11..13])?;
+    let min = num(&s[14..16])?;
+    let sec = num(&s[17..19])?;
+    if !(1..=12).contains(&month)
+        || !(1..=31).contains(&day)
+        || !(0..=23).contains(&hour)
+        || !(0..=59).contains(&min)
+        || !(0..=60).contains(&sec)
+    {
+        return None;
+    }
+    // days_from_civil (Howard Hinnant): days since 1970-01-01 for a proleptic
+    // Gregorian (y, m, d).
+    let y = if month <= 2 { year - 1 } else { year };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400; // [0, 399]
+    let doy = (153 * (if month > 2 { month - 3 } else { month + 9 }) + 2) / 5 + day - 1; // [0,365]
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy; // [0, 146096]
+    let days = era * 146097 + doe - 719468;
+    let total = days * 86400 + hour * 3600 + min * 60 + sec;
+    u64::try_from(total).ok()
+}
+
 /// Collapses the flat per-file rows into one [`GistGroup`] per gist, preserving
 /// the first-seen order of `files` (which mirrors the `gh` list order).
 pub fn group_gists(files: &[GistFile]) -> Vec<GistGroup> {
@@ -87,6 +124,24 @@ pub fn group_gists(files: &[GistFile]) -> Vec<GistGroup> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_rfc3339_to_unix_known_values() {
+        // 1970-01-01T00:00:00Z == 0
+        assert_eq!(parse_rfc3339_to_unix("1970-01-01T00:00:00Z"), Some(0));
+        // 2024-01-02T03:04:05Z == 1704164645
+        assert_eq!(
+            parse_rfc3339_to_unix("2024-01-02T03:04:05Z"),
+            Some(1704164645)
+        );
+    }
+
+    #[test]
+    fn parse_rfc3339_to_unix_rejects_garbage() {
+        assert_eq!(parse_rfc3339_to_unix(""), None);
+        assert_eq!(parse_rfc3339_to_unix("not-a-date"), None);
+        assert_eq!(parse_rfc3339_to_unix("2024-13-99T99:99:99Z"), None);
+    }
 
     #[test]
     fn sha256_hex_matches_known_vector() {

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -137,6 +137,31 @@ pub fn parse_rfc3339_to_unix(s: &str) -> Option<u64> {
     u64::try_from(total).ok()
 }
 
+/// Compact relative-age label for `secs_ago` seconds in the past.
+/// Approximate (month = 30d, year = 365d); a staleness hint, not calendar-exact.
+/// Zero or negative (now/future) renders as "now".
+pub fn humanize_age(secs_ago: i64) -> String {
+    if secs_ago <= 0 {
+        return "now".to_string();
+    }
+    let s = secs_ago;
+    if s < 60 {
+        format!("{s}s")
+    } else if s < 3600 {
+        format!("{}m", s / 60)
+    } else if s < 86_400 {
+        format!("{}h", s / 3600)
+    } else if s < 7 * 86_400 {
+        format!("{}d", s / 86_400)
+    } else if s < 35 * 86_400 {
+        format!("{}w", s / (7 * 86_400))
+    } else if s < 365 * 86_400 {
+        format!("{}mo", s / (30 * 86_400))
+    } else {
+        format!("{}y", s / (365 * 86_400))
+    }
+}
+
 /// Collapses the flat per-file rows into one [`GistGroup`] per gist, preserving
 /// the first-seen order of `files` (which mirrors the `gh` list order).
 pub fn group_gists(files: &[GistFile]) -> Vec<GistGroup> {
@@ -245,6 +270,25 @@ mod tests {
     #[test]
     fn empty_input_yields_no_groups() {
         assert!(group_gists(&[]).is_empty());
+    }
+
+    #[test]
+    fn humanize_age_buckets() {
+        assert_eq!(humanize_age(0), "now");
+        assert_eq!(humanize_age(-5), "now");
+        assert_eq!(humanize_age(5), "5s");
+        assert_eq!(humanize_age(59), "59s");
+        assert_eq!(humanize_age(60), "1m");
+        assert_eq!(humanize_age(59 * 60), "59m");
+        assert_eq!(humanize_age(60 * 60), "1h");
+        assert_eq!(humanize_age(23 * 3600), "23h");
+        assert_eq!(humanize_age(24 * 3600), "1d");
+        assert_eq!(humanize_age(6 * 86400), "6d");
+        assert_eq!(humanize_age(7 * 86400), "1w");
+        assert_eq!(humanize_age(34 * 86400), "4w");
+        assert_eq!(humanize_age(35 * 86400), "1mo");
+        assert_eq!(humanize_age(359 * 86400), "11mo");
+        assert_eq!(humanize_age(365 * 86400), "1y");
     }
 }
 

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -18,6 +18,43 @@ pub enum SyncDirection {
     Download,
 }
 
+/// Suggested sync action for a pinned pair, decided by comparing modification
+/// times. Pure; derived by [`sync_status`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SyncStatus {
+    /// Both sides carry the same modification time.
+    InSync,
+    /// Local is newer → upload local into the gist.
+    Push,
+    /// Remote is newer → download the gist into the local file.
+    Pull,
+    /// A timestamp is unavailable — direction cannot be suggested.
+    Unknown,
+}
+
+impl SyncStatus {
+    /// Single-glyph indicator shown in the Pins list.
+    pub fn icon(self) -> &'static str {
+        match self {
+            SyncStatus::InSync => "✓",
+            SyncStatus::Push => "↑",
+            SyncStatus::Pull => "↓",
+            SyncStatus::Unknown => "?",
+        }
+    }
+}
+
+/// Pure decision: which side is newer? `local_ts`/`remote_ts` are Unix seconds;
+/// `None` means the timestamp was unavailable.
+pub fn sync_status(local_ts: Option<u64>, remote_ts: Option<u64>) -> SyncStatus {
+    match (local_ts, remote_ts) {
+        (Some(l), Some(r)) if l > r => SyncStatus::Push,
+        (Some(l), Some(r)) if r > l => SyncStatus::Pull,
+        (Some(_), Some(_)) => SyncStatus::InSync,
+        _ => SyncStatus::Unknown,
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LocalCandidate {
     pub path: PathBuf,
@@ -124,6 +161,24 @@ pub fn group_gists(files: &[GistFile]) -> Vec<GistGroup> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn sync_status_from_mtime() {
+        assert_eq!(sync_status(Some(20), Some(10)), SyncStatus::Push); // local newer
+        assert_eq!(sync_status(Some(10), Some(20)), SyncStatus::Pull); // remote newer
+        assert_eq!(sync_status(Some(15), Some(15)), SyncStatus::InSync);
+        assert_eq!(sync_status(None, Some(10)), SyncStatus::Unknown);
+        assert_eq!(sync_status(Some(10), None), SyncStatus::Unknown);
+        assert_eq!(sync_status(None, None), SyncStatus::Unknown);
+    }
+
+    #[test]
+    fn sync_status_icons() {
+        assert_eq!(SyncStatus::InSync.icon(), "✓");
+        assert_eq!(SyncStatus::Push.icon(), "↑");
+        assert_eq!(SyncStatus::Pull.icon(), "↓");
+        assert_eq!(SyncStatus::Unknown.icon(), "?");
+    }
 
     #[test]
     fn parse_rfc3339_to_unix_known_values() {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -232,6 +232,8 @@ pub enum KeyOutcome {
     SyncPinPush,
     /// Force pull the selected Pins-screen pair (download gist → local).
     SyncPinPull,
+    /// Smart-sync the selected local↔gist pair from the List screen (if pinned).
+    SyncSelectedPair,
 }
 
 #[derive(Debug, Clone)]
@@ -288,6 +290,10 @@ pub struct AppState {
     pub upload_remote_content: Option<String>,
     pub upload_local_label: Option<String>,
     pub upload_gist_label: Option<String>,
+    /// gist_id of the active download (set when entering the diff Confirm for a pull).
+    pub download_gist_id: Option<String>,
+    /// filename of the active download (set when entering the diff Confirm for a pull).
+    pub download_gist_filename: Option<String>,
 }
 
 fn unranked_gists(gists: Vec<GistFile>) -> Vec<RankedGistFile> {
@@ -577,6 +583,10 @@ impl AppState {
         self.preview_remote.clear();
         self.preview_local = PathBuf::new();
         self.download_target = PathBuf::new();
+        // Clear the pull's pinned-pair identity so a later non-pinned download
+        // can't be mis-attributed to a pin via a stale gist id/filename.
+        self.download_gist_id = None;
+        self.download_gist_filename = None;
         self.diff_scroll = 0;
         self.diff_hscroll = 0;
         self.diff_identical = false;
@@ -905,6 +915,7 @@ impl AppState {
                 self.pins_index = 0;
                 self.screen = Screen::Pins;
             }
+            KeyCode::Char('S') => return KeyOutcome::SyncSelectedPair,
             KeyCode::Char('g') => {
                 if self.gists.is_empty() {
                     self.status = Some("no gists to manage".into());
@@ -1151,6 +1162,8 @@ enum BgTaskOutcome {
         target: PathBuf,
         local_label: String,
         gist_label: String,
+        gist_id: String,
+        filename: String,
     },
     UploadPreview {
         result: std::result::Result<String, String>,
@@ -1244,6 +1257,8 @@ pub fn initial_state() -> AppState {
         upload_remote_content: None,
         upload_local_label: None,
         upload_gist_label: None,
+        download_gist_id: None,
+        download_gist_filename: None,
     }
 }
 
@@ -1417,6 +1432,8 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
                         target,
                         local_label,
                         gist_label,
+                        gist_id,
+                        filename,
                     } => match result {
                         Ok(remote) => {
                             if target.exists() {
@@ -1429,6 +1446,8 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
                                     &remote,
                                 );
                                 let identical = local_content == remote;
+                                state.download_gist_id = Some(gist_id);
+                                state.download_gist_filename = Some(filename);
                                 state.enter_diff(diff, remote, target.clone(), target);
                                 state.diff_identical = identical;
                             } else {
@@ -1436,6 +1455,14 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
                                     Ok(()) => {
                                         state
                                             .set_status(format!("Downloaded {}", target.display()));
+                                        record_pin_sync(
+                                            &mut state,
+                                            &target,
+                                            &gist_id,
+                                            &filename,
+                                            &remote,
+                                            crate::domain::SyncDirection::Download,
+                                        );
                                         refresh_locals(&mut state);
                                     }
                                     Err(error) => {
@@ -1483,6 +1510,17 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
                                 .gist_content_cache
                                 .remove(&(gist_id.clone(), filename.clone()));
                             state.set_status(format!("Uploaded {} to gist {}", filename, gist_id));
+                            if let Some(local_path) = state.upload_local_path() {
+                                let content = state.content_to_upload();
+                                record_pin_sync(
+                                    &mut state,
+                                    &local_path,
+                                    &gist_id,
+                                    &filename,
+                                    &content,
+                                    crate::domain::SyncDirection::Upload,
+                                );
+                            }
                             state.back_to_list();
                             state.loading = true;
                             gist_rx = Some(spawn_gist_fetch());
@@ -1636,6 +1674,8 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
                             target,
                             local_label,
                             gist_label,
+                            gist_id,
+                            filename,
                         });
                     });
                 }
@@ -1921,8 +1961,80 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
                     ));
                 }
                 KeyOutcome::UnpinAtPin => unpin_at_pin_index(&mut state),
-                // Placeholder: wired in Task 9.
-                KeyOutcome::SyncPinAuto | KeyOutcome::SyncPinPush | KeyOutcome::SyncPinPull => {}
+                KeyOutcome::SyncSelectedPair => {
+                    let (Some(local), Some(gist)) = (state.selected_local(), state.selected_gist())
+                    else {
+                        continue;
+                    };
+                    let local_abs = state.cwd.join(&local.path);
+                    let gist_id = gist.file.gist_id.clone();
+                    let filename = gist.file.filename.clone();
+                    let idx = state.pinned.iter().position(|m| {
+                        pin_local_abs(&state, m) == local_abs
+                            && m.gist_id == gist_id
+                            && m.gist_filename == filename
+                    });
+                    let Some(idx) = idx else {
+                        state.set_status("pair is not pinned — press p to pin first");
+                        continue;
+                    };
+                    let m = state.pinned[idx].clone();
+                    match state.pin_sync_status(idx) {
+                        crate::domain::SyncStatus::Push => {
+                            spawn_pin_push(&mut state, &mut bg_rx, &m)
+                        }
+                        crate::domain::SyncStatus::Pull => {
+                            spawn_pin_pull(&mut state, &mut bg_rx, &m)
+                        }
+                        crate::domain::SyncStatus::InSync => state.set_status("already in sync"),
+                        crate::domain::SyncStatus::Unknown => state.set_status(
+                            "can't tell which side is newer — use u to push or d to pull",
+                        ),
+                    }
+                }
+                KeyOutcome::SyncPinPush => {
+                    if let Some(m) = selected_pin(&state) {
+                        spawn_pin_push(&mut state, &mut bg_rx, &m);
+                    }
+                }
+                KeyOutcome::SyncPinPull => {
+                    if let Some(m) = selected_pin(&state) {
+                        spawn_pin_pull(&mut state, &mut bg_rx, &m);
+                    }
+                }
+                KeyOutcome::SyncPinAuto => {
+                    let Some(m) = selected_pin(&state) else {
+                        continue;
+                    };
+                    match state.pin_sync_status(state.pins_index) {
+                        crate::domain::SyncStatus::InSync => state.set_status("already in sync"),
+                        crate::domain::SyncStatus::Pull => {
+                            spawn_pin_pull(&mut state, &mut bg_rx, &m)
+                        }
+                        crate::domain::SyncStatus::Push => {
+                            // Cheap, network-free no-op check: if the local file still
+                            // hashes to last_seen_hash, the newer mtime is a touch with
+                            // no content change. Note: only fires for plain pushes — a
+                            // push whose baseline was a JSON-transformed/redacted upload
+                            // won't match the raw file, so it harmlessly falls through to
+                            // a full push.
+                            let local_abs = pin_local_abs(&state, &m);
+                            let unchanged = m.last_seen_hash.as_deref().is_some_and(|baseline| {
+                                std::fs::read(&local_abs)
+                                    .map(|b| crate::domain::sha256_hex(&b) == baseline)
+                                    .unwrap_or(false)
+                            });
+                            if unchanged {
+                                state.set_status("already in sync");
+                            } else {
+                                spawn_pin_push(&mut state, &mut bg_rx, &m);
+                            }
+                        }
+                        crate::domain::SyncStatus::Unknown => state.set_status(
+                            "can't tell which side is newer — use u to push or d to pull",
+                        ),
+                    }
+                }
                 KeyOutcome::None => {}
             }
         }
@@ -2037,6 +2149,132 @@ fn gist_time_label(updated_at: &str) -> String {
         format!("{} UTC", updated_at[..16].replace('T', " "))
     } else {
         updated_at.to_string()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pinned-sync helpers (Task 9 + Task 10)
+// ---------------------------------------------------------------------------
+
+type BgRx = Option<std::sync::mpsc::Receiver<BgTaskOutcome>>;
+
+/// The pin currently selected in the Pins screen, if any.
+fn selected_pin(state: &AppState) -> Option<crate::domain::PinnedMapping> {
+    state.pinned.get(state.pins_index).cloned()
+}
+
+/// Resolve a pin's absolute local path against cwd.
+fn pin_local_abs(state: &AppState, m: &crate::domain::PinnedMapping) -> PathBuf {
+    if m.local_path.is_absolute() {
+        m.local_path.clone()
+    } else {
+        state.cwd.join(&m.local_path)
+    }
+}
+
+/// Spawn the push (upload local → gist) flow for a pin: lands in the existing
+/// upload `Screen::Confirm` diff.
+fn spawn_pin_push(state: &mut AppState, bg_rx: &mut BgRx, m: &crate::domain::PinnedMapping) {
+    let local_path = pin_local_abs(state, m);
+    let gist_id = m.gist_id.clone();
+    let filename = m.gist_filename.clone();
+    state.pending_action = Some(PendingAction::Upload {
+        gist_id: gist_id.clone(),
+        filename: filename.clone(),
+        local_path: local_path.clone(),
+    });
+    let gist_file = GistFile {
+        gist_id: gist_id.clone(),
+        description: String::new(),
+        filename: filename.clone(),
+        public: false,
+        updated_at: String::new(),
+        created_at: String::new(),
+    };
+    let (local_label, gist_label) = diff_labels(Some(&local_path), &gist_file);
+    state.bg_task_msg = Some("Loading diff…".to_string());
+    let (tx, rx) = std::sync::mpsc::channel();
+    *bg_rx = Some(rx);
+    std::thread::spawn(move || {
+        let result =
+            crate::gh::fetch_gist_file_content(&gist_id, &filename).map_err(|e| e.to_string());
+        let _ = tx.send(BgTaskOutcome::UploadPreview {
+            result,
+            gist_id,
+            filename,
+            local_path,
+            local_label,
+            gist_label,
+        });
+    });
+}
+
+/// Spawn the pull (download gist → local) flow for a pin: lands in the existing
+/// download `Screen::Confirm` diff when the local file exists.
+fn spawn_pin_pull(state: &mut AppState, bg_rx: &mut BgRx, m: &crate::domain::PinnedMapping) {
+    let target = pin_local_abs(state, m);
+    let gist_id = m.gist_id.clone();
+    let filename = m.gist_filename.clone();
+    let gist_file = GistFile {
+        gist_id: gist_id.clone(),
+        description: String::new(),
+        filename: filename.clone(),
+        public: false,
+        updated_at: String::new(),
+        created_at: String::new(),
+    };
+    let (local_label, gist_label) = diff_labels(Some(&target), &gist_file);
+    state.bg_task_msg = Some("Downloading…".to_string());
+    let (tx, rx) = std::sync::mpsc::channel();
+    *bg_rx = Some(rx);
+    std::thread::spawn(move || {
+        let result =
+            crate::gh::fetch_gist_file_content(&gist_id, &filename).map_err(|e| e.to_string());
+        let _ = tx.send(BgTaskOutcome::DownloadSelected {
+            result,
+            target,
+            local_label,
+            gist_label,
+            gist_id,
+            filename,
+        });
+    });
+}
+
+/// If `(local_abs, gist_id, filename)` is a pinned pair, record the sync result
+/// (hash of `content` + `direction`) to config and update `state.pinned`.
+fn record_pin_sync(
+    state: &mut AppState,
+    local_abs: &std::path::Path,
+    gist_id: &str,
+    filename: &str,
+    content: &str,
+    direction: crate::domain::SyncDirection,
+) {
+    // Find the pin using its STORED (possibly relative) local_path form.
+    let stored_local = state.pinned.iter().find_map(|m| {
+        let mabs = pin_local_abs(state, m);
+        (mabs == local_abs && m.gist_id == gist_id && m.gist_filename == filename)
+            .then(|| m.local_path.clone())
+    });
+    let Some(stored_local) = stored_local else {
+        return;
+    };
+    let hash = crate::domain::sha256_hex(content.as_bytes());
+    if let Ok(path) = crate::config::config_path() {
+        if let Ok(config) = crate::config::load_config(&path) {
+            if let Ok(updated) = crate::actions::record_sync(
+                &path,
+                config,
+                &stored_local,
+                gist_id,
+                filename,
+                &hash,
+                direction,
+            ) {
+                state.pinned = updated.pinned;
+            }
+        }
     }
 }
 
@@ -2189,6 +2427,19 @@ fn download(state: &mut AppState) {
     match crate::actions::execute_download(&target, &content, true) {
         Ok(()) => {
             state.set_status(format!("Downloaded {}", target.display()));
+            if let (Some(gid), Some(fname)) = (
+                state.download_gist_id.clone(),
+                state.download_gist_filename.clone(),
+            ) {
+                record_pin_sync(
+                    state,
+                    &target,
+                    &gid,
+                    &fname,
+                    &content,
+                    crate::domain::SyncDirection::Download,
+                );
+            }
             state.back_to_list();
             refresh_locals(state);
         }
@@ -4745,5 +4996,27 @@ mod tests {
             KeyOutcome::SyncPinPull
         );
         assert_eq!(state.handle_key(KeyCode::Char('x')), KeyOutcome::UnpinAtPin);
+    }
+
+    #[test]
+    fn list_screen_capital_s_syncs_selected_pair() {
+        let mut state = initial_state();
+        state.locals = vec![LocalCandidate {
+            path: PathBuf::from("a.txt"),
+            pinned: true,
+            modified: None,
+        }];
+        state.gists = vec![GistFile {
+            gist_id: "g1".into(),
+            description: String::new(),
+            filename: "a.txt".into(),
+            public: false,
+            updated_at: String::new(),
+            created_at: String::new(),
+        }];
+        assert_eq!(
+            state.handle_key(KeyCode::Char('S')),
+            KeyOutcome::SyncSelectedPair
+        );
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2044,12 +2044,10 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
 }
 
 impl AppState {
-    /// Derive the [`SyncStatus`] for `pinned[index]` from in-memory mtimes.
-    /// Local mtime comes from the matching local candidate (if discovered);
-    /// remote mtime from the matching gist's `updated_at`.
-    pub fn pin_sync_status(&self, index: usize) -> crate::domain::SyncStatus {
+    /// `(local_ts, remote_ts)` Unix-seconds for `pinned[index]`, from in-memory data.
+    pub fn pin_mtimes(&self, index: usize) -> (Option<u64>, Option<u64>) {
         let Some(m) = self.pinned.get(index) else {
-            return crate::domain::SyncStatus::Unknown;
+            return (None, None);
         };
         let local_abs = if m.local_path.is_absolute() {
             m.local_path.clone()
@@ -2069,6 +2067,14 @@ impl AppState {
                 .then(|| crate::domain::parse_rfc3339_to_unix(&g.updated_at))
                 .flatten()
         });
+        (local_ts, remote_ts)
+    }
+
+    /// Derive the [`SyncStatus`] for `pinned[index]` from in-memory mtimes.
+    /// Local mtime comes from the matching local candidate (if discovered);
+    /// remote mtime from the matching gist's `updated_at`.
+    pub fn pin_sync_status(&self, index: usize) -> crate::domain::SyncStatus {
+        let (local_ts, remote_ts) = self.pin_mtimes(index);
         crate::domain::sync_status(local_ts, remote_ts)
     }
 }
@@ -2676,6 +2682,10 @@ fn render_pins(frame: &mut Frame, state: &AppState) {
         .constraints([Constraint::Min(3), Constraint::Length(footer_lines + 2)])
         .split(area);
 
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
     let items: Vec<ListItem> = if state.pinned.is_empty() {
         vec![
             ListItem::new("  📌 No pinned mappings found (use p to pin a pair)")
@@ -2687,12 +2697,19 @@ fn render_pins(frame: &mut Frame, state: &AppState) {
             .iter()
             .enumerate()
             .map(|(i, m)| {
+                let (lts, rts) = state.pin_mtimes(i);
+                let age = |ts: Option<u64>| {
+                    ts.map(|t| crate::domain::humanize_age(now - t as i64))
+                        .unwrap_or_else(|| "?".to_string())
+                };
                 ListItem::new(format!(
-                    "{}  {}  ↔  {} / {}",
+                    "{}  {}  ↔  {} / {}   (local {} · gist {})",
                     state.pin_sync_status(i).icon(),
                     m.local_path.display(),
                     m.gist_id,
-                    m.gist_filename
+                    m.gist_filename,
+                    age(lts),
+                    age(rts),
                 ))
             })
             .collect()

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -226,6 +226,12 @@ pub enum KeyOutcome {
     RefreshLocals,
     RefreshPreview,
     UnpinAtPin,
+    /// Smart-sync the selected Pins-screen pair (direction from mtime).
+    SyncPinAuto,
+    /// Force push the selected Pins-screen pair (upload local → gist).
+    SyncPinPush,
+    /// Force pull the selected Pins-screen pair (download gist → local).
+    SyncPinPull,
 }
 
 #[derive(Debug, Clone)]
@@ -657,9 +663,10 @@ impl AppState {
             KeyCode::Up if self.pins_index > 0 => {
                 self.pins_index -= 1;
             }
-            KeyCode::Char('x') | KeyCode::Char('d') if !self.pinned.is_empty() => {
-                return KeyOutcome::UnpinAtPin;
-            }
+            KeyCode::Char('x') if !self.pinned.is_empty() => return KeyOutcome::UnpinAtPin,
+            KeyCode::Char('s') if !self.pinned.is_empty() => return KeyOutcome::SyncPinAuto,
+            KeyCode::Char('u') if !self.pinned.is_empty() => return KeyOutcome::SyncPinPush,
+            KeyCode::Char('d') if !self.pinned.is_empty() => return KeyOutcome::SyncPinPull,
             _ => {}
         }
         KeyOutcome::None
@@ -1914,6 +1921,8 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
                     ));
                 }
                 KeyOutcome::UnpinAtPin => unpin_at_pin_index(&mut state),
+                // Placeholder: wired in Task 9.
+                KeyOutcome::SyncPinAuto | KeyOutcome::SyncPinPush | KeyOutcome::SyncPinPull => {}
                 KeyOutcome::None => {}
             }
         }
@@ -4710,5 +4719,31 @@ mod tests {
         assert_eq!(state.pending_action, None);
         assert!(!state.editing_description);
         assert!(state.description_input.is_empty());
+    }
+
+    #[test]
+    fn pins_screen_sync_keys_emit_outcomes() {
+        let mut state = initial_state();
+        state.screen = Screen::Pins;
+        state.pinned = vec![PinnedMapping {
+            local_path: PathBuf::from("/tmp/a.txt"),
+            gist_id: "g1".into(),
+            gist_filename: "a.txt".into(),
+            direction: None,
+            last_seen_hash: None,
+        }];
+        assert_eq!(
+            state.handle_key(KeyCode::Char('s')),
+            KeyOutcome::SyncPinAuto
+        );
+        assert_eq!(
+            state.handle_key(KeyCode::Char('u')),
+            KeyOutcome::SyncPinPush
+        );
+        assert_eq!(
+            state.handle_key(KeyCode::Char('d')),
+            KeyOutcome::SyncPinPull
+        );
+        assert_eq!(state.handle_key(KeyCode::Char('x')), KeyOutcome::UnpinAtPin);
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2582,10 +2582,19 @@ Actions (on the selected local file + gist)
   u          upload the local file into the gist
   n          create a new gist from the local file (type a description, then s/p)
   p          pin / unpin the local <-> gist pair
-  P          view / manage all pinned mappings (x to unpin)
+  P          view / manage all pinned mappings (sync status + s/u/d/x)
+  S          smart-sync the selected pinned pair (push/pull by modified time)
   X          remove the selected file from its gist (y/n confirm)
   g          open the gist manager (edit description, delete gist)
   e          edit the local file in $EDITOR
+
+Pinned Mappings screen (P)
+  Up/Down    move between pins
+  s          smart-sync (newer side wins; skips if already identical)
+  u          force push  (upload local → gist)
+  d          force pull  (download gist → local, diff + y/n confirm)
+  x          unpin the selected pair
+  status     ✓ synced · ↑ local newer · ↓ remote newer · ? unknown
 
 Upload Confirmation screen (u)
   y          confirm and execute the upload

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1641,6 +1641,9 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
                     let Some(ranked) = state.selected_gist() else {
                         continue;
                     };
+                    // List-originated diff returns to the List on Esc (reset any
+                    // leftover Pins origin from an earlier pin diff).
+                    state.diff_return = Screen::List;
                     let local_path = state.selected_local().map(|local| local.path.clone());
                     let gist = ranked.file.clone();
                     let gist_id = gist.gist_id.clone();

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -234,6 +234,8 @@ pub enum KeyOutcome {
     SyncPinPull,
     /// Smart-sync the selected local↔gist pair from the List screen (if pinned).
     SyncSelectedPair,
+    /// Diff the selected pinned pair (read-only, lands on Screen::Diff; q/Esc returns to Pins).
+    PreviewPinDiff,
 }
 
 #[derive(Debug, Clone)]
@@ -294,6 +296,8 @@ pub struct AppState {
     pub download_gist_id: Option<String>,
     /// filename of the active download (set when entering the diff Confirm for a pull).
     pub download_gist_filename: Option<String>,
+    /// Screen to return to when leaving the diff (default: List; set to Pins for pin diffs).
+    pub diff_return: Screen,
 }
 
 fn unranked_gists(gists: Vec<GistFile>) -> Vec<RankedGistFile> {
@@ -673,6 +677,7 @@ impl AppState {
             KeyCode::Up if self.pins_index > 0 => {
                 self.pins_index -= 1;
             }
+            KeyCode::Enter if !self.pinned.is_empty() => return KeyOutcome::PreviewPinDiff,
             KeyCode::Char('x') if !self.pinned.is_empty() => return KeyOutcome::UnpinAtPin,
             KeyCode::Char('s') if !self.pinned.is_empty() => return KeyOutcome::SyncPinAuto,
             KeyCode::Char('u') if !self.pinned.is_empty() => return KeyOutcome::SyncPinPush,
@@ -1032,8 +1037,13 @@ impl AppState {
 
     fn handle_key_diff(&mut self, code: KeyCode) -> KeyOutcome {
         match code {
-            // In the diff, q and Esc both return to the list (no accidental app exit).
-            KeyCode::Char('q') | KeyCode::Esc => self.back_to_list(),
+            // In the diff, q and Esc return to diff_return (normally List; Pins for pin diffs).
+            KeyCode::Char('q') | KeyCode::Esc => {
+                let ret = self.diff_return;
+                self.back_to_list();
+                self.screen = ret;
+                self.diff_return = Screen::List;
+            }
             KeyCode::Down => self.scroll_diff_down(),
             KeyCode::Up => self.scroll_diff_up(),
             KeyCode::Right => self.scroll_diff_right(),
@@ -1259,6 +1269,7 @@ pub fn initial_state() -> AppState {
         upload_gist_label: None,
         download_gist_id: None,
         download_gist_filename: None,
+        diff_return: Screen::List,
     }
 }
 
@@ -2035,6 +2046,12 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
                         ),
                     }
                 }
+                KeyOutcome::PreviewPinDiff => {
+                    if let Some(m) = selected_pin(&state) {
+                        state.diff_return = Screen::Pins;
+                        spawn_pin_diff(&mut state, &mut bg_rx, &m);
+                    }
+                }
                 KeyOutcome::None => {}
             }
         }
@@ -2243,6 +2260,37 @@ fn spawn_pin_pull(state: &mut AppState, bg_rx: &mut BgRx, m: &crate::domain::Pin
             gist_label,
             gist_id,
             filename,
+        });
+    });
+}
+
+/// Spawn a read-only diff (gist vs local) for a pin, landing on `Screen::Diff`.
+fn spawn_pin_diff(state: &mut AppState, bg_rx: &mut BgRx, m: &crate::domain::PinnedMapping) {
+    let local_abs = pin_local_abs(state, m);
+    let gist_id = m.gist_id.clone();
+    let filename = m.gist_filename.clone();
+    let gist_file = GistFile {
+        gist_id: gist_id.clone(),
+        description: String::new(),
+        filename: filename.clone(),
+        public: false,
+        updated_at: String::new(),
+        created_at: String::new(),
+    };
+    let (local_label, gist_label) = diff_labels(Some(&local_abs), &gist_file);
+    state.bg_task_msg = Some("Loading diff…".to_string());
+    let (tx, rx) = std::sync::mpsc::channel();
+    *bg_rx = Some(rx);
+    let target = local_abs.clone();
+    std::thread::spawn(move || {
+        let result =
+            crate::gh::fetch_gist_file_content(&gist_id, &filename).map_err(|e| e.to_string());
+        let _ = tx.send(BgTaskOutcome::PreviewDiff {
+            result,
+            local_path: Some(local_abs),
+            local_label,
+            gist_label,
+            target,
         });
     });
 }
@@ -5022,6 +5070,20 @@ mod tests {
             KeyOutcome::SyncPinPull
         );
         assert_eq!(state.handle_key(KeyCode::Char('x')), KeyOutcome::UnpinAtPin);
+    }
+
+    #[test]
+    fn pins_screen_enter_emits_preview_pin_diff() {
+        let mut state = initial_state();
+        state.screen = Screen::Pins;
+        state.pinned = vec![PinnedMapping {
+            local_path: PathBuf::from("/tmp/a.txt"),
+            gist_id: "g1".into(),
+            gist_filename: "a.txt".into(),
+            direction: None,
+            last_seen_hash: None,
+        }];
+        assert_eq!(state.handle_key(KeyCode::Enter), KeyOutcome::PreviewPinDiff);
     }
 
     #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1922,6 +1922,36 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
     Ok(())
 }
 
+impl AppState {
+    /// Derive the [`SyncStatus`] for `pinned[index]` from in-memory mtimes.
+    /// Local mtime comes from the matching local candidate (if discovered);
+    /// remote mtime from the matching gist's `updated_at`.
+    pub fn pin_sync_status(&self, index: usize) -> crate::domain::SyncStatus {
+        let Some(m) = self.pinned.get(index) else {
+            return crate::domain::SyncStatus::Unknown;
+        };
+        let local_abs = if m.local_path.is_absolute() {
+            m.local_path.clone()
+        } else {
+            self.cwd.join(&m.local_path)
+        };
+        let local_ts = self.locals.iter().find_map(|c| {
+            let cabs = if c.path.is_absolute() {
+                c.path.clone()
+            } else {
+                self.cwd.join(&c.path)
+            };
+            (cabs == local_abs).then_some(c.modified).flatten()
+        });
+        let remote_ts = self.gists.iter().find_map(|g| {
+            (g.gist_id == m.gist_id && g.filename == m.gist_filename)
+                .then(|| crate::domain::parse_rfc3339_to_unix(&g.updated_at))
+                .flatten()
+        });
+        crate::domain::sync_status(local_ts, remote_ts)
+    }
+}
+
 /// A centered "Working…" box shown while a blocking `gh` action runs. Animating a
 /// spinner would require running the action off-thread (see issue #11); under the
 /// current synchronous model this is a single static frame.

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2399,7 +2399,7 @@ fn render_pins(frame: &mut Frame, state: &AppState) {
     let footer = if state.pinned.is_empty() {
         "Esc/q back".to_string()
     } else {
-        "↑↓ move  ·  x unpin  ·  Esc/q back".to_string()
+        "↑↓ move  ·  s sync · u push · d pull · x unpin  ·  ✓ synced ↑ local-newer ↓ remote-newer ? n/a  ·  Esc/q back".to_string()
     };
     let footer_lines = wrap_line_count(&footer, area.width.saturating_sub(4)).max(1);
     let chunks = Layout::default()
@@ -2416,9 +2416,11 @@ fn render_pins(frame: &mut Frame, state: &AppState) {
         state
             .pinned
             .iter()
-            .map(|m| {
+            .enumerate()
+            .map(|(i, m)| {
                 ListItem::new(format!(
-                    "{}  ↔  {} / {}",
+                    "{}  {}  ↔  {} / {}",
+                    state.pin_sync_status(i).icon(),
                     m.local_path.display(),
                     m.gist_id,
                     m.gist_filename

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2644,11 +2644,13 @@ Actions (on the selected local file + gist)
 
 Pinned Mappings screen (P)
   Up/Down    move between pins
+  Enter      diff the selected pair (then d pull / u push from the diff)
   s          smart-sync (newer side wins; skips if already identical)
   u          force push  (upload local → gist)
   d          force pull  (download gist → local, diff + y/n confirm)
   x          unpin the selected pair
   status     ✓ synced · ↑ local newer · ↓ remote newer · ? unknown
+  Each row shows (local <age> · gist <age>) relative modification times.
 
 Upload Confirmation screen (u)
   y          confirm and execute the upload
@@ -2722,7 +2724,7 @@ fn render_pins(frame: &mut Frame, state: &AppState) {
     let footer = if state.pinned.is_empty() {
         "Esc/q back".to_string()
     } else {
-        "↑↓ move  ·  s sync · u push · d pull · x unpin  ·  ✓ synced ↑ local-newer ↓ remote-newer ? n/a  ·  Esc/q back".to_string()
+        "↑↓ move  ·  Enter diff · s sync · u push · d pull · x unpin  ·  ✓ synced ↑ local-newer ↓ remote-newer ? n/a  ·  Esc/q back".to_string()
     };
     let footer_lines = wrap_line_count(&footer, area.width.saturating_sub(4)).max(1);
     let chunks = Layout::default()


### PR DESCRIPTION
Closes #4.

Activates the dormant `PinnedMapping.direction` / `last_seen_hash` fields so each pinned pair shows a sync status and can be synced with one key.

## What's new
- **Sync status in the Pins screen (`P`)** — each pair shows an icon (`✓ synced · ↑ local newer · ↓ remote newer · ? unknown`) plus relative ages `(local <age> · gist <age>)`. Direction is decided by modification time (local mtime vs gist `updated_at`), computed purely from in-memory data — no network on open.
- **One-key sync** — `s` smart-sync (newer side wins; skips when already identical via a cheap SHA-256 check), `u` force push, `d` force pull, `x` unpin. List screen gains `S` to smart-sync the selected pinned pair.
- **`Enter` diffs the selected pair** — reuses the read-only diff screen (where `d` pull / `u` push / scroll already work); returns to the Pins screen on `Esc`.
- Push reuses the existing upload-Confirm flow; pull reuses the download-Confirm flow — the overwrite gate (diff + `y/n` before overwriting an existing local file) is preserved.
- After a successful sync, `last_seen_hash` (SHA-256 of agreed content) and `direction` are recorded to config.

## Implementation notes
- Pure, unit-tested core in `domain.rs`: `sha256_hex`, `parse_rfc3339_to_unix`, `sync_status` + `SyncStatus`, `humanize_age`. Consolidated a pre-existing duplicate `diff::sha256_hex` into `domain`.
- Version bumped to 0.3.0.
- README keymap/Safety + `?` help text updated in lockstep.

## Verification
`cargo fmt --check`, `cargo test` (162 passing), `cargo check`, `cargo clippy --all-targets -- -D warnings` all clean.