### PR TITLE
feat: collapse diff context to a configurable radius

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ selected gist instead. Browse with `Tab` (switch pane), `Up`/`Down` (move), and
 
 - `Enter` (on a gist) — preview the unified diff between the selected local file and the
   gist, with `+`/`-` colour and **word-level inline highlighting** of changed words. From
-  there `d` downloads or `u` uploads.
+  there `d` downloads or `u` uploads, and `c` toggles between showing a few context lines
+  around each change (the `diff_context` config, default 3) and the full file. The choice
+  is remembered (persisted to config).
 - `d` (on a gist) — download it into the cwd as `./<gist-filename>`. A brand-new file is
   written directly; an existing one is shown as a diff and overwritten only after a `y`/`n`
   confirmation.

--- a/config.example.toml
+++ b/config.example.toml
@@ -6,6 +6,14 @@
 # Depth 0 = cwd only, 1 = one level deep, 2 = two levels deep, etc.
 scan_depth = 2
 
+# Unchanged context lines kept around each change in the diff view. The `c` key
+# in the diff toggles between this radius and the full file. Default 3.
+diff_context = 3
+
+# Remembered state of the diff view's `c` toggle: true shows the full file,
+# false collapses to diff_context lines. The app rewrites this when you press `c`.
+diff_show_full = false
+
 # Directories skipped when recursive local file discovery is active (r key).
 # Hidden directories (names starting with ".") are always skipped regardless
 # of this list. Add project-specific build output dirs here as needed.

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,10 @@ fn default_scan_depth() -> u32 {
     2
 }
 
+fn default_diff_context() -> u32 {
+    3
+}
+
 fn default_skip_dirs() -> Vec<String> {
     [
         "node_modules",
@@ -39,6 +43,14 @@ pub struct AppConfig {
     /// Maximum directory depth for recursive local file discovery (r key).
     #[serde(default = "default_scan_depth")]
     pub scan_depth: u32,
+    /// Unchanged context lines kept around each change in the diff view (`c` toggles
+    /// between this radius and the full file).
+    #[serde(default = "default_diff_context")]
+    pub diff_context: u32,
+    /// Remembered state of the diff view's context toggle: `true` shows the full file,
+    /// `false` collapses to `diff_context` lines. Persisted when the user presses `c`.
+    #[serde(default)]
+    pub diff_show_full: bool,
 }
 
 impl Default for AppConfig {
@@ -47,6 +59,8 @@ impl Default for AppConfig {
             pinned: Vec::new(),
             skip_dirs: default_skip_dirs(),
             scan_depth: default_scan_depth(),
+            diff_context: default_diff_context(),
+            diff_show_full: false,
         }
     }
 }
@@ -150,6 +164,8 @@ mod tests {
             }],
             skip_dirs: default_skip_dirs(),
             scan_depth: default_scan_depth(),
+            diff_context: default_diff_context(),
+            diff_show_full: false,
         };
 
         save_config(&path, &config).unwrap();

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,4 +1,5 @@
 use similar::{ChangeTag, TextDiff};
+use std::fmt::Write;
 
 pub fn unified_diff(old_label: &str, old: &str, new_label: &str, new: &str) -> String {
     let diff = TextDiff::from_lines(old, new);
@@ -17,6 +18,52 @@ pub fn unified_diff(old_label: &str, old: &str, new_label: &str, new: &str) -> S
     out
 }
 
+/// Collapse a full unified diff (as produced by [`unified_diff`]) so that at most `radius`
+/// unchanged context lines surround each change; longer unchanged runs are replaced with a
+/// single `@@ N unchanged line(s) hidden @@` marker. The `--- / +++` header lines are always
+/// kept. Output stays in the same `' '/'+'/'-'` prefixed format `diff_view` parses, and the
+/// marker starts with `@` so it renders as neutral text.
+pub fn collapse_context(diff: &str, radius: usize) -> String {
+    let lines: Vec<&str> = diff.lines().collect();
+    let is_change = |l: &str| (l.starts_with('-') || l.starts_with('+')) && !is_header(l);
+
+    let mut keep = vec![false; lines.len()];
+    for (i, &line) in lines.iter().enumerate() {
+        if is_header(line) {
+            keep[i] = true;
+        } else if is_change(line) {
+            let lo = i.saturating_sub(radius);
+            let hi = (i + radius + 1).min(lines.len());
+            for slot in keep.iter_mut().take(hi).skip(lo) {
+                *slot = true;
+            }
+        }
+    }
+
+    let mut out = String::new();
+    let mut i = 0;
+    while i < lines.len() {
+        if keep[i] {
+            out.push_str(lines[i]);
+            out.push('\n');
+            i += 1;
+        } else {
+            let start = i;
+            while i < lines.len() && !keep[i] {
+                i += 1;
+            }
+            let hidden = i - start;
+            let plural = if hidden == 1 { "" } else { "s" };
+            let _ = writeln!(out, "@@ {hidden} unchanged line{plural} hidden @@");
+        }
+    }
+    out
+}
+
+fn is_header(line: &str) -> bool {
+    line.starts_with("---") || line.starts_with("+++")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -26,5 +73,38 @@ mod tests {
         let diff = unified_diff("gist", "a\nb\n", "local", "a\nc\n");
         assert!(diff.contains("-b\n"));
         assert!(diff.contains("+c\n"));
+    }
+
+    #[test]
+    fn collapse_context_keeps_changes_and_nearby_context() {
+        // 6 equal lines, a change, 6 more equal lines; radius 2 keeps 2 each side.
+        let old = "a\nb\nc\nd\ne\nf\nX\ng\nh\ni\nj\nk\nl\n";
+        let new = "a\nb\nc\nd\ne\nf\nY\ng\nh\ni\nj\nk\nl\n";
+        let collapsed = collapse_context(&unified_diff("old", old, "new", new), 2);
+        let lines: Vec<&str> = collapsed.lines().collect();
+
+        // The change is preserved.
+        assert!(lines.contains(&"-X"));
+        assert!(lines.contains(&"+Y"));
+        // Two context lines on each side are kept; the far ones are hidden behind a marker.
+        assert!(lines.contains(&" e"));
+        assert!(lines.contains(&" f"));
+        assert!(lines.contains(&" g"));
+        assert!(lines.contains(&" h"));
+        assert!(!lines.contains(&" a"));
+        assert!(!lines.contains(&" l"));
+        assert!(collapsed.contains("unchanged line"));
+        // Headers always survive.
+        assert!(lines.contains(&"--- old"));
+        assert!(lines.contains(&"+++ new"));
+    }
+
+    #[test]
+    fn collapse_context_with_large_radius_is_lossless() {
+        let diff = unified_diff("g", "a\nb\nc\n", "l", "a\nx\nc\n");
+        let collapsed = collapse_context(&diff, 100);
+        assert!(!collapsed.contains("hidden"));
+        assert!(collapsed.contains(" a"));
+        assert!(collapsed.contains(" c"));
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -236,6 +236,8 @@ pub enum KeyOutcome {
     SyncSelectedPair,
     /// Diff the selected pinned pair (read-only, lands on Screen::Diff; q/Esc returns to Pins).
     PreviewPinDiff,
+    /// Persist the diff-context toggle (`diff_show_full`) to config after pressing `c`.
+    PersistDiffContext,
 }
 
 #[derive(Debug, Clone)]
@@ -261,6 +263,11 @@ pub struct AppState {
     pub diff_scroll: u16,
     pub diff_hscroll: u16,
     pub diff_identical: bool,
+    /// Unchanged context lines kept around each change in the diff view (from config).
+    pub diff_context: u32,
+    /// When true the diff view shows the full file; when false it collapses to
+    /// `diff_context` lines. Toggled with `c` and persisted to config.
+    pub diff_show_full: bool,
     pub preview_remote: String,
     pub preview_local: PathBuf,
     pub download_target: PathBuf,
@@ -633,6 +640,16 @@ impl AppState {
 
     pub fn scroll_diff_left(&mut self) {
         self.diff_hscroll = self.diff_hscroll.saturating_sub(1);
+    }
+
+    /// Context radius to render the diff with: `None` shows the full file, `Some(n)`
+    /// collapses unchanged regions to `n` lines around each change.
+    pub fn effective_diff_context(&self) -> Option<usize> {
+        if self.diff_show_full {
+            None
+        } else {
+            Some(self.diff_context as usize)
+        }
     }
 
     pub fn handle_key(&mut self, code: KeyCode) -> KeyOutcome {
@@ -1058,6 +1075,13 @@ impl AppState {
                 }
             }
             KeyCode::Char('u') if !self.diff_identical => return self.upload_intent(),
+            // Toggle between the configured context radius and the full file; the line
+            // count changes, so reset the vertical scroll. The choice is persisted.
+            KeyCode::Char('c') => {
+                self.diff_show_full = !self.diff_show_full;
+                self.diff_scroll = 0;
+                return KeyOutcome::PersistDiffContext;
+            }
             _ => {}
         }
         KeyOutcome::None
@@ -1236,6 +1260,8 @@ pub fn initial_state() -> AppState {
         diff_scroll: 0,
         diff_hscroll: 0,
         diff_identical: false,
+        diff_context: 3,
+        diff_show_full: false,
         preview_remote: String::new(),
         preview_local: PathBuf::new(),
         download_target: PathBuf::new(),
@@ -1282,6 +1308,8 @@ pub fn load_startup_state() -> Result<AppState> {
     state.pinned = config.pinned;
     state.skip_dirs = config.skip_dirs;
     state.scan_depth = config.scan_depth;
+    state.diff_context = config.diff_context;
+    state.diff_show_full = config.diff_show_full;
     state.locals = crate::local::discover_local_candidates(
         &cwd,
         &state.pinned,
@@ -2055,6 +2083,7 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
                         spawn_pin_diff(&mut state, &mut bg_rx, &m);
                     }
                 }
+                KeyOutcome::PersistDiffContext => persist_diff_context(&mut state),
                 KeyOutcome::None => {}
             }
         }
@@ -2535,6 +2564,22 @@ fn refresh_locals(state: &mut AppState) {
     }
 }
 
+/// Persist the diff-context toggle (`diff_show_full`) to the config file, leaving the
+/// configured `diff_context` radius untouched. IO boundary, called from `run_loop`.
+fn persist_diff_context(state: &mut AppState) {
+    let result = crate::config::config_path().and_then(|path| {
+        let mut config = crate::config::load_config(&path)?;
+        config.diff_show_full = state.diff_show_full;
+        crate::config::save_config(&path, &config)?;
+        Ok(())
+    });
+    match result {
+        Ok(()) if state.diff_show_full => state.set_status("Diff context: full file"),
+        Ok(()) => state.set_status(format!("Diff context: {} lines", state.diff_context)),
+        Err(error) => state.set_status(format!("save config failed: {error}")),
+    }
+}
+
 fn pin_selected(state: &mut AppState) {
     let (Some(local), Some(gist)) = (state.selected_local(), state.selected_gist()) else {
         return;
@@ -2660,6 +2705,12 @@ Pinned Mappings screen (P)
   x          unpin the selected pair
   status     ✓ synced · ↑ local newer · ↓ remote newer · ? unknown
   Each row shows (local <age> · gist <age>) relative modification times.
+
+Diff view (Enter / d / u)
+  Up/Down/Left/Right  scroll the diff
+  c          toggle context: configured radius <-> full file (remembered)
+  d / u      download / upload from the diff
+  Esc / q    back
 
 Upload Confirmation screen (u)
   y          confirm and execute the upload
@@ -3430,13 +3481,13 @@ fn confirm_modal_style(state: &AppState) -> (&'static str, Color) {
 
 /// Render just the diff content pane (no footer) into `area`.
 fn render_diff_pane(frame: &mut Frame, area: Rect, state: &AppState) {
+    // Collapse unchanged context to the configured radius unless the user toggled full view.
+    let diff_body = match state.effective_diff_context() {
+        Some(radius) => crate::diff::collapse_context(&state.diff_text, radius),
+        None => state.diff_text.clone(),
+    };
     frame.render_widget(
-        Paragraph::new(diff_view(
-            &state.diff_text,
-            state.diff_scroll,
-            state.diff_hscroll,
-        ))
-        .block(
+        Paragraph::new(diff_view(&diff_body, state.diff_scroll, state.diff_hscroll)).block(
             Block::default()
                 .title(diff_title(state))
                 .borders(Borders::ALL)
@@ -3448,10 +3499,17 @@ fn render_diff_pane(frame: &mut Frame, area: Rect, state: &AppState) {
 
 /// The `Screen::Diff` preview: the diff pane plus a scroll/commands footer.
 fn render_diff(frame: &mut Frame, state: &AppState) {
-    let footer = if state.diff_identical {
-        "Files are identical — nothing to sync  ·  ↑↓←→ scroll  ·  Esc/q back".to_string()
+    let context = if state.diff_show_full {
+        "c context [full]".to_string()
     } else {
-        "↑↓←→ scroll  ·  d download  ·  u upload  ·  Esc/q back".to_string()
+        format!("c context [{}]", state.diff_context)
+    };
+    let footer = if state.diff_identical {
+        format!(
+            "Files are identical — nothing to sync  ·  ↑↓←→ scroll  ·  {context}  ·  Esc/q back"
+        )
+    } else {
+        format!("↑↓←→ scroll  ·  d download  ·  u upload  ·  {context}  ·  Esc/q back")
     };
 
     let area = frame.area();
@@ -3939,6 +3997,27 @@ mod tests {
         state.screen = Screen::Help;
         assert_eq!(state.handle_key(KeyCode::Char('q')), KeyOutcome::None);
         assert_eq!(state.screen, Screen::List);
+    }
+
+    #[test]
+    fn diff_context_toggle_flips_effective_radius() {
+        let mut state = initial_state();
+        state.diff_context = 3;
+        assert_eq!(state.effective_diff_context(), Some(3));
+
+        // Pressing `c` in the diff view flips to full view and resets the scroll.
+        state.screen = Screen::Diff;
+        state.diff_scroll = 12;
+        let outcome = state.handle_key(KeyCode::Char('c'));
+        assert_eq!(outcome, KeyOutcome::PersistDiffContext);
+        assert!(state.diff_show_full);
+        assert_eq!(state.diff_scroll, 0);
+        assert_eq!(state.effective_diff_context(), None);
+
+        // Pressing it again returns to the configured radius.
+        state.handle_key(KeyCode::Char('c'));
+        assert!(!state.diff_show_full);
+        assert_eq!(state.effective_diff_context(), Some(3));
     }
 
     #[test]


### PR DESCRIPTION
## What

Large diffs bury the actual change in unchanged lines. This collapses the unified diff to a configurable number of context lines around each change (like `git diff -U<n>`), replacing longer unchanged runs with a `@@ N unchanged line(s) hidden @@` marker.

- **Config:** new `diff_context` (default `3`) — context lines kept around each change.
- **Runtime toggle:** `c` in the diff view flips between the configured radius and the full file. The state is **remembered** via a persisted `diff_show_full` flag (rewritten on press).
- The collapse is a **pure transform** over the existing unified-diff text (`diff::collapse_context`), applied at render time — `diff_text` stays full, so toggling needs no re-fetch. All `+`/`-` changes and word-level inline highlighting are preserved, keeping the overwrite gate's diff intact.
- Footer shows the current mode (`c context [3]` / `c context [full]`).

## Docs

README Actions, `?` help (new "Diff view" section), and `config.example.toml` updated.

## Test

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — all pass. Added pure unit tests for `collapse_context` (radius keep/hide, lossless at large radius) and the `c` toggle (`effective_diff_context`). Live TUI rendering not exercised (needs a TTY).

Closes #52


---
_Rebased onto `main` after #51 merged; the collapse now runs in the shared `render_diff_pane`, so it applies to both the Diff screen and the centered confirm prompt while keeping all changes (and the overwrite gate) visible._
