### PR TITLE
feat(tui): cursor-based file selection in gist detail view (#67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,13 @@ the gist owning the currently selected file. From here you manage gists as a who
 - `e` — edit the gist's description (type, `Enter` applies, `Esc` cancels).
 - `Enter` — open the **gist detail view**: shows basic info (description, visibility,
   created/updated age, file count, short id), the file list, and fetched comments.
-  - `↑`/`↓` scroll comments · `PageUp`/`PageDown` page through comments.
-  - `1`–`9` preview the content of the Nth file full-screen (`↑↓←→` scroll, `R` refresh,
-    `q`/`Esc` back).
+  - `Tab` switch focus between the comments pane and the file list.
+  - `↑`/`↓` scroll comments, or move the file cursor when the list is focused · `PageUp`/`PageDown`
+    page either by 10.
+  - `Enter` (file list focused) preview the cursor-selected file — this reaches **any** file,
+    including the 10th and beyond.
+  - `1`–`9` still preview the content of the Nth file directly, full-screen (`↑↓←→` scroll,
+    `R` refresh, `q`/`Esc` back).
   - `c` compact · `o` browser · `q`/`Esc` back to the gist manager.
 - `X` — delete the entire gist and all its files, after a `y`/`n` confirmation.
 - `o` — open the gist on gist.github.com in your browser.

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -175,10 +175,10 @@ impl AppState {
             KeyCode::Char('q') | KeyCode::Esc => {
                 self.screen = Screen::Gists;
             }
-            KeyCode::Down => self.detail_scroll = self.detail_scroll.saturating_add(1),
-            KeyCode::Up => self.detail_scroll = self.detail_scroll.saturating_sub(1),
-            KeyCode::PageDown => self.detail_scroll = self.detail_scroll.saturating_add(10),
-            KeyCode::PageUp => self.detail_scroll = self.detail_scroll.saturating_sub(10),
+            KeyCode::Down => self.detail_nav(1),
+            KeyCode::Up => self.detail_nav(-1),
+            KeyCode::PageDown => self.detail_nav(10),
+            KeyCode::PageUp => self.detail_nav(-10),
             KeyCode::Char('o') => return KeyOutcome::OpenBrowser,
             KeyCode::Char('c') => {
                 self.compact_return_screen = Screen::GistDetail;
@@ -195,9 +195,52 @@ impl AppState {
                     }
                 }
             }
+            KeyCode::Tab => {
+                self.detail_focus = match self.detail_focus {
+                    DetailFocus::Comments => DetailFocus::Files,
+                    DetailFocus::Files => DetailFocus::Comments,
+                };
+            }
+            KeyCode::Enter if self.detail_focus == DetailFocus::Files => {
+                if let Some(gist_id) = self.detail_gist_id.clone() {
+                    let cursor = self.detail_file_cursor;
+                    if let Some(filename) = self.gist_filenames(&gist_id).into_iter().nth(cursor) {
+                        self.preview_request = Some((gist_id, filename));
+                        self.preview_return = Screen::GistDetail;
+                        return KeyOutcome::PreviewContent;
+                    }
+                }
+            }
             _ => {}
         }
         KeyOutcome::None
+    }
+
+    /// Move within the focused detail pane: scroll comments, or move the file cursor
+    /// (clamped to the gist's file count). `delta` is signed rows.
+    fn detail_nav(&mut self, delta: i32) {
+        match self.detail_focus {
+            DetailFocus::Comments => {
+                self.detail_scroll = if delta < 0 {
+                    self.detail_scroll.saturating_sub((-delta) as u16)
+                } else {
+                    self.detail_scroll.saturating_add(delta as u16)
+                };
+            }
+            DetailFocus::Files => {
+                let count = self
+                    .detail_gist_id
+                    .as_deref()
+                    .map(|id| self.gist_filenames(id).len())
+                    .unwrap_or(0);
+                if count == 0 {
+                    return;
+                }
+                let max = count - 1;
+                let next = self.detail_file_cursor as i64 + delta as i64;
+                self.detail_file_cursor = next.clamp(0, max as i64) as usize;
+            }
+        }
     }
 
     /// Apply a finished comment fetch, ignoring it if the user has since navigated to a

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -28,6 +28,14 @@ pub enum Screen {
     GistDetail,
 }
 
+/// Which pane the navigation keys drive in `Screen::GistDetail`. Default `Comments`
+/// preserves the pre-#67 up/down = comment-scroll behavior until the user presses Tab.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DetailFocus {
+    Comments,
+    Files,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PendingAction {
     Download,
@@ -327,6 +335,10 @@ pub struct AppState {
     pub detail_comments_error: Option<String>,
     /// Comment-pane scroll offset.
     pub detail_scroll: u16,
+    /// Which detail-view pane Tab/arrows currently drive (Comments vs Files).
+    pub detail_focus: DetailFocus,
+    /// Cursor index into the detail gist's files when `detail_focus == Files`.
+    pub detail_file_cursor: usize,
     /// Screen to return to after a compaction confirm is cancelled/finished (Gists or GistDetail).
     pub compact_return_screen: Screen,
 }
@@ -788,6 +800,8 @@ pub fn initial_state() -> AppState {
         detail_comments: None,
         detail_comments_error: None,
         detail_scroll: 0,
+        detail_focus: DetailFocus::Comments,
+        detail_file_cursor: 0,
         compact_return_screen: Screen::Gists,
     }
 }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -98,8 +98,10 @@ Gist manager (g)
   q / Esc    back to the list
 
 Gist detail (Enter from gist manager)
-  Up/Down    scroll comments
-  PageUp/Dn  page through comments
+  Tab        switch focus between comments and the file list
+  Up/Down    scroll comments, or move the file cursor when the list is focused
+  PageUp/Dn  page comments / file cursor by 10
+  Enter      preview the cursor-selected file (file list focused)
   1-9        preview the content of the Nth file (full-screen; R refresh, q back)
   c          compact revisions (y/n confirm; gist info shown as context)
   o          open the gist in your web browser
@@ -353,6 +355,15 @@ pub(super) fn unix_now() -> u64 {
 }
 
 /// Info + file-list block for a gist (reused as the compaction-confirm background).
+/// First visible file index so `cursor` stays within a `visible_rows`-high window over
+/// `count` files. Returns 0 when everything fits or `visible_rows == 0`.
+pub(super) fn file_list_scroll(cursor: usize, visible_rows: usize, count: usize) -> usize {
+    if visible_rows == 0 || count <= visible_rows || cursor < visible_rows {
+        return 0;
+    }
+    (cursor + 1).saturating_sub(visible_rows)
+}
+
 pub(super) fn render_gist_info_and_files(
     frame: &mut Frame,
     area: Rect,
@@ -369,23 +380,50 @@ pub(super) fn render_gist_info_and_files(
         format!("Gist: {}", group.description)
     };
     let files = state.gist_filenames(gist_id);
+    let files_focused =
+        state.detail_focus == DetailFocus::Files && state.screen == Screen::GistDetail;
+    let files_title = if files_focused {
+        format!("Files ({})  [focus: ↑↓ select · ⏎ preview]", files.len())
+    } else {
+        format!("Files ({})", files.len())
+    };
     let mut lines: Vec<Line> = vec![
         Line::from(gist_info_line(&group, now)),
         Line::from(""),
         Line::from(Span::styled(
-            format!("Files ({})", files.len()),
+            files_title,
             Style::default().add_modifier(Modifier::BOLD),
         )),
     ];
     // Number the first nine files so the detail view's 1–9 preview keys are discoverable;
-    // any beyond the ninth are bullet-aligned (not directly previewable).
-    for (i, f) in files.iter().enumerate() {
+    // any beyond the ninth are bullet-aligned. When the file list is focused, a cursor row
+    // is highlighted and the list auto-scrolls to keep it visible.
+    let cursor = state.detail_file_cursor.min(files.len().saturating_sub(1));
+    // Visible file rows = area height minus borders(2), info line, blank, "Files (n)" header (3).
+    let visible_rows = (area.height as usize).saturating_sub(5);
+    let offset = file_list_scroll(cursor, visible_rows, files.len());
+    for (i, f) in files
+        .iter()
+        .enumerate()
+        .skip(offset)
+        .take(visible_rows.max(1))
+    {
         let marker = if i < 9 {
             format!("{}.", i + 1)
         } else {
             "·".to_string()
         };
-        lines.push(Line::from(format!("  {marker} {f}")));
+        if files_focused && i == cursor {
+            lines.push(Line::from(Span::styled(
+                format!("▸ {marker} {f}"),
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            )));
+        } else {
+            lines.push(Line::from(format!("  {marker} {f}")));
+        }
     }
     frame.render_widget(
         Paragraph::new(lines).block(
@@ -456,19 +494,26 @@ pub(super) fn render_gist_comments(frame: &mut Frame, area: Rect, state: &AppSta
 /// The detail-view footer: a one-shot `state.status` message (e.g. the compaction result,
 /// including "nothing to compact") when present, else the key hints. Only the hints are
 /// colourised. Mirrors the gist-manager footer so detail-triggered statuses are visible.
-pub(super) fn detail_footer(status: Option<&str>) -> (String, bool) {
+pub(super) fn detail_footer(status: Option<&str>, focus: DetailFocus) -> (String, bool) {
     match status {
         Some(message) => (message.to_string(), false),
-        None => (
-            "↑↓ scroll · 1-9 preview file · c compact · o browser · q back".to_string(),
-            true,
-        ),
+        None => {
+            let hints = match focus {
+                DetailFocus::Comments => {
+                    "Tab files · ↑↓ scroll · 1-9 preview · c compact · o browser · q back"
+                }
+                DetailFocus::Files => {
+                    "Tab comments · ↑↓ select · ⏎ preview · 1-9 preview · c compact · o browser · q back"
+                }
+            };
+            (hints.to_string(), true)
+        }
     }
 }
 
 pub(super) fn render_gist_detail(frame: &mut Frame, state: &AppState) {
     let area = frame.area();
-    let (footer, colored) = detail_footer(state.status.as_deref());
+    let (footer, colored) = detail_footer(state.status.as_deref(), state.detail_focus);
     let footer_lines = wrap_line_count(&footer, area.width.saturating_sub(2)).max(1);
     let files = state
         .detail_gist_id

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -398,6 +398,8 @@ pub(super) fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) ->
                     state.detail_comments = None;
                     state.detail_comments_error = None;
                     state.detail_scroll = 0;
+                    state.detail_focus = DetailFocus::Comments;
+                    state.detail_file_cursor = 0;
 
                     state.bg_task_msg = Some("Loading comments…".to_string());
                     let (tx, rx) = std::sync::mpsc::channel();

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -27,6 +27,21 @@ fn state_with_gists() -> AppState {
     state
 }
 
+fn state_with_many_files(n: usize) -> AppState {
+    let mut state = initial_state();
+    state.gists = (0..n)
+        .map(|i| GistFile {
+            gist_id: "g1".into(),
+            description: "demo".into(),
+            filename: format!("f{i}.txt"),
+            public: false,
+            updated_at: "2026-06-10T00:00:00Z".into(),
+            created_at: "2026-06-01T00:00:00Z".into(),
+        })
+        .collect();
+    state
+}
+
 fn list_state_with_matches() -> AppState {
     let mut state = initial_state();
     state.locals = vec![
@@ -147,6 +162,79 @@ fn enter_on_gist_opens_detail() {
 }
 
 #[test]
+fn detail_focus_and_cursor_default_to_comments_and_zero() {
+    let state = initial_state();
+    assert_eq!(state.detail_focus, DetailFocus::Comments);
+    assert_eq!(state.detail_file_cursor, 0);
+}
+
+#[test]
+fn detail_tab_toggles_focus() {
+    let mut state = state_with_gists();
+    state.screen = Screen::GistDetail;
+    assert_eq!(state.detail_focus, DetailFocus::Comments);
+    state.handle_key(KeyCode::Tab);
+    assert_eq!(state.detail_focus, DetailFocus::Files);
+    state.handle_key(KeyCode::Tab);
+    assert_eq!(state.detail_focus, DetailFocus::Comments);
+}
+
+#[test]
+fn detail_files_focus_arrows_move_cursor_and_clamp() {
+    let mut state = state_with_gists(); // g1 has 2 files: a.txt, b.txt
+    state.screen = Screen::GistDetail;
+    state.detail_gist_id = Some("g1".into());
+    state.detail_focus = DetailFocus::Files;
+
+    state.handle_key(KeyCode::Up); // already at 0, clamps
+    assert_eq!(state.detail_file_cursor, 0);
+    state.handle_key(KeyCode::Down);
+    assert_eq!(state.detail_file_cursor, 1);
+    state.handle_key(KeyCode::Down); // only 2 files, clamps at index 1
+    assert_eq!(state.detail_file_cursor, 1);
+    state.handle_key(KeyCode::PageUp); // jumps to 0
+    assert_eq!(state.detail_file_cursor, 0);
+    state.handle_key(KeyCode::PageDown); // +10 clamps to last (1)
+    assert_eq!(state.detail_file_cursor, 1);
+    // Comment scroll is untouched while files-focused.
+    assert_eq!(state.detail_scroll, 0);
+}
+
+#[test]
+fn detail_comments_focus_arrows_still_scroll_comments() {
+    let mut state = state_with_gists();
+    state.screen = Screen::GistDetail;
+    state.detail_focus = DetailFocus::Comments;
+    state.handle_key(KeyCode::Down);
+    assert_eq!(state.detail_scroll, 1);
+    assert_eq!(state.detail_file_cursor, 0); // cursor untouched
+}
+
+#[test]
+fn detail_enter_previews_cursor_file_including_tenth() {
+    let mut state = state_with_many_files(12);
+    state.screen = Screen::GistDetail;
+    state.detail_gist_id = Some("g1".into());
+    state.detail_focus = DetailFocus::Files;
+    state.detail_file_cursor = 9; // the 10th file — unreachable via 1-9
+    let outcome = state.handle_key(KeyCode::Enter);
+    assert!(matches!(outcome, KeyOutcome::PreviewContent));
+    assert_eq!(state.preview_request, Some(("g1".into(), "f9.txt".into())));
+    assert_eq!(state.preview_return, Screen::GistDetail);
+}
+
+#[test]
+fn detail_enter_in_comments_focus_is_noop() {
+    let mut state = state_with_gists();
+    state.screen = Screen::GistDetail;
+    state.detail_gist_id = Some("g1".into());
+    state.detail_focus = DetailFocus::Comments;
+    let outcome = state.handle_key(KeyCode::Enter);
+    assert!(matches!(outcome, KeyOutcome::None));
+    assert_eq!(state.preview_request, None);
+}
+
+#[test]
 fn detail_q_returns_to_gists() {
     let mut state = state_with_gists();
     state.screen = Screen::GistDetail;
@@ -208,13 +296,36 @@ fn preview_q_returns_to_launch_screen() {
 }
 
 #[test]
+fn file_list_scroll_keeps_cursor_visible() {
+    // count <= visible: no scroll.
+    assert_eq!(file_list_scroll(0, 5, 3), 0);
+    assert_eq!(file_list_scroll(2, 5, 3), 0);
+    // cursor within the first window: no scroll.
+    assert_eq!(file_list_scroll(2, 5, 20), 0);
+    assert_eq!(file_list_scroll(4, 5, 20), 0);
+    // cursor past the window: scroll so cursor is the last visible row.
+    assert_eq!(file_list_scroll(5, 5, 20), 1);
+    assert_eq!(file_list_scroll(19, 5, 20), 15);
+    // visible_rows == 0: never panic, offset 0.
+    assert_eq!(file_list_scroll(19, 0, 20), 0);
+}
+
+#[test]
 fn detail_footer_surfaces_status_else_hints() {
-    let (msg, colored) = detail_footer(Some("nothing to compact"));
+    let (msg, colored) = detail_footer(Some("nothing to compact"), DetailFocus::Comments);
     assert_eq!(msg, "nothing to compact");
     assert!(!colored);
-    let (hint, colored) = detail_footer(None);
+    let (hint, colored) = detail_footer(None, DetailFocus::Comments);
     assert!(hint.contains("1-9") && hint.contains("compact"));
     assert!(colored);
+}
+
+#[test]
+fn detail_footer_is_focus_aware() {
+    let (comments, _) = detail_footer(None, DetailFocus::Comments);
+    assert!(comments.contains("Tab files") && comments.contains("scroll"));
+    let (files, _) = detail_footer(None, DetailFocus::Files);
+    assert!(files.contains("Tab comments") && files.contains("preview"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #67. Follow-up to #66, which added `1`-`9` number-key file preview in the gist detail view but left gists with **more than 9 files** unable to preview the 10th+, with no visual cursor.

This adds a Tab-focusable, cursor-driven file list:

- **`Tab`** toggles focus between the comments pane (default) and the file list.
- **`↑`/`↓`** and **`PageUp`/`PageDown`** drive the focused pane: scroll comments (unchanged default behavior), or move the file cursor (clamped) when the list is focused.
- **`Enter`** (file list focused) previews the cursor-selected file — reaching **any** file, including the 10th and beyond.
- The cursor row is highlighted and the list **auto-scrolls** to keep it visible on small terminals / large gists.
- **`1`-`9`** shortcuts are **retained** unchanged (backward compatible).

The footer hints and the `?` help screen are focus-aware and updated in lockstep with `README.md`.

## Implementation

- `DetailFocus { Comments, Files }` state in `AppState`, reset on opening the detail view (`run_loop`, the IO boundary).
- Key logic stays pure in `handle_key_detail` / a new `detail_nav` helper (`tui/keys.rs`).
- Render highlights the cursor and auto-scrolls via a pure `file_list_scroll` helper (`tui/render.rs`).

## Testing

`cargo fmt --check`, `cargo test` (226 pass, incl. new pure unit tests for Tab toggle, cursor move/clamp, comment-scroll unchanged, Enter preview incl. 10th file, `file_list_scroll` offsets, focus-aware footer), `cargo check`, `cargo clippy --all-targets -- -D warnings` — all green.

The demo (`scripts/demo/`) does not enter the gist detail view, so `docs/demo.gif` is unchanged.