### PR TITLE
feat: gist detail view with comments + list refinements (v0.5.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "gistui"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gistui"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 description = "A terminal UI for managing GitHub Gists"

--- a/README.md
+++ b/README.md
@@ -149,11 +149,16 @@ Press `g` to open the **gist manager** — a gist-level view (one row per gist) 
 the gist owning the currently selected file. From here you manage gists as a whole:
 
 - `e` — edit the gist's description (type, `Enter` applies, `Esc` cancels).
+- `Enter` — open the **gist detail view**: shows basic info (description, visibility,
+  created/updated age, file count, short id), the file list, and fetched comments.
+  - `↑`/`↓` scroll comments · `PageUp`/`PageDown` page through comments.
+  - `c` compact · `o` browser · `q`/`Esc` back to the gist manager.
 - `X` — delete the entire gist and all its files, after a `y`/`n` confirmation.
 - `o` — open the gist on gist.github.com in your browser.
 - `c` — compact revisions: after showing the revision count and a `y`/`n` confirmation, the
   gist is cloned to a temp dir, its history squashed to a single commit, and force-pushed —
-  collapsing all older revisions. Irreversible.
+  collapsing all older revisions. Irreversible. (When triggered from the detail view, the
+  confirmation prompt shows the gist's info as context.)
 - `s` cycle sort (updated / created) · `v` cycle visibility (all/public/secret) · `/` filter
   by description or id · `Left`/`Right` scroll a long description.
 - `q`/`Esc` — back to the list.
@@ -170,7 +175,8 @@ the gist owning the currently selected file. From here you manage gists as a who
   confirmation — one-key sync never overwrites a local file silently.
 - Destructive remote actions each require a `y`/`n` confirmation: removing a file from a
   gist (`X` on the list), deleting a whole gist (`X` in the gist manager), and compacting a
-  gist's revisions (`c` in the gist manager — a history-rewriting force-push).
+  gist's revisions (`c` in the gist manager or detail view — a history-rewriting force-push;
+  the confirmation prompt displays the gist's info so the target stays visible while you decide).
 - No GitHub token is stored by the app, and gist content is never written to the config
   file — only path↔gist pin mappings are persisted.
 

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -86,6 +86,15 @@ pub struct GistGroup {
     pub file_count: usize,
 }
 
+/// A single gist comment, mirroring one object from `gh api /gists/{id}/comments`.
+/// The body is kept as raw plain text; the TUI wraps it to width (no markdown rendering).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GistComment {
+    pub author: String,
+    pub created_at: String,
+    pub body: String,
+}
+
 /// Lowercase hex SHA-256 of `bytes`. Used as the stable, content-only digest
 /// persisted in `PinnedMapping.last_seen_hash` (the config never stores content).
 pub fn sha256_hex(bytes: &[u8]) -> String {

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -1,5 +1,5 @@
 use crate::actions::{run_command, CommandPlan, CommandRunner, SystemRunner};
-use crate::domain::GistFile;
+use crate::domain::{GistComment, GistFile};
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 use std::collections::BTreeMap;
@@ -73,6 +73,26 @@ pub fn gist_view_plan(gist_id: &str, filename: &str) -> CommandPlan {
     }
 }
 
+/// Plan for fetching a gist's comments via the REST API.
+pub fn gist_comments_plan(gist_id: &str) -> CommandPlan {
+    CommandPlan {
+        program: "gh".into(),
+        args: vec![
+            "api".into(),
+            "--paginate".into(),
+            format!("/gists/{gist_id}/comments?per_page=100"),
+        ],
+    }
+}
+
+pub fn fetch_gist_comments_json(gist_id: &str) -> Result<String> {
+    fetch_gist_comments_json_with(&SystemRunner, gist_id)
+}
+
+pub fn fetch_gist_comments_json_with(runner: &dyn CommandRunner, gist_id: &str) -> Result<String> {
+    run_command(runner, &gist_comments_plan(gist_id))
+}
+
 pub fn check_gh_ready() -> Result<()> {
     check_gh_ready_with(&SystemRunner)
 }
@@ -106,6 +126,39 @@ pub fn parse_gist_list_json(raw: &str) -> Result<Vec<GistFile>> {
     }
 
     Ok(files)
+}
+
+#[derive(Debug, Deserialize)]
+struct GhComment {
+    #[serde(default)]
+    user: Option<GhCommentUser>,
+    #[serde(default)]
+    created_at: String,
+    #[serde(default)]
+    body: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhCommentUser {
+    #[serde(default)]
+    login: String,
+}
+
+pub fn parse_gist_comments_json(raw: &str) -> Result<Vec<GistComment>> {
+    let comments: Vec<GhComment> =
+        serde_json::from_str(raw).context("parse gh gist comments JSON")?;
+    Ok(comments
+        .into_iter()
+        .map(|c| GistComment {
+            author: c
+                .user
+                .map(|u| u.login)
+                .filter(|l| !l.is_empty())
+                .unwrap_or_else(|| "(unknown)".to_string()),
+            created_at: c.created_at,
+            body: c.body,
+        })
+        .collect())
 }
 
 pub fn fetch_gist_list_json() -> Result<String> {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -3409,12 +3409,6 @@ fn render_pane(
     } else {
         Style::default().add_modifier(Modifier::BOLD)
     };
-    let title = if focused {
-        format!("{title} [focus]")
-    } else {
-        title.to_string()
-    };
-
     let list = List::new(items)
         .block(
             Block::default()

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -511,7 +511,7 @@ impl AppState {
     fn gists_hscroll_max(&self) -> u16 {
         self.visible_gist_groups()
             .iter()
-            .map(|g| gist_group_row_label(g).chars().count())
+            .map(|g| gist_group_row_label(g, unix_now()).chars().count())
             .max()
             .unwrap_or(0)
             .saturating_sub(1)
@@ -3135,18 +3135,19 @@ fn render_pins(frame: &mut Frame, state: &AppState) {
     render_footer(frame, chunks[1], "", &footer, true);
 }
 
-fn gist_group_row_label(g: &GistGroup) -> String {
+fn gist_group_row_label(g: &GistGroup, now: u64) -> String {
     let desc = if g.description.trim().is_empty() {
         "(no description)".to_string()
     } else {
         g.description.clone()
     };
-    let visibility = if g.public { "public" } else { "secret" };
-    let date: String = g.updated_at.chars().take(10).collect();
-    format!(
-        "{}  {}  [{}]  {}f  {}",
-        g.id, desc, visibility, g.file_count, date
-    )
+    // Visibility is dropped from the row — it's surfaced by the `v` filter, the title's
+    // `type:` label, and the detail view. 📄 / 🕒 distinguish file count from last-updated age.
+    // The date is shown as a relative age (single largest unit), matching the detail view.
+    let updated = crate::domain::parse_rfc3339_to_unix(&g.updated_at)
+        .map(|t| crate::domain::humanize_age(now as i64 - t as i64))
+        .unwrap_or_else(|| "?".into());
+    format!("{}  {}  📄 {}  🕒 {}", g.id, desc, g.file_count, updated)
 }
 
 fn render_gists(frame: &mut Frame, state: &AppState) {
@@ -3176,6 +3177,7 @@ fn render_gists(frame: &mut Frame, state: &AppState) {
         .split(area);
 
     let groups = state.visible_gist_groups();
+    let now = unix_now();
     let items: Vec<ListItem> = if groups.is_empty() {
         let msg = if state.gist_groups().is_empty() {
             ListItem::new("  📭 No gists found").style(Style::default().fg(Color::DarkGray))
@@ -3187,7 +3189,12 @@ fn render_gists(frame: &mut Frame, state: &AppState) {
     } else {
         groups
             .iter()
-            .map(|g| ListItem::new(hscroll_str(&gist_group_row_label(g), state.gists_hscroll)))
+            .map(|g| {
+                ListItem::new(hscroll_str(
+                    &gist_group_row_label(g, now),
+                    state.gists_hscroll,
+                ))
+            })
             .collect()
     };
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,4 +1,4 @@
-use crate::domain::{group_gists, GistFile, GistGroup, LocalCandidate, PinnedMapping};
+use crate::domain::{group_gists, GistComment, GistFile, GistGroup, LocalCandidate, PinnedMapping};
 use crate::ranking::{rank_gist_files, rank_local_files, RankedGistFile, RankedLocal};
 use anyhow::Result;
 use crossterm::{
@@ -36,6 +36,8 @@ pub enum Screen {
     Help,
     Pins,
     Gists,
+    /// Single-gist detail: basic info + file list + comments (entered from Gists with Enter).
+    GistDetail,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -226,6 +228,8 @@ pub enum KeyOutcome {
     EditUpload,
     ExecuteDelete,
     ExecuteRemoveFile,
+    /// Open the selected gist's detail screen and fetch its comments in the background.
+    OpenGistDetail,
     /// Analyse the selected Gist-manager gist's revision count, then ask to confirm a compaction.
     CompactGist,
     /// Run the confirmed compaction (clone → squash → force-push) on the pending gist.
@@ -316,6 +320,16 @@ pub struct AppState {
     pub download_gist_filename: Option<String>,
     /// Screen to return to when leaving the diff (default: List; set to Pins for pin diffs).
     pub diff_return: Screen,
+    /// The gist currently shown in `Screen::GistDetail`; also guards stale comment responses.
+    pub detail_gist_id: Option<String>,
+    /// Comments: `None` means loading, `Some` is the fetched result.
+    pub detail_comments: Option<Vec<GistComment>>,
+    /// Comment-fetch error message, if any.
+    pub detail_comments_error: Option<String>,
+    /// Comment-pane scroll offset.
+    pub detail_scroll: u16,
+    /// Screen to return to after a compaction confirm is cancelled/finished (Gists or GistDetail).
+    pub compact_return_screen: Screen,
 }
 
 fn unranked_gists(gists: Vec<GistFile>) -> Vec<RankedGistFile> {
@@ -510,6 +524,31 @@ impl AppState {
         self.gists.iter().filter(|g| g.gist_id == gist_id).count()
     }
 
+    /// Filenames the given gist holds in the current in-memory list (gh order).
+    pub fn gist_filenames(&self, gist_id: &str) -> Vec<String> {
+        self.gists
+            .iter()
+            .filter(|g| g.gist_id == gist_id)
+            .map(|g| g.filename.clone())
+            .collect()
+    }
+
+    /// Look up a gist group by id (unaffected by filtering); used by detail + confirm background.
+    pub fn group_by_id(&self, gist_id: &str) -> Option<GistGroup> {
+        self.gist_groups().into_iter().find(|g| g.id == gist_id)
+    }
+
+    /// The gist the current screen acts on: the gist-level cursor on `Gists`, the
+    /// viewed gist on `GistDetail`, otherwise the gist owning the selected file row.
+    /// Screen-aware so IO actions (open-in-browser, compact) target what the user sees.
+    pub fn context_gist_id(&self) -> Option<String> {
+        match self.screen {
+            Screen::Gists => self.selected_group().map(|g| g.id),
+            Screen::GistDetail => self.detail_gist_id.clone(),
+            _ => self.selected_gist().map(|g| g.file.gist_id),
+        }
+    }
+
     /// Upload intent shared by the list and the diff screen: requires a selected local file
     /// and gist, then branches on whether the gist already holds a file of the local name
     /// (case C: preview + confirm overwrite) or not (case B: add directly).
@@ -673,6 +712,7 @@ impl AppState {
             Screen::Help => self.handle_key_help(code),
             Screen::Pins => self.handle_key_pins(code),
             Screen::Gists => self.handle_key_gists(code),
+            Screen::GistDetail => self.handle_key_detail(code),
         }
     }
 
@@ -791,12 +831,16 @@ impl AppState {
                     self.description_input = group.description.clone();
                 }
             }
+            KeyCode::Enter if self.gists_index < groups.len() => {
+                return KeyOutcome::OpenGistDetail;
+            }
             KeyCode::Char('o') if self.gists_index < groups.len() => {
                 return KeyOutcome::OpenBrowser
             }
             KeyCode::Char('c') if self.gists_index < groups.len() => {
                 // The revision count needs a network call, so analysis happens in run_loop;
                 // the confirm prompt is raised once the count is back.
+                self.compact_return_screen = Screen::Gists;
                 return KeyOutcome::CompactGist;
             }
             KeyCode::Char('X') => {
@@ -822,6 +866,50 @@ impl AppState {
             _ => {}
         }
         KeyOutcome::None
+    }
+
+    /// Pure key handling for `Screen::GistDetail`: scroll comments, compact, browser, back.
+    fn handle_key_detail(&mut self, code: KeyCode) -> KeyOutcome {
+        self.status = None;
+        match code {
+            KeyCode::Char('q') | KeyCode::Esc => {
+                self.screen = Screen::Gists;
+            }
+            KeyCode::Down => self.detail_scroll = self.detail_scroll.saturating_add(1),
+            KeyCode::Up => self.detail_scroll = self.detail_scroll.saturating_sub(1),
+            KeyCode::PageDown => self.detail_scroll = self.detail_scroll.saturating_add(10),
+            KeyCode::PageUp => self.detail_scroll = self.detail_scroll.saturating_sub(10),
+            KeyCode::Char('o') => return KeyOutcome::OpenBrowser,
+            KeyCode::Char('c') => {
+                self.compact_return_screen = Screen::GistDetail;
+                return KeyOutcome::CompactGist;
+            }
+            _ => {}
+        }
+        KeyOutcome::None
+    }
+
+    /// Apply a finished comment fetch, ignoring it if the user has since navigated to a
+    /// different gist (stale response). On error, comments become an empty list and the
+    /// error message is retained so the detail view can surface it.
+    pub fn apply_fetched_comments(
+        &mut self,
+        gist_id: &str,
+        result: Result<Vec<GistComment>, String>,
+    ) {
+        if self.detail_gist_id.as_deref() != Some(gist_id) {
+            return;
+        }
+        match result {
+            Ok(comments) => {
+                self.detail_comments = Some(comments);
+                self.detail_comments_error = None;
+            }
+            Err(error) => {
+                self.detail_comments = Some(Vec::new());
+                self.detail_comments_error = Some(error);
+            }
+        }
     }
 
     fn handle_key_preview(&mut self, code: KeyCode) -> KeyOutcome {
@@ -1201,9 +1289,9 @@ impl AppState {
             Some(PendingAction::CompactGist { .. }) => match code {
                 KeyCode::Char('y') => return KeyOutcome::ExecuteCompactGist,
                 KeyCode::Char('n') | KeyCode::Char('q') | KeyCode::Esc => {
-                    // Compaction is launched from the gist manager; return there, not the list.
+                    // Return to whichever screen launched the compaction (Gists or GistDetail).
                     self.pending_action = None;
-                    self.screen = Screen::Gists;
+                    self.screen = self.compact_return_screen;
                 }
                 _ => {}
             },
@@ -1283,6 +1371,10 @@ enum BgTaskOutcome {
         label: String,
         count: usize,
     },
+    CommentsFetched {
+        gist_id: String,
+        result: Result<Vec<GistComment>, String>,
+    },
 }
 
 pub fn initial_state() -> AppState {
@@ -1345,6 +1437,11 @@ pub fn initial_state() -> AppState {
         download_gist_id: None,
         download_gist_filename: None,
         diff_return: Screen::List,
+        detail_gist_id: None,
+        detail_comments: None,
+        detail_comments_error: None,
+        detail_scroll: 0,
+        compact_return_screen: Screen::Gists,
     }
 }
 
@@ -1734,6 +1831,9 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
                         }
                         Err(error) => state.set_status(format!("compact failed: {error}")),
                     },
+                    BgTaskOutcome::CommentsFetched { gist_id, result } => {
+                        state.apply_fetched_comments(&gist_id, result);
+                    }
                 }
             }
         }
@@ -1812,11 +1912,40 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
                         });
                     });
                 }
-                KeyOutcome::CompactGist => {
+                KeyOutcome::OpenGistDetail => {
                     let Some(group) = state.selected_group() else {
                         continue;
                     };
                     let gist_id = group.id.clone();
+                    state.screen = Screen::GistDetail;
+                    state.detail_gist_id = Some(gist_id.clone());
+                    state.detail_comments = None;
+                    state.detail_comments_error = None;
+                    state.detail_scroll = 0;
+
+                    state.bg_task_msg = Some("Loading comments…".to_string());
+                    let (tx, rx) = std::sync::mpsc::channel();
+                    bg_rx = Some(rx);
+                    let fetch_id = gist_id.clone();
+                    std::thread::spawn(move || {
+                        let result = crate::gh::fetch_gist_comments_json(&fetch_id)
+                            .map_err(|e| e.to_string())
+                            .and_then(|raw| {
+                                crate::gh::parse_gist_comments_json(&raw).map_err(|e| e.to_string())
+                            });
+                        let _ = tx.send(BgTaskOutcome::CommentsFetched {
+                            gist_id: fetch_id,
+                            result,
+                        });
+                    });
+                }
+                KeyOutcome::CompactGist => {
+                    let Some(gist_id) = state.context_gist_id() else {
+                        continue;
+                    };
+                    let Some(group) = state.group_by_id(&gist_id) else {
+                        continue;
+                    };
                     let label = if group.description.trim().is_empty() {
                         group.id.clone()
                     } else {
@@ -2100,7 +2229,7 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
                         continue;
                     };
                     state.pending_action = None;
-                    state.screen = Screen::Gists;
+                    state.screen = state.compact_return_screen;
 
                     state.bg_task_msg = Some("Compacting revisions…".to_string());
                     let (tx, rx) = std::sync::mpsc::channel();
@@ -2558,11 +2687,7 @@ fn preview_diff_text(
 }
 
 fn open_browser(state: &mut AppState) {
-    // The gist-level view selects by gist; the main list selects by file row.
-    let gist_id = match state.screen {
-        Screen::Gists => state.selected_group().map(|g| g.id),
-        _ => state.selected_gist().map(|g| g.file.gist_id),
-    };
+    let gist_id = state.context_gist_id();
     let Some(gist_id) = gist_id else {
         return;
     };
@@ -2816,6 +2941,7 @@ fn render(frame: &mut Frame, state: &AppState) {
         Screen::Help => render_help(frame, state),
         Screen::Pins => render_pins(frame, state),
         Screen::Gists => render_gists(frame, state),
+        Screen::GistDetail => render_gist_detail(frame, state),
     }
     if let Some(ref msg) = state.bg_task_msg {
         render_loading_overlay(frame, msg);
@@ -3097,6 +3223,148 @@ fn render_gists(frame: &mut Frame, state: &AppState) {
             Color::Cyan,
         );
     }
+}
+
+/// One-line info summary for the detail header.
+fn gist_info_line(group: &GistGroup, now: u64) -> String {
+    let vis = if group.public { "public" } else { "secret" };
+    let created = crate::domain::parse_rfc3339_to_unix(&group.created_at)
+        .map(|t| crate::domain::humanize_age(now as i64 - t as i64))
+        .unwrap_or_else(|| "?".into());
+    let updated = crate::domain::parse_rfc3339_to_unix(&group.updated_at)
+        .map(|t| crate::domain::humanize_age(now as i64 - t as i64))
+        .unwrap_or_else(|| "?".into());
+    // The file count lives in the "Files (N)" section header below, so it's omitted here.
+    // The detail view has room, so show the full gist id (not a truncated prefix).
+    format!(
+        "{vis} · created {created} · updated {updated} · {}",
+        group.id
+    )
+}
+
+/// Current Unix time in seconds (saturating to 0 before the epoch); used for relative-age labels.
+fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Info + file-list block for a gist (reused as the compaction-confirm background).
+fn render_gist_info_and_files(frame: &mut Frame, area: Rect, state: &AppState, gist_id: &str) {
+    let Some(group) = state.group_by_id(gist_id) else {
+        return;
+    };
+    let now = unix_now();
+    let title = if group.description.trim().is_empty() {
+        format!("Gist {}", group.id)
+    } else {
+        format!("Gist: {}", group.description)
+    };
+    let files = state.gist_filenames(gist_id);
+    let mut lines: Vec<Line> = vec![
+        Line::from(gist_info_line(&group, now)),
+        Line::from(""),
+        Line::from(Span::styled(
+            format!("Files ({})", files.len()),
+            Style::default().add_modifier(Modifier::BOLD),
+        )),
+    ];
+    for f in &files {
+        lines.push(Line::from(format!("  {f}")));
+    }
+    frame.render_widget(
+        Paragraph::new(lines).block(
+            Block::default()
+                .title(title)
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(Style::default().fg(Color::Cyan))
+                .padding(Padding::horizontal(1)),
+        ),
+        area,
+    );
+}
+
+/// Comments pane: loading / error / empty / list (plain text wrapped to width, scrollable).
+fn render_gist_comments(frame: &mut Frame, area: Rect, state: &AppState) {
+    let now = unix_now();
+    let body: Vec<Line> = match (&state.detail_comments, &state.detail_comments_error) {
+        (None, _) => vec![Line::from(Span::styled(
+            "Loading comments…",
+            Style::default().fg(Color::DarkGray),
+        ))],
+        (Some(_), Some(err)) => vec![Line::from(Span::styled(
+            format!("comments error: {err}"),
+            Style::default().fg(Color::Red),
+        ))],
+        (Some(comments), None) if comments.is_empty() => vec![Line::from(Span::styled(
+            "No comments",
+            Style::default().fg(Color::DarkGray),
+        ))],
+        (Some(comments), None) => {
+            let mut lines = Vec::new();
+            for c in comments {
+                let age = crate::domain::parse_rfc3339_to_unix(&c.created_at)
+                    .map(|t| crate::domain::humanize_age(now as i64 - t as i64))
+                    .unwrap_or_else(|| "?".into());
+                lines.push(Line::from(Span::styled(
+                    format!("{} · {age}", c.author),
+                    Style::default().fg(Color::Cyan),
+                )));
+                for raw in c.body.lines() {
+                    lines.push(Line::from(format!("  {raw}")));
+                }
+                lines.push(Line::from(""));
+            }
+            lines
+        }
+    };
+    let title = match &state.detail_comments {
+        Some(c) if state.detail_comments_error.is_none() => format!("Comments ({})", c.len()),
+        _ => "Comments".to_string(),
+    };
+    frame.render_widget(
+        Paragraph::new(body)
+            .scroll((state.detail_scroll, 0))
+            .wrap(Wrap { trim: false })
+            .block(
+                Block::default()
+                    .title(title)
+                    .borders(Borders::ALL)
+                    .border_type(BorderType::Rounded)
+                    .padding(Padding::horizontal(1)),
+            ),
+        area,
+    );
+}
+
+fn render_gist_detail(frame: &mut Frame, state: &AppState) {
+    let area = frame.area();
+    let footer = "↑↓ scroll · c compact · o browser · q back";
+    let footer_lines = wrap_line_count(footer, area.width.saturating_sub(2)).max(1);
+    let files = state
+        .detail_gist_id
+        .as_deref()
+        .map(|id| state.gist_filenames(id).len())
+        .unwrap_or(0);
+    // Scale to the file count, but never exceed half the screen nor drop below 5 rows.
+    let info_height = (files as u16)
+        .saturating_add(5)
+        .clamp(5, (area.height / 2).max(5));
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(info_height),
+            Constraint::Min(3),
+            Constraint::Length(footer_lines + 1),
+        ])
+        .split(area);
+    if let Some(id) = state.detail_gist_id.as_deref() {
+        render_gist_info_and_files(frame, chunks[0], state, id);
+    }
+    render_gist_comments(frame, chunks[1], state);
+    render_footer(frame, chunks[2], "", footer, true);
 }
 
 fn local_row_label(path: &std::path::Path, cwd: &std::path::Path) -> String {
@@ -3791,7 +4059,12 @@ fn render_diff(frame: &mut Frame, state: &AppState) {
 /// `Screen::Confirm`: the diff fills the screen as context behind a centered prompt modal,
 /// keeping the overwrite gate's diff visible while the question is asked front-and-centre.
 fn render_confirm(frame: &mut Frame, state: &AppState) {
-    render_diff_pane(frame, frame.area(), state);
+    match &state.pending_action {
+        Some(PendingAction::CompactGist { gist_id, .. }) => {
+            render_gist_info_and_files(frame, frame.area(), state, gist_id);
+        }
+        _ => render_diff_pane(frame, frame.area(), state),
+    }
     let (title, border) = confirm_modal_style(state);
     render_centered_modal(frame, title, &confirm_prompt(state), border);
 }
@@ -3807,6 +4080,85 @@ fn is_json_file(path: &std::path::Path) -> bool {
 mod tests {
     use super::*;
     use std::path::PathBuf;
+
+    fn state_with_gists() -> AppState {
+        let mut state = initial_state();
+        state.gists = vec![
+            GistFile {
+                gist_id: "g1".into(),
+                description: "demo".into(),
+                filename: "a.txt".into(),
+                public: false,
+                updated_at: "2026-06-10T00:00:00Z".into(),
+                created_at: "2026-06-01T00:00:00Z".into(),
+            },
+            GistFile {
+                gist_id: "g1".into(),
+                description: "demo".into(),
+                filename: "b.txt".into(),
+                public: false,
+                updated_at: "2026-06-10T00:00:00Z".into(),
+                created_at: "2026-06-01T00:00:00Z".into(),
+            },
+        ];
+        state.gists_index = 0;
+        state
+    }
+
+    #[test]
+    fn enter_on_gist_opens_detail() {
+        let mut state = state_with_gists();
+        state.screen = Screen::Gists;
+        let outcome = state.handle_key(KeyCode::Enter);
+        assert!(matches!(outcome, KeyOutcome::OpenGistDetail));
+    }
+
+    #[test]
+    fn detail_q_returns_to_gists() {
+        let mut state = state_with_gists();
+        state.screen = Screen::GistDetail;
+        state.handle_key(KeyCode::Char('q'));
+        assert_eq!(state.screen, Screen::Gists);
+    }
+
+    #[test]
+    fn detail_scroll_saturates_at_zero() {
+        let mut state = state_with_gists();
+        state.screen = Screen::GistDetail;
+        state.detail_scroll = 0;
+        state.handle_key(KeyCode::Up);
+        assert_eq!(state.detail_scroll, 0);
+        state.handle_key(KeyCode::Down);
+        assert_eq!(state.detail_scroll, 1);
+    }
+
+    #[test]
+    fn detail_c_triggers_compaction_and_records_origin() {
+        let mut state = state_with_gists();
+        state.screen = Screen::GistDetail;
+        let outcome = state.handle_key(KeyCode::Char('c'));
+        assert!(matches!(outcome, KeyOutcome::CompactGist));
+        assert_eq!(state.compact_return_screen, Screen::GistDetail);
+    }
+
+    #[test]
+    fn context_gist_id_uses_detail_id_on_detail_screen() {
+        let mut state = state_with_gists();
+        state.screen = Screen::GistDetail;
+        state.detail_gist_id = Some("g1".into());
+        assert_eq!(state.context_gist_id().as_deref(), Some("g1"));
+    }
+
+    #[test]
+    fn context_gist_id_uses_group_cursor_on_gists_screen() {
+        let mut state = state_with_gists();
+        state.screen = Screen::Gists;
+        state.gists_index = 0;
+        assert_eq!(
+            state.context_gist_id(),
+            state.selected_group().map(|g| g.id)
+        );
+    }
 
     #[test]
     fn about_metadata_is_available_for_help() {
@@ -5677,5 +6029,47 @@ mod tests {
             state.handle_key(KeyCode::Char('S')),
             KeyOutcome::SyncSelectedPair
         );
+    }
+
+    #[test]
+    fn fetched_comments_apply_when_viewing_same_gist() {
+        let mut state = initial_state();
+        state.detail_gist_id = Some("g1".into());
+        state.apply_fetched_comments(
+            "g1",
+            Ok(vec![GistComment {
+                author: "alice".into(),
+                created_at: "2026-06-10T00:00:00Z".into(),
+                body: "hi".into(),
+            }]),
+        );
+        assert_eq!(state.detail_comments.as_ref().unwrap().len(), 1);
+        assert!(state.detail_comments_error.is_none());
+    }
+
+    #[test]
+    fn fetched_comments_ignored_when_gist_changed() {
+        let mut state = initial_state();
+        state.detail_gist_id = Some("g2".into());
+        state.detail_comments = None;
+        state.apply_fetched_comments(
+            "g1",
+            Ok(vec![GistComment {
+                author: "alice".into(),
+                created_at: "2026-06-10T00:00:00Z".into(),
+                body: "stale".into(),
+            }]),
+        );
+        // Result was for g1 but user is on g2 → ignored.
+        assert!(state.detail_comments.is_none());
+    }
+
+    #[test]
+    fn fetched_comments_error_sets_empty_list_and_message() {
+        let mut state = initial_state();
+        state.detail_gist_id = Some("g1".into());
+        state.apply_fetched_comments("g1", Err("boom".into()));
+        assert_eq!(state.detail_comments.as_ref().unwrap().len(), 0);
+        assert_eq!(state.detail_comments_error.as_deref(), Some("boom"));
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -3010,10 +3010,18 @@ Gist manager (g)
   s          cycle sort: updated / created
   v          cycle visibility: all / public / secret
   e          edit the gist description (Enter apply, Esc cancel)
+  Enter      open the gist detail view (info, file list, comments)
   o          open the gist in your web browser
   c          compact revisions: squash history to one commit (force-push, y/n confirm)
   X          delete the entire gist and all its files (y/n confirm)
   q / Esc    back to the list
+
+Gist detail (Enter from gist manager)
+  Up/Down    scroll comments
+  PageUp/Dn  page through comments
+  c          compact revisions (y/n confirm; gist info shown as context)
+  o          open the gist in your web browser
+  q / Esc    back to the gist manager
 
 General
   Esc / q    close an overlay; from the list, press twice to quit the app
@@ -3156,7 +3164,7 @@ fn render_gists(frame: &mut Frame, state: &AppState) {
     } else {
         (
             String::new(),
-            "↑↓ move · ←→ scroll · / filter · s sort · v type · e desc · o browser · c compact · X delete · q back"
+            "↑↓ move · ←→ scroll · Enter detail · / filter · s sort · v type · e desc · o browser · c compact · X delete · q back"
                 .to_string(),
             true,
         )

--- a/tests/fixtures/gh/gist-comments.json
+++ b/tests/fixtures/gh/gist-comments.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": 1001,
+    "user": { "login": "alice" },
+    "created_at": "2026-06-10T08:30:00Z",
+    "body": "Looks good — maybe add a usage example?"
+  },
+  {
+    "id": 1002,
+    "user": { "login": "bob" },
+    "created_at": "2026-06-10T12:00:00Z",
+    "body": "Multi-line\nbody here."
+  },
+  {
+    "id": 1003,
+    "user": null,
+    "created_at": "2026-06-11T01:00:00Z",
+    "body": "ghost comment"
+  }
+]

--- a/tests/gh_integration.rs
+++ b/tests/gh_integration.rs
@@ -12,8 +12,9 @@ use std::path::PathBuf;
 use gistui::actions::{run_command, upload_command, CommandOutput, CommandPlan, CommandRunner};
 use gistui::domain::GistFile;
 use gistui::gh::{
-    auth_status_plan, check_gh_ready_with, fetch_gist_file_content_with, fetch_gist_list_json_with,
-    gh_version_plan, gist_list_plan, gist_view_plan, parse_gist_list_json,
+    auth_status_plan, check_gh_ready_with, fetch_gist_comments_json_with,
+    fetch_gist_file_content_with, fetch_gist_list_json_with, gh_version_plan, gist_comments_plan,
+    gist_list_plan, gist_view_plan, parse_gist_comments_json, parse_gist_list_json,
 };
 
 /// A scripted runner: returns queued outputs in order and records every plan it
@@ -60,6 +61,7 @@ impl CommandRunner for FakeRunner {
 }
 
 const GIST_LIST_JSON: &str = include_str!("fixtures/gh/gist-list.json");
+const GIST_COMMENTS_JSON: &str = include_str!("fixtures/gh/gist-comments.json");
 
 #[test]
 fn fetch_and_parse_gist_list_via_fake_runner() {
@@ -164,4 +166,35 @@ fn run_command_surfaces_stderr_on_failure() {
 
     let err = run_command(&runner, &plan).unwrap_err();
     assert!(err.to_string().contains("gist not found"));
+}
+
+#[test]
+fn fetch_and_parse_gist_comments_via_fake_runner() {
+    let runner = FakeRunner::new(vec![FakeRunner::ok(GIST_COMMENTS_JSON)]);
+
+    let raw = fetch_gist_comments_json_with(&runner, "abc123").unwrap();
+    let comments = parse_gist_comments_json(&raw).unwrap();
+
+    assert_eq!(comments.len(), 3);
+    assert_eq!(comments[0].author, "alice");
+    assert_eq!(comments[1].author, "bob");
+    assert_eq!(comments[1].body, "Multi-line\nbody here.");
+    assert_eq!(comments[2].author, "(unknown)");
+    assert_eq!(comments[2].body, "ghost comment");
+    assert_eq!(comments[2].created_at, "2026-06-11T01:00:00Z");
+    assert_eq!(runner.calls.borrow()[0], gist_comments_plan("abc123"));
+}
+
+#[test]
+fn fetch_gist_comments_surfaces_stderr_on_failure() {
+    let runner = FakeRunner::new(vec![FakeRunner::fail("HTTP 404: Not Found")]);
+
+    let err = fetch_gist_comments_json_with(&runner, "missing").unwrap_err();
+    assert!(err.to_string().contains("Not Found"));
+}
+
+#[test]
+fn parse_gist_comments_handles_empty_array() {
+    let comments = parse_gist_comments_json("[]").unwrap();
+    assert!(comments.is_empty());
 }


### PR DESCRIPTION
## Summary

Adds a **gist detail view** (basic info + file list + live comments) to the gist manager, fixes the compaction confirmation to show gist info instead of an unrelated diff, and refines the gist list rows. Bumps to **v0.5.0**.

## Changes

- **New `Screen::GistDetail`** — opened with `Enter` from the gist manager. Shows description, visibility, created/updated age, full gist id, the file list, and comments fetched live via `gh api /gists/{id}/comments`.
  - Keys: `↑↓` scroll comments · `PageUp/PageDown` page · `c` compact · `o` browser · `q`/`Esc` back.
  - Comments fetched async with a stale-response guard (ignores results when the user has navigated to another gist).
- **Compaction confirm** now shows the gist's info as its background (previously an unrelated diff). Launchable from both the list and the detail view; returns to the originating screen.
- **Gist list rows** — dropped the per-row `[public]/[secret]` (still available via the `v` filter, the title's `type:` label, and the detail view); file count and last-updated marked with 📄 / 🕒; date shown as a relative age (single largest unit, consistent with the detail view).
- **`[focus]` pane label removed** — focus is already signalled by the highlighted border.

## Implementation notes

- New `GistComment` domain type + `parse_gist_comments_json` (fixture-tested); `gh` fetch is a thin untested boundary, per project convention.
- `handle_key` stays pure; all IO in `run_loop`. Stale-guard extracted into a pure, unit-tested `apply_fetched_comments`. A shared pure `context_gist_id()` ensures browser-open and compact target the *viewed* gist from the detail screen.

## Verification

`cargo fmt --check`, `cargo test` (193 lib + 12 integration), `cargo check`, `cargo clippy --all-targets -- -D warnings` — all green.

## Pending

- **demo.gif not yet re-recorded** — one more feature is coming; the GIF will be regenerated (`scripts/demo/record.sh`) once that lands, so this PR intentionally does not touch `docs/demo.gif` yet.