### PR TITLE
feat(tui): copy gist URL or file content to clipboard (#70)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ GitHub CLI (`gh`).
 - The GitHub CLI: [`gh`](https://cli.github.com), installed and on your `PATH`
 - An authenticated `gh` session: `gh auth login`
 - A Rust toolchain — **only if building from source** — <https://rustup.rs>
+- _Optional, for `y`/`Y` clipboard copy:_ a clipboard tool on your `PATH` — `pbcopy` (macOS,
+  built in), `clip` (Windows, built in), or `wl-copy` / `xclip` / `xsel` (Linux). Without one,
+  copy reports a clear status instead of failing.
 
 `gistui` shells out to `gh` at runtime (it stores no GitHub token of its own), so `gh` must
 be installed and authenticated wherever you run `gistui`.
@@ -131,9 +134,12 @@ Gist pane), `Up`/`Down` (move), and `Left`/`Right` (scroll a long row).
 - `S` (on a pinned pair) — smart-sync the selected local↔gist pair from the list screen
   (push/pull by modified time; only available when the pair is pinned).
 - `e` (on a local file) — open it in `$VISUAL`/`$EDITOR`.
+- `y` (on a gist) — copy the gist's URL (`https://gist.github.com/<id>`) to the system
+  clipboard. Works on the list, the gist manager, the detail view, and the preview overlay.
 - `Space` (on a gist) — preview the gist's raw content in a scrollable overlay (`R` to
   force-refresh, bypassing the session cache; `w` to toggle soft line wrapping for long lines,
-  remembered for the session).
+  remembered for the session). Inside the preview, `y` copies the gist URL and `Y` copies the
+  full file content to the clipboard.
 - `r` — toggle **recursive** local file discovery; the pane title shows `[↓]` while active
   and scans in the background so the UI stays responsive.
 - `a` — flip the **anchor** (which pane drives match ranking); independent of focus, so you
@@ -163,10 +169,11 @@ the gist owning the currently selected file. From here you manage gists as a who
     including the 10th and beyond.
   - `1`–`9` still preview the content of the Nth file directly, full-screen (`↑↓←→` scroll,
     `R` refresh, `w` wrap, `q`/`Esc` back).
-  - `c` compact · `o` browser · `X` delete the entire gist (`y`/`n` confirm) · `q`/`Esc` back to
-    the gist manager.
+  - `c` compact · `o` browser · `y` copy gist URL · `X` delete the entire gist (`y`/`n` confirm) ·
+    `q`/`Esc` back to the gist manager.
 - `X` — delete the entire gist and all its files, after a `y`/`n` confirmation.
 - `o` — open the gist on gist.github.com in your browser.
+- `y` — copy the gist's URL to the system clipboard.
 - `c` — compact revisions: after showing the revision count and a `y`/`n` confirmation, the
   gist is cloned to a temp dir over HTTPS (authenticating through your `gh` token, never SSH
   keys), its history squashed to a single commit, and force-pushed — collapsing all older
@@ -193,6 +200,9 @@ the gist owning the currently selected file. From here you manage gists as a who
   the confirmation prompt displays the gist's info so the target stays visible while you decide).
 - No GitHub token is stored by the app, and gist content is never written to the config
   file — only path↔gist pin mappings are persisted.
+- Clipboard copy (`y` URL, `Y` content) hands the text to the system clipboard via the OS
+  tool, where other applications can read it. `Y` copies the full previewed file content, so
+  treat it like any other paste of potentially sensitive data.
 
 ## Configuration
 

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -133,6 +133,35 @@ pub fn open_browser_command(gist_id: &str) -> CommandPlan {
     }
 }
 
+/// The public web URL for a gist id (what `gh gist view --web` opens).
+pub fn gist_web_url(gist_id: &str) -> String {
+    format!("https://gist.github.com/{gist_id}")
+}
+
+/// Clipboard-copy candidates for `os` (an `std::env::consts::OS` value), in
+/// priority order. Each reads the text to copy from stdin. Returns empty for
+/// platforms with no known tool, so callers can report a clear status.
+pub fn clipboard_copy_candidates(os: &str) -> Vec<CommandPlan> {
+    let specs: &[(&str, &[&str])] = match os {
+        "macos" => &[("pbcopy", &[])],
+        "windows" => &[("clip", &[])],
+        // Linux/BSD: prefer Wayland, then fall back to the X11 tools.
+        "linux" | "freebsd" | "netbsd" | "openbsd" | "dragonfly" | "solaris" | "illumos" => &[
+            ("wl-copy", &[]),
+            ("xclip", &["-selection", "clipboard"]),
+            ("xsel", &["--clipboard", "--input"]),
+        ],
+        _ => &[],
+    };
+    specs
+        .iter()
+        .map(|(program, args)| CommandPlan {
+            program: (*program).into(),
+            args: args.iter().map(|a| (*a).to_string()).collect(),
+        })
+        .collect()
+}
+
 pub fn create_command(local_path: &Path, public: bool, description: &str) -> CommandPlan {
     let mut args = vec![
         "gist".into(),
@@ -339,6 +368,56 @@ pub fn execute_command(plan: &CommandPlan) -> Result<String> {
     run_command(&SystemRunner, plan)
 }
 
+/// Copies `text` to the system clipboard by shelling out to the first available
+/// platform tool (pbcopy/clip/wl-copy/xclip/xsel), piping `text` via stdin.
+/// Returns the tool used on success, or an error naming the tools tried so the
+/// headless / no-clipboard case surfaces as a status rather than a panic.
+/// Thin IO boundary: not unit-tested (mirrors [`execute_command`]).
+pub fn copy_to_clipboard(text: &str) -> Result<String> {
+    let candidates = clipboard_copy_candidates(std::env::consts::OS);
+    let tried = candidates
+        .iter()
+        .map(|p| p.program.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    if candidates.is_empty() {
+        bail!("no clipboard tool for this platform");
+    }
+    let mut last_err: Option<String> = None;
+    for plan in &candidates {
+        match copy_via(plan, text) {
+            Ok(()) => return Ok(plan.program.clone()),
+            Err(error) => last_err = Some(error.to_string()),
+        }
+    }
+    match last_err {
+        Some(error) => bail!("no clipboard tool worked (tried {tried}): {error}"),
+        None => bail!("no clipboard tool found (tried {tried})"),
+    }
+}
+
+fn copy_via(plan: &CommandPlan, text: &str) -> Result<()> {
+    use std::io::Write;
+    use std::process::Stdio;
+    let mut child = Command::new(&plan.program)
+        .args(&plan.args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .with_context(|| format!("spawn {}", plan.program))?;
+    {
+        let mut stdin = child.stdin.take().context("clipboard stdin unavailable")?;
+        stdin.write_all(text.as_bytes())?;
+        // `stdin` drops here, closing the pipe so the tool sees EOF and exits.
+    }
+    let status = child.wait()?;
+    if !status.success() {
+        bail!("{} exited with {status}", plan.program);
+    }
+    Ok(())
+}
+
 pub fn execute_download(local_path: &Path, content: &str, overwrite_confirmed: bool) -> Result<()> {
     if local_path.exists() && !overwrite_confirmed {
         bail!(
@@ -505,6 +584,44 @@ mod tests {
         let plan = open_browser_command("abc123");
         assert_eq!(plan.program, "gh");
         assert_eq!(plan.args, vec!["gist", "view", "abc123", "--web"]);
+    }
+
+    #[test]
+    fn gist_web_url_builds_canonical_gist_link() {
+        assert_eq!(gist_web_url("abc123"), "https://gist.github.com/abc123");
+    }
+
+    #[test]
+    fn clipboard_candidates_pick_the_platform_tool() {
+        assert_eq!(
+            clipboard_copy_candidates("macos")
+                .iter()
+                .map(|p| p.program.clone())
+                .collect::<Vec<_>>(),
+            vec!["pbcopy"]
+        );
+        assert_eq!(
+            clipboard_copy_candidates("windows")
+                .iter()
+                .map(|p| p.program.clone())
+                .collect::<Vec<_>>(),
+            vec!["clip"]
+        );
+        // Linux prefers Wayland, then falls back to the X11 tools in order.
+        assert_eq!(
+            clipboard_copy_candidates("linux")
+                .iter()
+                .map(|p| p.program.clone())
+                .collect::<Vec<_>>(),
+            vec!["wl-copy", "xclip", "xsel"]
+        );
+        let xclip = &clipboard_copy_candidates("linux")[1];
+        assert_eq!(xclip.args, vec!["-selection", "clipboard"]);
+    }
+
+    #[test]
+    fn clipboard_candidates_empty_for_unknown_os() {
+        assert!(clipboard_copy_candidates("plan9").is_empty());
     }
 
     #[test]

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -140,6 +140,9 @@ impl AppState {
             KeyCode::Char('o') if self.gists_index < groups.len() => {
                 return KeyOutcome::OpenBrowser
             }
+            KeyCode::Char('y') if self.gists_index < groups.len() => {
+                return KeyOutcome::CopyGistUrl
+            }
             KeyCode::Char('c') if self.gists_index < groups.len() => {
                 // The revision count needs a network call, so analysis happens in run_loop;
                 // the confirm prompt is raised once the count is back.
@@ -183,6 +186,7 @@ impl AppState {
             KeyCode::PageDown => self.detail_nav(10),
             KeyCode::PageUp => self.detail_nav(-10),
             KeyCode::Char('o') => return KeyOutcome::OpenBrowser,
+            KeyCode::Char('y') => return KeyOutcome::CopyGistUrl,
             KeyCode::Char('c') => {
                 self.compact_return_screen = Screen::GistDetail;
                 return KeyOutcome::CompactGist;
@@ -311,6 +315,8 @@ impl AppState {
             }
             KeyCode::Char('R') => return KeyOutcome::RefreshPreview,
             KeyCode::Char('w') => self.preview_wrap = !self.preview_wrap,
+            KeyCode::Char('y') => return KeyOutcome::CopyGistUrl,
+            KeyCode::Char('Y') => return KeyOutcome::CopyPreviewContent,
             KeyCode::Down => self.scroll_diff_down(),
             KeyCode::Up => self.scroll_diff_up(),
             KeyCode::Right => self.scroll_diff_right(),
@@ -447,6 +453,7 @@ impl AppState {
                 return KeyOutcome::RefreshLocals;
             }
             KeyCode::Char('/') => self.filtering = true,
+            KeyCode::Char('y') => return KeyOutcome::CopyGistUrl,
             KeyCode::Char('?') => self.screen = Screen::Help,
             KeyCode::Char('P') => {
                 self.pins_index = 0;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -246,6 +246,10 @@ pub enum KeyOutcome {
     PreviewPinDiff,
     /// Persist the diff-context toggle (`diff_show_full`) to config after pressing `c`.
     PersistDiffContext,
+    /// Copy the context gist's web URL to the system clipboard (`y`).
+    CopyGistUrl,
+    /// Copy the previewed file content to the system clipboard (`Y`, Preview screen).
+    CopyPreviewContent,
 }
 
 #[derive(Debug, Clone)]

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -60,6 +60,7 @@ Actions (on the selected local file + gist)
   X          remove the selected file from its gist (y/n confirm)
   g          open the gist manager (edit description, delete gist)
   e          edit the local file in $EDITOR
+  y          copy the selected gist's URL to the system clipboard
 
 Pinned Mappings screen (P)
   Up/Down    move between pins
@@ -80,6 +81,7 @@ Diff view (Enter / d / u)
 Full-screen preview (Space, or 1-9 in the detail view)
   Up/Down/Left/Right  scroll (Left/Right only when wrap is off)
   w          toggle soft line wrapping (remembered for the session)
+  y          copy the gist URL · Y copy the file content to the clipboard
   R          re-fetch the content
   Esc / q    back
 
@@ -99,6 +101,7 @@ Gist manager (g)
   e          edit the gist description (Enter apply, Esc cancel)
   Enter      open the gist detail view (info, file list, comments)
   o          open the gist in your web browser
+  y          copy the gist's URL to the system clipboard
   c          compact revisions: squash history to one commit (force-push, y/n confirm)
   X          delete the entire gist and all its files (y/n confirm)
   q / Esc    back to the list
@@ -111,6 +114,7 @@ Gist detail (Enter from gist manager)
   1-9        preview the content of the Nth file (full-screen; R refresh, q back)
   c          compact revisions (y/n confirm; gist info shown as context)
   o          open the gist in your web browser
+  y          copy the gist's URL to the system clipboard
   X          delete the entire gist and all its files (y/n confirm)
   q / Esc    back to the gist manager
 
@@ -135,9 +139,9 @@ pub(super) fn render_preview(frame: &mut Frame, state: &AppState) {
     let area = frame.area();
     // A `R`-refresh fetch error (set via state.status) must surface here, not be swallowed.
     let hints = if state.preview_wrap {
-        "↑↓ scroll  ·  w wrap [on]  ·  R refresh  ·  Esc/q back"
+        "↑↓ scroll  ·  w wrap [on]  ·  y/Y copy url/content  ·  R refresh  ·  Esc/q back"
     } else {
-        "↑↓←→ scroll  ·  w wrap [off]  ·  R refresh  ·  Esc/q back"
+        "↑↓←→ scroll  ·  w wrap [off]  ·  y/Y copy url/content  ·  R refresh  ·  Esc/q back"
     };
     let (footer, colored) = footer_with_status(state.status.as_deref(), hints);
     let footer_lines = wrap_line_count(&footer, area.width.saturating_sub(2)).max(1);

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -659,6 +659,8 @@ pub(super) fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) ->
                     }
                 }
                 KeyOutcome::OpenBrowser => open_browser(&mut state),
+                KeyOutcome::CopyGistUrl => copy_gist_url(&mut state),
+                KeyOutcome::CopyPreviewContent => copy_preview_content(&mut state),
                 KeyOutcome::EditLocal => edit_local(terminal, &mut state)?,
                 KeyOutcome::ExecuteDelete => {
                     let Some(PendingAction::Delete { gist_id, .. }) = state.pending_action.clone()
@@ -1128,6 +1130,38 @@ fn open_browser(state: &mut AppState) {
     match crate::actions::execute_command(&plan) {
         Ok(_) => state.set_status(format!("Opened gist {gist_id} in the browser")),
         Err(error) => state.set_status(format!("open failed: {error}")),
+    }
+}
+
+/// Copies the context gist's web URL to the system clipboard. On the Preview screen the
+/// URL comes from the previewed file's gist; elsewhere from the current selection.
+fn copy_gist_url(state: &mut AppState) {
+    let gist_id = match state.screen {
+        Screen::Preview => state.preview_gist_key.as_ref().map(|(id, _)| id.clone()),
+        _ => state.context_gist_id(),
+    };
+    let Some(gist_id) = gist_id else {
+        state.set_status("no gist selected to copy");
+        return;
+    };
+    let url = crate::actions::gist_web_url(&gist_id);
+    match crate::actions::copy_to_clipboard(&url) {
+        Ok(_) => state.set_status(format!("Copied URL to clipboard: {url}")),
+        Err(error) => state.set_status(format!("copy failed: {error}")),
+    }
+}
+
+/// Copies the full previewed file content (the text shown on `Screen::Preview`) to the
+/// system clipboard.
+fn copy_preview_content(state: &mut AppState) {
+    if state.diff_text.is_empty() {
+        state.set_status("no content to copy");
+        return;
+    }
+    let bytes = state.diff_text.len();
+    match crate::actions::copy_to_clipboard(&state.diff_text) {
+        Ok(_) => state.set_status(format!("Copied {bytes} bytes to clipboard")),
+        Err(error) => state.set_status(format!("copy failed: {error}")),
     }
 }
 

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1707,6 +1707,41 @@ fn o_on_main_list_is_noop_now_that_browser_moved_to_gist_view() {
 }
 
 #[test]
+fn y_copies_gist_url_on_list_gists_and_detail() {
+    let mut list = state_with_two_gists();
+    assert_eq!(list.handle_key(KeyCode::Char('y')), KeyOutcome::CopyGistUrl);
+
+    let mut gists = state_with_two_gists();
+    gists.screen = Screen::Gists;
+    assert_eq!(
+        gists.handle_key(KeyCode::Char('y')),
+        KeyOutcome::CopyGistUrl
+    );
+
+    let mut detail = state_with_gists();
+    detail.screen = Screen::GistDetail;
+    detail.detail_gist_id = Some("g1".into());
+    assert_eq!(
+        detail.handle_key(KeyCode::Char('y')),
+        KeyOutcome::CopyGistUrl
+    );
+}
+
+#[test]
+fn preview_y_copies_url_and_capital_y_copies_content() {
+    let mut state = state_with_gists();
+    state.screen = Screen::Preview;
+    assert_eq!(
+        state.handle_key(KeyCode::Char('y')),
+        KeyOutcome::CopyGistUrl
+    );
+    assert_eq!(
+        state.handle_key(KeyCode::Char('Y')),
+        KeyOutcome::CopyPreviewContent
+    );
+}
+
+#[test]
 fn c_in_gist_view_requests_compaction() {
     let mut state = state_with_two_gists();
     state.screen = Screen::Gists;


### PR DESCRIPTION
Closes #70.

## What

- `y` yanks the context gist's web URL (`https://gist.github.com/<id>`) to the system clipboard — works on the List, Gist manager, detail view, and preview overlay.
- `Y` (preview screen) yanks the full previewed file content to the clipboard.

## How

Clipboard writes shell out to the first available platform tool — `pbcopy` (macOS), `clip` (Windows), or `wl-copy` / `xclip` / `xsel` (Linux/BSD) — piping the text via stdin. No new crate; matches the existing `gh`/`$EDITOR` shell-out convention. A headless / no-clipboard environment reports a clear status instead of panicking.

Pure, testable parts (URL builder, per-OS candidate list) live in `actions.rs`; the stdin-piping spawn is a thin untested IO boundary mirroring `execute_command`. Key handling stays pure in `handle_key` (new `KeyOutcome::{CopyGistUrl, CopyPreviewContent}`); the IO lands in `run_loop` helpers.

## Acceptance

- [x] Copy works on macOS/Linux/Windows or fails with a clear status, never a panic.
- [x] Footer / help / README updated (Actions, Gist manager, Requirements, Safety, `?` help, preview footer hint).

## Verification

`cargo fmt --check` · `cargo test` (226 passed) · `cargo check` · `cargo clippy --all-targets -- -D warnings` — all green.

## Notes

The demo GIF (`scripts/demo/`) was not re-recorded — the storyboard does not exercise clipboard actions. Can add it if desired.