### PR TITLE
chore: bump version to 0.4.0 and align help text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "gistui"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gistui"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "MIT"
 description = "A terminal UI for managing GitHub Gists"

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 #[command(
     name = "gistui",
     version,
-    about = "Manage local config files and GitHub gist files"
+    about = "A terminal UI for managing GitHub Gists"
 )]
 struct Cli {
     #[arg(long, help = "Print startup checks without launching the TUI")]


### PR DESCRIPTION
Bump version to 0.4.0 and align the CLI about description in help text with the Cargo.toml project description.