### PR TITLE
fix(tui): ignore non-Press key events so Windows keys don't fire twice

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2,7 +2,7 @@ use crate::domain::{group_gists, GistComment, GistFile, GistGroup, LocalCandidat
 use crate::ranking::{rank_gist_files, rank_local_files, MatchReason, RankedGistFile, RankedLocal};
 use anyhow::Result;
 use crossterm::{
-    event::{self, Event, KeyCode},
+    event::{self, Event, KeyCode, KeyEventKind},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -1875,6 +1875,13 @@ fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()>
             continue;
         }
         if let Event::Key(key) = event::read()? {
+            // Windows reports both Press and Release (and Repeat) for each
+            // keystroke, while Unix terminals report only Press. Without this
+            // filter every key fires twice on Windows — Tab toggles focus back
+            // to where it started and Up/Down jump two rows. See ratatui#347.
+            if key.kind != KeyEventKind::Press {
+                continue;
+            }
             if state.bg_task_msg.is_some() {
                 if key.code == KeyCode::Esc {
                     state.bg_task_msg = None;


### PR DESCRIPTION
## Problem

On Windows, navigating the TUI is broken:

- **Tab** does nothing (focus never appears to change).
- **Up / Down** jump two rows at a time.

## Root cause

crossterm reports **both** a `Press` and a `Release` event (plus `Repeat`) for every keystroke on Windows, while Unix terminals report only `Press`. The input loop in `src/tui.rs` dispatched on every `Event::Key` regardless of `kind`, so each physical key was handled twice on Windows:

- Tab toggled focus on Press and toggled it straight back on Release → net no-op.
- Up/Down moved on both Press and Release → two rows per tap.

This is the well-known crossterm/ratatui Windows duplicate-key-event behaviour ([ratatui#347](https://github.com/ratatui/ratatui/issues/347), [crossterm#797](https://github.com/crossterm-rs/crossterm/issues/797), [Ratatui FAQ](https://ratatui.rs/faq/)).

## Fix

Skip events whose kind is not `KeyEventKind::Press`. Unix behaviour is unchanged since it only ever emits `Press`.

## Verification

- `cargo build --release` and `cargo test --release` on Windows (MSVC): the TUI/key-handling tests pass.
- Manually confirmed on Windows that Tab and Up/Down now behave correctly.

> Note: a pre-existing, unrelated Windows-only test failure remains in `config::tests::normalize_path_preserves_absolute_path` (path normalization assumes Unix semantics); not touched here.