### PR TITLE
fix(actions): actionable error when gist credential helper is missing (#71)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "gistui"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gistui"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 license = "MIT"
 description = "A terminal UI for managing GitHub Gists"

--- a/README.md
+++ b/README.md
@@ -169,7 +169,8 @@ the gist owning the currently selected file. From here you manage gists as a who
   gist is cloned to a temp dir over HTTPS (authenticating through your `gh` token, never SSH
   keys), its history squashed to a single commit, and force-pushed — collapsing all older
   revisions. Irreversible. (When triggered from the detail view, the confirmation prompt shows
-  the gist's info as context.)
+  the gist's info as context.) Requires the git credential helper that `gh auth setup-git`
+  configures; if it is missing, compaction reports an actionable error pointing you to that command.
 - `s` cycle sort (updated / created) · `v` cycle visibility (all/public/secret) · `/` filter
   by description or id · `Left`/`Right` scroll a long description.
 - `q`/`Esc` — back to the list.

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1,6 +1,6 @@
 use crate::config::{save_config, AppConfig};
 use crate::domain::{GistFile, PinnedMapping, SyncDirection};
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -280,7 +280,29 @@ pub fn execute_compact_gist(gist_id: &str) -> Result<()> {
     let dir = compact_temp_dir(gist_id);
     let result = compact_in_dir(gist_id, &dir);
     let _ = fs::remove_dir_all(&dir);
-    result
+    // A raw git HTTPS auth failure (no gist.github.com credential helper) is confusing; map it
+    // to an actionable hint. Unrelated errors surface verbatim, and the happy path is untouched.
+    result.map_err(|e| match compact_auth_hint(&e.to_string()) {
+        Some(hint) => anyhow!(hint),
+        None => e,
+    })
+}
+
+/// Map a git failure `stderr` to an actionable hint when it looks like an HTTPS authentication
+/// failure against gist.github.com — typically because `gh auth setup-git` was never run, so git
+/// has no credential helper for the host. Returns `None` for unrelated errors so they surface
+/// verbatim. See #71 (follow-up to #65, which routes compaction over HTTPS/the gh token).
+pub fn compact_auth_hint(stderr: &str) -> Option<String> {
+    let lower = stderr.to_lowercase();
+    let is_auth_failure = lower.contains("could not read username")
+        || lower.contains("could not read password")
+        || lower.contains("authentication failed")
+        || lower.contains("terminal prompts disabled");
+    is_auth_failure.then(|| {
+        "git could not authenticate to gist.github.com. \
+         Run `gh auth setup-git` to enable gist compaction (one-time setup)."
+            .to_string()
+    })
 }
 
 fn compact_in_dir(gist_id: &str, dir: &Path) -> Result<()> {
@@ -542,6 +564,33 @@ mod tests {
         );
         // The commit forces an identity so it never falls back to (possibly absent) global config.
         assert!(plans[2].args.contains(&"user.name=gistui".to_string()));
+    }
+
+    #[test]
+    fn compact_auth_hint_flags_git_auth_failures() {
+        // The signatures git emits when no gist.github.com credential helper is configured.
+        for stderr in [
+            "fatal: could not read Username for 'https://gist.github.com': terminal prompts disabled",
+            "remote: Support for password authentication was removed.\nfatal: Authentication failed for 'https://gist.github.com/abc.git/'",
+            "fatal: could not read Password for 'https://gist.github.com': No such device",
+        ] {
+            let hint = compact_auth_hint(stderr).expect("auth failure should yield a hint");
+            assert!(hint.contains("gh auth setup-git"));
+        }
+    }
+
+    #[test]
+    fn compact_auth_hint_ignores_unrelated_errors() {
+        assert_eq!(
+            compact_auth_hint("could not determine the gist's default branch"),
+            None
+        );
+        assert_eq!(
+            compact_auth_hint(
+                "fatal: unable to access 'https://gist.github.com/': Could not resolve host"
+            ),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #71 (follow-up to #65). Compaction clones/force-pushes gists over HTTPS, authenticating through the `gh` token credential helper that `gh auth setup-git` configures. A user who authenticated (`gh auth login`) but never ran `gh auth setup-git` previously got a **raw git auth failure**, which is confusing.

`execute_compact_gist` now maps the error through the pure `compact_auth_hint`, which recognises the git HTTPS auth-failure signatures (`could not read Username/Password`, `Authentication failed`, `terminal prompts disabled`) and returns an actionable message:

> compact failed: git could not authenticate to gist.github.com. Run `gh auth setup-git` to enable gist compaction (one-time setup).

Unrelated errors surface verbatim and the happy path is unchanged.

## Also in this PR

- Bumps the version to **0.7.0** (release-prep; tag to be pushed separately).
- README: notes that compaction requires the `gh auth setup-git` credential helper.

## Testing

`cargo fmt --check`, `cargo test` (228 pass, incl. new pure unit tests covering each auth signature and unrelated errors like host-resolution / branch-detection failures), `cargo check`, `cargo clippy --all-targets -- -D warnings` — all green.