### PR TITLE
fix(tui): surface swallowed status messages on Pins and Preview (#72)

### DIFF
--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -36,6 +36,9 @@ impl AppState {
     }
 
     fn handle_key_pins(&mut self, code: KeyCode) -> KeyOutcome {
+        // One-shot: any key dismisses a lingering sync status; the run_loop IO helper for this
+        // key may set a fresh one afterwards (e.g. "already in sync").
+        self.status = None;
         match code {
             KeyCode::Char('q') | KeyCode::Esc => self.screen = Screen::List,
             KeyCode::Down if self.pins_index + 1 < self.pinned.len() => {
@@ -267,6 +270,9 @@ impl AppState {
     }
 
     fn handle_key_preview(&mut self, code: KeyCode) -> KeyOutcome {
+        // One-shot: any key dismisses a lingering status (e.g. a previous "fetch failed: …"); the
+        // run_loop refresh helper may set a fresh one afterwards.
+        self.status = None;
         match code {
             // In the preview, q and Esc return to wherever it was launched from (the list, or
             // the gist detail view) — never an accidental app exit. Reset to List afterwards.

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -126,8 +126,12 @@ General
 
 pub(super) fn render_preview(frame: &mut Frame, state: &AppState) {
     let area = frame.area();
-    let footer = "↑↓←→ scroll  ·  R refresh  ·  Esc/q back";
-    let footer_lines = wrap_line_count(footer, area.width.saturating_sub(2)).max(1);
+    // A `R`-refresh fetch error (set via state.status) must surface here, not be swallowed.
+    let (footer, colored) = footer_with_status(
+        state.status.as_deref(),
+        "↑↓←→ scroll  ·  R refresh  ·  Esc/q back",
+    );
+    let footer_lines = wrap_line_count(&footer, area.width.saturating_sub(2)).max(1);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(5), Constraint::Length(footer_lines + 1)])
@@ -145,16 +149,19 @@ pub(super) fn render_preview(frame: &mut Frame, state: &AppState) {
             ),
         chunks[0],
     );
-    render_footer(frame, chunks[1], "", footer, true);
+    render_footer(frame, chunks[1], "", &footer, colored);
 }
 
 pub(super) fn render_pins(frame: &mut Frame, state: &AppState) {
     let area = frame.area();
-    let footer = if state.pinned.is_empty() {
-        "Esc/q back".to_string()
+    // Sync feedback (e.g. "already in sync", "can't tell which side is newer") is set via
+    // state.status while staying on this screen, so the footer must surface it (see #72).
+    let hints = if state.pinned.is_empty() {
+        "Esc/q back"
     } else {
-        "↑↓ move  ·  Enter diff · s sync · u push · d pull · x unpin  ·  ✓ synced ↑ local-newer ↓ remote-newer ? n/a  ·  Esc/q back".to_string()
+        "↑↓ move  ·  Enter diff · s sync · u push · d pull · x unpin  ·  ✓ synced ↑ local-newer ↓ remote-newer ? n/a  ·  Esc/q back"
     };
+    let (footer, colored) = footer_with_status(state.status.as_deref(), hints);
     let footer_lines = wrap_line_count(&footer, area.width.saturating_sub(2)).max(1);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -216,7 +223,7 @@ pub(super) fn render_pins(frame: &mut Frame, state: &AppState) {
     list_state.select(selected);
     frame.render_stateful_widget(list, chunks[0], &mut list_state);
 
-    render_footer(frame, chunks[1], "", &footer, true);
+    render_footer(frame, chunks[1], "", &footer, colored);
 }
 
 pub(super) fn gist_group_row_label(g: &GistGroup, now: u64, sort: GistGroupSort) -> String {
@@ -491,24 +498,28 @@ pub(super) fn render_gist_comments(frame: &mut Frame, area: Rect, state: &AppSta
     );
 }
 
-/// The detail-view footer: a one-shot `state.status` message (e.g. the compaction result,
-/// including "nothing to compact") when present, else the key hints. Only the hints are
-/// colourised. Mirrors the gist-manager footer so detail-triggered statuses are visible.
-pub(super) fn detail_footer(status: Option<&str>, focus: DetailFocus) -> (String, bool) {
+/// Footer text + whether to colourise it: a one-shot `state.status` message (shown plain) when
+/// present, else the colourised key `hints`. Shared by every screen so action results/errors
+/// surface consistently and are never swallowed by a hard-coded footer (see #72, #66).
+pub(super) fn footer_with_status(status: Option<&str>, hints: &str) -> (String, bool) {
     match status {
         Some(message) => (message.to_string(), false),
-        None => {
-            let hints = match focus {
-                DetailFocus::Comments => {
-                    "Tab files · ↑↓ scroll · 1-9 preview · c compact · o browser · q back"
-                }
-                DetailFocus::Files => {
-                    "Tab comments · ↑↓ select · ⏎ preview · 1-9 preview · c compact · o browser · q back"
-                }
-            };
-            (hints.to_string(), true)
-        }
+        None => (hints.to_string(), true),
     }
+}
+
+/// The detail-view footer: a one-shot `state.status` message (e.g. the compaction result,
+/// including "nothing to compact") when present, else the focus-aware key hints.
+pub(super) fn detail_footer(status: Option<&str>, focus: DetailFocus) -> (String, bool) {
+    let hints = match focus {
+        DetailFocus::Comments => {
+            "Tab files · ↑↓ scroll · 1-9 preview · c compact · o browser · q back"
+        }
+        DetailFocus::Files => {
+            "Tab comments · ↑↓ select · ⏎ preview · 1-9 preview · c compact · o browser · q back"
+        }
+    };
+    footer_with_status(status, hints)
 }
 
 pub(super) fn render_gist_detail(frame: &mut Frame, state: &AppState) {
@@ -1217,6 +1228,10 @@ pub(super) fn render_diff_pane(frame: &mut Frame, area: Rect, state: &AppState) 
 }
 
 /// The `Screen::Diff` preview: the diff pane plus a scroll/commands footer.
+///
+/// #72 audit: this footer intentionally does not surface `state.status`. Diff actions (`d`/`u`)
+/// transition to `Screen::Confirm` or to the IO that lands back on `List`; their results surface
+/// on those destination screens (which read `state.status`), so no status is set while on Diff.
 pub(super) fn render_diff(frame: &mut Frame, state: &AppState) {
     let context = if state.diff_show_full {
         "c context [full]".to_string()
@@ -1245,6 +1260,9 @@ pub(super) fn render_diff(frame: &mut Frame, state: &AppState) {
 
 /// `Screen::Confirm`: the diff fills the screen as context behind a centered prompt modal,
 /// keeping the overwrite gate's diff visible while the question is asked front-and-centre.
+/// #72 audit: this modal intentionally does not surface `state.status`. It is a transient y/n
+/// gate — confirming executes the action and transitions to `List`/`Gists`, where the result
+/// status is shown; cancelling returns to the launching screen without setting a status here.
 pub(super) fn render_confirm(frame: &mut Frame, state: &AppState) {
     match &state.pending_action {
         Some(PendingAction::CompactGist { gist_id, .. }) => {

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -311,6 +311,36 @@ fn file_list_scroll_keeps_cursor_visible() {
 }
 
 #[test]
+fn pins_key_clears_lingering_status_for_one_shot_display() {
+    let mut state = initial_state();
+    state.screen = Screen::Pins;
+    state.status = Some("already in sync".into());
+    state.handle_key(KeyCode::Up); // any key
+    assert_eq!(state.status, None);
+}
+
+#[test]
+fn preview_key_clears_lingering_status_for_one_shot_display() {
+    let mut state = initial_state();
+    state.screen = Screen::Preview;
+    state.status = Some("fetch failed: boom".into());
+    state.handle_key(KeyCode::Down); // any key
+    assert_eq!(state.status, None);
+}
+
+#[test]
+fn footer_with_status_prefers_status_else_colourised_hints() {
+    // A one-shot status message wins and is shown plain (not key-colourised).
+    let (msg, colored) = footer_with_status(Some("already in sync"), "↑↓ move · q back");
+    assert_eq!(msg, "already in sync");
+    assert!(!colored);
+    // Otherwise the key hints render, colourised.
+    let (hint, colored) = footer_with_status(None, "↑↓ move · q back");
+    assert_eq!(hint, "↑↓ move · q back");
+    assert!(colored);
+}
+
+#[test]
 fn detail_footer_surfaces_status_else_hints() {
     let (msg, colored) = detail_footer(Some("nothing to compact"), DetailFocus::Comments);
     assert_eq!(msg, "nothing to compact");


### PR DESCRIPTION
## Summary

Closes #72. Audits every screen footer for the #66-class bug — `state.status` set by an action but never rendered because the footer is hard-coded.

### Bugs fixed
- **Pins** (`render_pins`): sync feedback set while staying on the screen — `"already in sync"`, `"can't tell which side is newer — use u to push or d to pull"`, `"pair is not pinned — press p to pin first"`, push/pull results, and the bg-cancel `"Cancelled"` — was swallowed by the hard-coded footer. Now surfaced.
- **Preview** (`render_preview`): an `R`-refresh `"fetch failed: …"` set while staying on Preview was swallowed. Now surfaced.

### How
- Extracts a shared pure helper `footer_with_status(status, hints)` (status wins, shown plain; else colourised hints); `detail_footer` now delegates to it.
- `handle_key_pins` / `handle_key_preview` now clear `state.status` on entry for one-shot display, matching the List/Gists/Detail convention.

### Audit conclusion (acceptance: "documented why not")
| Screen | Result |
|---|---|
| List, Gists, GistDetail | already surface `state.status` ✅ |
| Pins, Preview | **fixed** here |
| Diff, Confirm | documented in-code as intentionally not surfacing status — their actions transition to Confirm/List/Gists where the result is shown |
| Help | keys-only; no action sets status |

## Testing
`cargo fmt --check`, `cargo test` (231 pass, incl. new tests: `footer_with_status` precedence + one-shot status clear on Pins/Preview), `cargo check`, `cargo clippy --all-targets -- -D warnings` — all green.