### PR TITLE
feat(tui): preview line-wrap toggle (#68) and delete-gist from detail view

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ Gist pane), `Up`/`Down` (move), and `Left`/`Right` (scroll a long row).
   (push/pull by modified time; only available when the pair is pinned).
 - `e` (on a local file) — open it in `$VISUAL`/`$EDITOR`.
 - `Space` (on a gist) — preview the gist's raw content in a scrollable overlay (`R` to
-  force-refresh, bypassing the session cache).
+  force-refresh, bypassing the session cache; `w` to toggle soft line wrapping for long lines,
+  remembered for the session).
 - `r` — toggle **recursive** local file discovery; the pane title shows `[↓]` while active
   and scans in the background so the UI stays responsive.
 - `a` — flip the **anchor** (which pane drives match ranking); independent of focus, so you
@@ -161,8 +162,9 @@ the gist owning the currently selected file. From here you manage gists as a who
   - `Enter` (file list focused) preview the cursor-selected file — this reaches **any** file,
     including the 10th and beyond.
   - `1`–`9` still preview the content of the Nth file directly, full-screen (`↑↓←→` scroll,
-    `R` refresh, `q`/`Esc` back).
-  - `c` compact · `o` browser · `q`/`Esc` back to the gist manager.
+    `R` refresh, `w` wrap, `q`/`Esc` back).
+  - `c` compact · `o` browser · `X` delete the entire gist (`y`/`n` confirm) · `q`/`Esc` back to
+    the gist manager.
 - `X` — delete the entire gist and all its files, after a `y`/`n` confirmation.
 - `o` — open the gist on gist.github.com in your browser.
 - `c` — compact revisions: after showing the revision count and a `y`/`n` confirmation, the

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -204,6 +204,32 @@ impl AppState {
                     DetailFocus::Files => DetailFocus::Comments,
                 };
             }
+            // X deletes the whole gist (y/n confirm), mirroring the gist manager. Reuses the
+            // shared Delete confirm path, which lands on the list once the gist is gone.
+            KeyCode::Char('X') => {
+                if let Some(group) = self
+                    .detail_gist_id
+                    .clone()
+                    .and_then(|id| self.group_by_id(&id))
+                {
+                    let label = if group.description.is_empty() {
+                        group.id.clone()
+                    } else {
+                        group.description.clone()
+                    };
+                    self.diff_text = format!(
+                        "Delete gist {} ({} file(s)): {label}.\n\nThis permanently removes the entire gist and all its files.",
+                        group.id, group.file_count
+                    );
+                    self.diff_scroll = 0;
+                    self.diff_hscroll = 0;
+                    self.pending_action = Some(PendingAction::Delete {
+                        gist_id: group.id.clone(),
+                        label,
+                    });
+                    self.screen = Screen::Confirm;
+                }
+            }
             KeyCode::Enter if self.detail_focus == DetailFocus::Files => {
                 if let Some(gist_id) = self.detail_gist_id.clone() {
                     let cursor = self.detail_file_cursor;
@@ -284,6 +310,7 @@ impl AppState {
                 self.preview_gist_key = None;
             }
             KeyCode::Char('R') => return KeyOutcome::RefreshPreview,
+            KeyCode::Char('w') => self.preview_wrap = !self.preview_wrap,
             KeyCode::Down => self.scroll_diff_down(),
             KeyCode::Up => self.scroll_diff_up(),
             KeyCode::Right => self.scroll_diff_right(),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -287,6 +287,9 @@ pub struct AppState {
     pub status: Option<String>,
     pub loading: bool,
     pub preview_title: String,
+    /// Soft line-wrapping in the full-screen preview, toggled with `w` (remembered for the
+    /// session). When on, long lines wrap instead of needing horizontal scroll.
+    pub preview_wrap: bool,
     pub preview_gist_key: Option<(String, String)>,
     /// Screen to return to when leaving the full-screen preview (default: List; set to
     /// GistDetail when a detail-view file preview is launched).
@@ -766,6 +769,7 @@ pub fn initial_state() -> AppState {
         status: None,
         loading: false,
         preview_title: String::new(),
+        preview_wrap: false,
         preview_gist_key: None,
         preview_return: Screen::List,
         preview_request: None,

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -77,6 +77,12 @@ Diff view (Enter / d / u)
   d / u      download / upload from the diff
   Esc / q    back
 
+Full-screen preview (Space, or 1-9 in the detail view)
+  Up/Down/Left/Right  scroll (Left/Right only when wrap is off)
+  w          toggle soft line wrapping (remembered for the session)
+  R          re-fetch the content
+  Esc / q    back
+
 Upload Confirmation screen (u)
   y          confirm and execute the upload
   n / Esc    cancel the upload
@@ -105,6 +111,7 @@ Gist detail (Enter from gist manager)
   1-9        preview the content of the Nth file (full-screen; R refresh, q back)
   c          compact revisions (y/n confirm; gist info shown as context)
   o          open the gist in your web browser
+  X          delete the entire gist and all its files (y/n confirm)
   q / Esc    back to the gist manager
 
 General
@@ -127,28 +134,36 @@ General
 pub(super) fn render_preview(frame: &mut Frame, state: &AppState) {
     let area = frame.area();
     // A `R`-refresh fetch error (set via state.status) must surface here, not be swallowed.
-    let (footer, colored) = footer_with_status(
-        state.status.as_deref(),
-        "↑↓←→ scroll  ·  R refresh  ·  Esc/q back",
-    );
+    let hints = if state.preview_wrap {
+        "↑↓ scroll  ·  w wrap [on]  ·  R refresh  ·  Esc/q back"
+    } else {
+        "↑↓←→ scroll  ·  w wrap [off]  ·  R refresh  ·  Esc/q back"
+    };
+    let (footer, colored) = footer_with_status(state.status.as_deref(), hints);
     let footer_lines = wrap_line_count(&footer, area.width.saturating_sub(2)).max(1);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(5), Constraint::Length(footer_lines + 1)])
         .split(area);
 
-    frame.render_widget(
+    // When wrapping, horizontal scroll is meaningless — pin the x offset to 0 so long lines
+    // wrap into view instead of being scrolled off-screen.
+    let block = Block::default()
+        .title(state.preview_title.clone())
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .padding(Padding::horizontal(1));
+    let paragraph = if state.preview_wrap {
+        Paragraph::new(state.diff_text.clone())
+            .scroll((state.diff_scroll, 0))
+            .wrap(Wrap { trim: false })
+            .block(block)
+    } else {
         Paragraph::new(state.diff_text.clone())
             .scroll((state.diff_scroll, state.diff_hscroll))
-            .block(
-                Block::default()
-                    .title(state.preview_title.clone())
-                    .borders(Borders::ALL)
-                    .border_type(BorderType::Rounded)
-                    .padding(Padding::horizontal(1)),
-            ),
-        chunks[0],
-    );
+            .block(block)
+    };
+    frame.render_widget(paragraph, chunks[0]);
     render_footer(frame, chunks[1], "", &footer, colored);
 }
 
@@ -513,10 +528,10 @@ pub(super) fn footer_with_status(status: Option<&str>, hints: &str) -> (String, 
 pub(super) fn detail_footer(status: Option<&str>, focus: DetailFocus) -> (String, bool) {
     let hints = match focus {
         DetailFocus::Comments => {
-            "Tab files · ↑↓ scroll · 1-9 preview · c compact · o browser · q back"
+            "Tab files · ↑↓ scroll · 1-9 preview · c compact · o browser · X delete · q back"
         }
         DetailFocus::Files => {
-            "Tab comments · ↑↓ select · ⏎ preview · 1-9 preview · c compact · o browser · q back"
+            "Tab comments · ↑↓ select · ⏎ preview · 1-9 preview · c compact · o browser · X delete · q back"
         }
     };
     footer_with_status(status, hints)

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -285,6 +285,31 @@ fn detail_number_key_out_of_range_is_ignored() {
 }
 
 #[test]
+fn preview_w_toggles_line_wrapping() {
+    let mut state = initial_state();
+    state.screen = Screen::Preview;
+    assert!(!state.preview_wrap);
+    state.handle_key(KeyCode::Char('w'));
+    assert!(state.preview_wrap);
+    state.handle_key(KeyCode::Char('w'));
+    assert!(!state.preview_wrap);
+}
+
+#[test]
+fn detail_x_requests_gist_delete_confirm() {
+    let mut state = state_with_gists();
+    state.screen = Screen::GistDetail;
+    state.detail_gist_id = Some("g1".into());
+    let outcome = state.handle_key(KeyCode::Char('X'));
+    assert!(matches!(outcome, KeyOutcome::None));
+    assert_eq!(state.screen, Screen::Confirm);
+    assert!(matches!(
+        state.pending_action,
+        Some(PendingAction::Delete { ref gist_id, .. }) if gist_id == "g1"
+    ));
+}
+
+#[test]
 fn preview_q_returns_to_launch_screen() {
     let mut state = state_with_gists();
     state.screen = Screen::Preview;


### PR DESCRIPTION
## Summary

Two related detail/preview viewing enhancements (requested together):

### #68 — toggle line wrapping in the preview
Closes #68. Adds **`w`** in `Screen::Preview` to toggle soft line wrapping (`Wrap { trim: false }`), remembered for the session via a new `preview_wrap` state field. When wrapping is on, the horizontal scroll offset is pinned to 0 so long lines wrap into view instead of being scrolled off-screen. The footer shows `w wrap [on]/[off]`.

### Bonus — delete a gist from the detail view
Adds **`X`** in `Screen::GistDetail` to delete the entire gist (y/n confirm), mirroring the gist manager's `X`. It reuses the shared `Delete` → `Confirm` → `back_to_list` path (no new IO): on confirm the gist is deleted and the list refreshes; on cancel it returns to the list, consistent with the existing gist-manager delete UX.

## Docs (in lockstep)
- Footer hints: Preview (`w wrap […]`) and detail view (`X delete`).
- `?` help: new "Full-screen preview" section documenting `w`/`R`/scroll; `X` added to the Gist detail section.
- README: `w` on the `Space` preview line; `X` (and `w`) in the detail-view keymap.

## Testing
`cargo fmt --check`, `cargo test` (233 pass, incl. new pure tests: `preview_w_toggles_line_wrapping`, `detail_x_requests_gist_delete_confirm`), `cargo check`, `cargo clippy --all-targets -- -D warnings` — all green.