### PR TITLE
fix(release): write LF-terminated Windows checksums; strip CR on install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,9 @@ jobs:
           Copy-Item $bin, README.md, LICENSE $pkg\
           Compress-Archive -Path $pkg -DestinationPath "${pkg}.zip"
           $hash = (Get-FileHash -Algorithm SHA256 "${pkg}.zip").Hash.ToLower()
-          "$hash  ${pkg}.zip" | Out-File -Encoding ascii "${pkg}.zip.sha256"
+          # Write LF-terminated (no CRLF, no BOM) so `sha256sum -c` under Git Bash
+          # doesn't see a trailing CR glued to the filename.
+          [System.IO.File]::WriteAllText("$pwd/${pkg}.zip.sha256", "$hash  ${pkg}.zip`n")
           "ASSET=${pkg}.zip" | Out-File -Append $env:GITHUB_ENV
 
       - name: Upload artifact

--- a/install.sh
+++ b/install.sh
@@ -94,6 +94,10 @@ curl -fsSL "$base_url/$archive" -o "$tmp/$archive" \
   || err "download failed; is $VERSION published for $target?"
 curl -fsSL "$base_url/$archive.sha256" -o "$tmp/$archive.sha256" \
   || err "checksum download failed for $archive"
+# Strip CR so checksum files written with CRLF (e.g. older Windows releases)
+# don't leave a trailing carriage return glued to the filename.
+tr -d '\r' < "$tmp/$archive.sha256" > "$tmp/$archive.sha256.tmp" \
+  && mv "$tmp/$archive.sha256.tmp" "$tmp/$archive.sha256"
 
 echo "verifying checksum..."
 (


### PR DESCRIPTION
## Problem

Installing on Windows via `install.sh` (Git Bash / MSYS2) fails at checksum verification:

```
sha256sum: 'gistui-v0.5.0-x86_64-pc-windows-msvc.zip'$'\r': No such file or directory
sha256sum: WARNING: 1 listed file could not be read
error: checksum verification failed for gistui-v0.5.0-x86_64-pc-windows-msvc.zip
```

## Root cause

The Windows release job wrote the `.sha256` file with PowerShell `Out-File`, which emits **CRLF** line endings. `sha256sum -c` under Git Bash then parses the filename with a trailing carriage return (`gistui-…zip\r`), which doesn't exist on disk, so verification fails. Unix assets use `shasum > file` (LF) and are unaffected.

## Fix

- **`release.yml`** — write the checksum via `[System.IO.File]::WriteAllText` with an explicit `` `n `` (LF) and no BOM. Fixes future releases.
- **`install.sh`** — strip CR from the downloaded checksum before verifying, which also recovers already-published CRLF assets (e.g. v0.5.0).

## Verification

Reproduced the exact error with a simulated CRLF checksum, then confirmed the `tr -d '\r'` step yields `x.zip: OK`. `bash -n install.sh` passes.