### PR TITLE
feat: accept a working-directory path argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,16 @@ ln -sf "$PWD/target/release/gistui" ~/.local/bin/gistui
 ## Usage
 
 ```bash
-gistui            # launch the TUI (needs a TTY)
+gistui            # launch the TUI in the current directory (needs a TTY)
+gistui ~/dotfiles # launch against a specific working directory
 gistui --check    # print gh readiness, then exit (no TUI)
 ```
 
-Run `gistui` from the directory whose files you want to pair with your gists. Inside the
-TUI press `?` for the full keymap (it also shows the running version and the project
-repository link); the footer shows the keys relevant to the focused pane.
+Run `gistui` from the directory whose files you want to pair with your gists, or pass that
+directory as an argument. The path defaults to the current directory; if you pass one that
+does not exist (or is not a directory) `gistui` prints an error and exits without launching.
+Inside the TUI press `?` for the full keymap (it also shows the running version and the
+project repository link); the footer shows the keys relevant to the focused pane.
 
 The left pane lists the files in your current working directory; the right pane lists your
 gists. Ranking is **focus-driven**: the focused pane is the driver and the other pane is

--- a/src/config.rs
+++ b/src/config.rs
@@ -81,6 +81,25 @@ pub fn normalize_path(path: &Path) -> Result<PathBuf> {
     }
 }
 
+/// Resolve the working directory to operate in. `None` keeps the current directory;
+/// `Some(path)` must point at an existing directory (a `~` prefix is expanded) — a missing
+/// path or a non-directory is an error, so the caller can report it and exit before the TUI.
+pub fn resolve_working_dir(path: Option<PathBuf>) -> Result<PathBuf> {
+    match path {
+        None => std::env::current_dir().context("could not determine the current directory"),
+        Some(path) => {
+            let path = normalize_path(&path)?;
+            if !path.exists() {
+                anyhow::bail!("path does not exist: {}", path.display());
+            }
+            if !path.is_dir() {
+                anyhow::bail!("not a directory: {}", path.display());
+            }
+            Ok(path)
+        }
+    }
+}
+
 pub fn config_path() -> Result<PathBuf> {
     let base = std::env::var_os("XDG_CONFIG_HOME")
         .filter(|value| !value.is_empty())
@@ -247,5 +266,39 @@ mod tests {
     fn normalize_path_preserves_absolute_path() {
         let absolute = PathBuf::from("/tmp/settings.json");
         assert_eq!(normalize_path(&absolute).unwrap(), absolute);
+    }
+
+    #[test]
+    fn resolve_working_dir_defaults_to_current_dir_when_none() {
+        assert_eq!(
+            resolve_working_dir(None).unwrap(),
+            env::current_dir().unwrap()
+        );
+    }
+
+    #[test]
+    fn resolve_working_dir_accepts_an_existing_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            resolve_working_dir(Some(dir.path().to_path_buf())).unwrap(),
+            dir.path()
+        );
+    }
+
+    #[test]
+    fn resolve_working_dir_rejects_a_missing_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("nope");
+        let err = resolve_working_dir(Some(missing)).unwrap_err();
+        assert!(err.to_string().contains("does not exist"));
+    }
+
+    #[test]
+    fn resolve_working_dir_rejects_a_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("a.txt");
+        std::fs::write(&file, "x").unwrap();
+        let err = resolve_working_dir(Some(file)).unwrap_err();
+        assert!(err.to_string().contains("not a directory"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use clap::Parser;
+use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -10,10 +11,21 @@ use clap::Parser;
 struct Cli {
     #[arg(long, help = "Print startup checks without launching the TUI")]
     check: bool,
+    #[arg(
+        value_name = "PATH",
+        help = "Working directory to pair files against (defaults to the current directory)"
+    )]
+    path: Option<PathBuf>,
 }
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
+
+    // Validate the working directory before touching the terminal, so a bad path fails
+    // cleanly with a non-zero exit instead of half-entering the TUI.
+    let workdir = gistui::config::resolve_working_dir(cli.path)?;
+    std::env::set_current_dir(&workdir)
+        .map_err(|e| anyhow::anyhow!("could not enter {}: {e}", workdir.display()))?;
 
     if cli.check {
         gistui::gh::check_gh_ready()?;


### PR DESCRIPTION
## What

Add an optional positional `PATH` argument so `gistui` can pair files against a directory other than the cwd.

- `gistui [PATH]` operates against `PATH`; omitting it keeps today's behaviour (current directory).
- The path is validated **before the terminal is touched** (`config::resolve_working_dir`, with `~` expansion): a missing path or a non-directory prints an error to stderr and exits non-zero — no half-started TUI, terminal left clean.
- A valid path becomes the process working directory via `set_current_dir`, so the existing cwd-based discovery and the download/overwrite safety rules apply unchanged.
- Composes with `--check`.

## Test

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — all pass (added 4 unit tests for `resolve_working_dir`: default cwd, existing dir, missing path, non-directory). Smoke-tested the binary:

- `gistui /no/such/dir` → `Error: path does not exist: …`, exit 1
- `gistui Cargo.toml` → `Error: not a directory: …`, exit 1
- `gistui /tmp --check` → exit 0

README Usage updated.

Closes #54