### PR TITLE
fix(actions): clone gists over HTTPS during compact to avoid SSH passphrase prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,10 @@ the gist owning the currently selected file. From here you manage gists as a who
 - `X` — delete the entire gist and all its files, after a `y`/`n` confirmation.
 - `o` — open the gist on gist.github.com in your browser.
 - `c` — compact revisions: after showing the revision count and a `y`/`n` confirmation, the
-  gist is cloned to a temp dir, its history squashed to a single commit, and force-pushed —
-  collapsing all older revisions. Irreversible. (When triggered from the detail view, the
-  confirmation prompt shows the gist's info as context.)
+  gist is cloned to a temp dir over HTTPS (authenticating through your `gh` token, never SSH
+  keys), its history squashed to a single commit, and force-pushed — collapsing all older
+  revisions. Irreversible. (When triggered from the detail view, the confirmation prompt shows
+  the gist's info as context.)
 - `s` cycle sort (updated / created) · `v` cycle visibility (all/public/secret) · `/` filter
   by description or id · `Left`/`Right` scroll a long description.
 - `q`/`Esc` — back to the list.

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -217,13 +217,18 @@ pub fn parse_revision_count(stdout: &str) -> Option<usize> {
 }
 
 /// Clones `gist_id` into `dir` as a git working copy (the gist's revisions are its commits).
+///
+/// Cloned over HTTPS (not `gh gist clone`, which follows the user's `git_protocol` and may
+/// pick SSH) so both the clone and the later force-push authenticate through git's credential
+/// helper — the `gh` token. Compaction runs while the TUI owns the terminal in raw mode, so an
+/// SSH key passphrase prompt cannot be answered and fails (`incorrect passphrase supplied to
+/// decrypt private key`); routing through HTTPS/`gh` token avoids SSH keys entirely.
 pub fn gist_clone_command(gist_id: &str, dir: &Path) -> CommandPlan {
     CommandPlan {
-        program: "gh".into(),
+        program: "git".into(),
         args: vec![
-            "gist".into(),
             "clone".into(),
-            gist_id.to_string(),
+            format!("https://gist.github.com/{gist_id}.git"),
             dir.display().to_string(),
         ],
     }
@@ -506,10 +511,15 @@ mod tests {
     }
 
     #[test]
-    fn gist_clone_command_clones_into_dir() {
+    fn gist_clone_command_clones_over_https_into_dir() {
         let plan = gist_clone_command("abc123", Path::new("/tmp/x"));
-        assert_eq!(plan.program, "gh");
-        assert_eq!(plan.args, vec!["gist", "clone", "abc123", "/tmp/x"]);
+        // HTTPS (not `gh gist clone`/SSH) so auth flows through the gh token credential
+        // helper and compaction never hits an SSH passphrase prompt under the TUI.
+        assert_eq!(plan.program, "git");
+        assert_eq!(
+            plan.args,
+            vec!["clone", "https://gist.github.com/abc123.git", "/tmp/x"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Compacting a gist (`c`) could fail with:

```
compact failed: error: Load key "/Users/.../.ssh/id_ed25519": incorrect passphrase supplied to decrypt private key
```

Compaction ran `gh gist clone`, which follows the user's `git_protocol`. On machines configured for SSH (or with a passphrase-protected key not loaded into an agent), the clone/force-push prompts for the passphrase **non-interactively** while the TUI owns the terminal in raw mode — so it cannot be answered and fails.

## Fix

Clone over HTTPS instead — `git clone https://gist.github.com/<id>.git <dir>`. Both the clone and the subsequent force-push then authenticate through git's credential helper (the `gh` token), never SSH keys. This matches the rest of the app, which goes through the `gh` token throughout.

## Changes

- `gist_clone_command`: `gh gist clone` → HTTPS `git clone` (`src/actions.rs`).
- Updated unit test → `gist_clone_command_clones_over_https_into_dir`.
- README compact note now states it clones over HTTPS using the `gh` token (never SSH keys).

## Note

Relies on the `gist.github.com` credential helper that `gh auth setup-git` configures. Users without it get a clear git auth error (fixable via `gh auth setup-git`) rather than an unanswerable SSH passphrase prompt.

## Verification

`cargo fmt --check`, `cargo test` (202 passed), `cargo check`, `cargo clippy --all-targets -- -D warnings` — all green.