### PR TITLE
feat(tui): syntax-highlight preview and diff context (#69)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "char_index"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b4b5c964e3265da460e34f037984985900ce56b7aba4bbf7d38473d7aec3d2"
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,6 +657,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "similar",
+ "synoptic",
  "tempfile",
  "toml",
 ]
@@ -718,6 +725,12 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "if_chain"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd62e6b5e86ea8eeeb8db1de02880a6abc01a397b2ebb64b5d74ac255318f5cb"
 
 [[package]]
 name = "indexmap"
@@ -941,6 +954,12 @@ dependencies = [
  "libc",
  "memoffset",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -1600,6 +1619,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synoptic"
+version = "2.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3961017ab3836f3d19579098fae565969c5e7c32c66d746bc706cfbbb047e080"
+dependencies = [
+ "char_index",
+ "if_chain",
+ "nohash-hasher",
+ "regex",
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 sha2 = "0.11"
 similar = "3"
+synoptic = "2.2.9"
 toml = "1.1"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ Gist pane), `Up`/`Down` (move), and `Left`/`Right` (scroll a long row).
   regardless of direction — **local in yellow, gist in blue**. From there `d` downloads or
   `u` uploads, and `c` toggles between showing a few context lines around each change (the
   `diff_context` config, default 3) and the full file. The choice is remembered (persisted
-  to config).
+  to config). Unchanged context lines are **syntax-highlighted** by file type; the `-`/`+`
+  lines keep their red/green and word-level highlighting so additions/removals stay obvious.
 - `d` (on a gist) — download it into the cwd as `./<gist-filename>`. A brand-new file is
   written directly; an existing one is shown as a diff and overwritten only after a `y`/`n`
   confirmation.
@@ -138,8 +139,8 @@ Gist pane), `Up`/`Down` (move), and `Left`/`Right` (scroll a long row).
   clipboard. Works on the list, the gist manager, the detail view, and the preview overlay.
 - `Space` (on a gist) — preview the gist's raw content in a scrollable overlay (`R` to
   force-refresh, bypassing the session cache; `w` to toggle soft line wrapping for long lines,
-  remembered for the session). Inside the preview, `y` copies the gist URL and `Y` copies the
-  full file content to the clipboard.
+  remembered for the session). Known file types are **syntax-highlighted** by extension. Inside
+  the preview, `y` copies the gist URL and `Y` copies the full file content to the clipboard.
 - `r` — toggle **recursive** local file discovery; the pane title shows `[↓]` while active
   and scans in the background so the UI stays responsive.
 - `a` — flip the **anchor** (which pane drives match ranking); independent of focus, so you
@@ -223,6 +224,10 @@ starting point:
 mkdir -p ~/.config/gistui
 cp config.example.toml ~/.config/gistui/config.toml
 ```
+
+Syntax highlighting in the preview and diff views honours the conventional
+[`NO_COLOR`](https://no-color.org) environment variable: set `NO_COLOR=1` to render content
+plain (the semantic diff `-`/`+` colours and other UI colours are unaffected).
 
 ## Building a release
 

--- a/src/tui/highlight.rs
+++ b/src/tui/highlight.rs
@@ -1,0 +1,112 @@
+//! Render-layer syntax highlighting (issue #69).
+//!
+//! Pure mapping from file content to coloured ratatui spans via the lean `synoptic` crate. It
+//! lives in the render layer to keep the domain/render split: nothing here mutates app state or
+//! touches IO. Unknown extensions fall through to plain text, and the whole feature is gated by
+//! `AppState::syntax_highlight` (off when `NO_COLOR` is set) at the call sites in `render`.
+
+use ratatui::style::{Color, Style};
+use ratatui::text::Span;
+use synoptic::{from_extension, Highlighter, TokOpt};
+
+/// Tab display width handed to synoptic; it expands `\t` to this many spaces in highlighted text.
+const TAB_WIDTH: usize = 4;
+
+/// Map a synoptic token kind to a terminal colour. Unknown kinds → `None`, rendered as plain
+/// text. Greens/reds are deliberately limited so highlighted diff-context lines don't read as
+/// added/removed lines. Synoptic's kinds across its bundled grammars are: comment, string,
+/// keyword, digit, boolean, function, struct, namespace, attribute, header.
+fn token_color(kind: &str) -> Option<Color> {
+    Some(match kind {
+        "comment" => Color::DarkGray,
+        "string" => Color::Green,
+        "keyword" => Color::Magenta,
+        "digit" | "boolean" => Color::Cyan,
+        "function" => Color::Blue,
+        "struct" | "namespace" => Color::Yellow,
+        "attribute" | "header" => Color::Cyan,
+        _ => return None,
+    })
+}
+
+/// Highlight a whole buffer, correct across multi-line strings/comments (synoptic tracks state
+/// over the run). Returns one span vector per input line, 1:1 with `lines`. `ext` selects the
+/// grammar; an unsupported extension yields all-plain spans so callers always get a usable
+/// result of the same shape.
+pub fn highlight_buffer(ext: &str, lines: &[String]) -> Vec<Vec<Span<'static>>> {
+    let Some(mut highlighter): Option<Highlighter> = from_extension(ext, TAB_WIDTH) else {
+        return lines.iter().map(|l| vec![Span::raw(l.clone())]).collect();
+    };
+    highlighter.run(lines);
+    lines
+        .iter()
+        .enumerate()
+        .map(|(y, line)| spans_from_tokens(&highlighter.line(y, line)))
+        .collect()
+}
+
+/// Convert one line's synoptic tokens into styled spans, colouring recognised kinds and leaving
+/// the rest plain. An empty token list (a blank line) yields a single empty span so the line
+/// still occupies a row.
+fn spans_from_tokens(tokens: &[TokOpt]) -> Vec<Span<'static>> {
+    if tokens.is_empty() {
+        return vec![Span::raw(String::new())];
+    }
+    tokens
+        .iter()
+        .map(|tok| match tok {
+            TokOpt::Some(text, kind) => match token_color(kind) {
+                Some(color) => Span::styled(text.clone(), Style::default().fg(color)),
+                None => Span::raw(text.clone()),
+            },
+            TokOpt::None(text) => Span::raw(text.clone()),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The concatenated span text must reproduce the source line exactly (no characters dropped
+    /// or reordered) — highlighting only re-styles, never rewrites content.
+    fn joined(spans: &[Span<'static>]) -> String {
+        spans.iter().map(|s| s.content.as_ref()).collect()
+    }
+
+    #[test]
+    fn known_language_colours_keywords() {
+        let lines = vec!["fn main() {}".to_string()];
+        let out = highlight_buffer("rs", &lines);
+        assert_eq!(out.len(), 1);
+        assert_eq!(joined(&out[0]), "fn main() {}");
+        // `fn` is a Rust keyword → magenta; at least one span must be coloured.
+        assert!(out[0]
+            .iter()
+            .any(|s| s.style.fg == Some(Color::Magenta) && s.content.contains("fn")));
+    }
+
+    #[test]
+    fn unknown_extension_renders_plain() {
+        let lines = vec!["fn main() {}".to_string()];
+        let out = highlight_buffer("unknown_ext_zzz", &lines);
+        assert_eq!(joined(&out[0]), "fn main() {}");
+        // No span carries a foreground colour for an unsupported grammar.
+        assert!(out[0].iter().all(|s| s.style.fg.is_none()));
+    }
+
+    #[test]
+    fn blank_line_stays_a_row() {
+        let out = highlight_buffer("rs", &["".to_string()]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(joined(&out[0]), "");
+    }
+
+    #[test]
+    fn token_color_maps_known_kinds_and_ignores_others() {
+        assert_eq!(token_color("comment"), Some(Color::DarkGray));
+        assert_eq!(token_color("string"), Some(Color::Green));
+        assert_eq!(token_color("keyword"), Some(Color::Magenta));
+        assert_eq!(token_color("operator"), None);
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -294,6 +294,9 @@ pub struct AppState {
     /// Soft line-wrapping in the full-screen preview, toggled with `w` (remembered for the
     /// session). When on, long lines wrap instead of needing horizontal scroll.
     pub preview_wrap: bool,
+    /// Syntax-highlight file content in the preview and diff-context lines (issue #69).
+    /// Defaults on; `load_startup_state` turns it off when `NO_COLOR` is set in the environment.
+    pub syntax_highlight: bool,
     pub preview_gist_key: Option<(String, String)>,
     /// Screen to return to when leaving the full-screen preview (default: List; set to
     /// GistDetail when a detail-view file preview is launched).
@@ -774,6 +777,7 @@ pub fn initial_state() -> AppState {
         loading: false,
         preview_title: String::new(),
         preview_wrap: false,
+        syntax_highlight: true,
         preview_gist_key: None,
         preview_return: Screen::List,
         preview_request: None,
@@ -825,6 +829,8 @@ pub fn load_startup_state() -> Result<AppState> {
     state.scan_depth = config.scan_depth;
     state.diff_context = config.diff_context;
     state.diff_show_full = config.diff_show_full;
+    // Honour NO_COLOR for the syntax-highlight feature only (existing semantic colours stay).
+    state.syntax_highlight = std::env::var_os("NO_COLOR").is_none();
     state.locals = crate::local::discover_local_candidates(
         &cwd,
         &state.pinned,
@@ -902,6 +908,7 @@ impl AppState {
 /// the frame) and wiped clean with `Clear` so whatever is behind it doesn't bleed through.
 /// This is the shared "centered window" primitive behind both the loading overlay and the
 /// confirm prompt.
+mod highlight;
 mod render;
 use render::*;
 mod keys;

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -76,12 +76,14 @@ Diff view (Enter / d / u)
   Up/Down/Left/Right  scroll the diff
   c          toggle context: configured radius <-> full file (remembered)
   d / u      download / upload from the diff
+  syntax     unchanged context lines are syntax-highlighted by file type
   Esc / q    back
 
 Full-screen preview (Space, or 1-9 in the detail view)
   Up/Down/Left/Right  scroll (Left/Right only when wrap is off)
   w          toggle soft line wrapping (remembered for the session)
   y          copy the gist URL · Y copy the file content to the clipboard
+  syntax     known file types are syntax-highlighted
   R          re-fetch the content
   Esc / q    back
 
@@ -121,7 +123,8 @@ Gist detail (Enter from gist manager)
 General
   Esc / q    close an overlay; from the list, press twice to quit the app
   ?          show this help
-  Up/Down    scroll this help text";
+  Up/Down    scroll this help text
+  NO_COLOR   set this env var to disable syntax highlighting (preview + diff)";
 
     frame.render_widget(
         Paragraph::new(body).scroll((state.help_scroll, 0)).block(
@@ -133,6 +136,42 @@ General
         ),
         frame.area(),
     );
+}
+
+/// Lowercase file extension of a filename or path string, if any.
+fn file_ext(name: &str) -> Option<String> {
+    std::path::Path::new(name)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_lowercase())
+}
+
+/// Language extension for the previewed file, taken from its gist key's filename.
+fn preview_ext(state: &AppState) -> Option<String> {
+    state
+        .preview_gist_key
+        .as_ref()
+        .and_then(|(_, filename)| file_ext(filename))
+}
+
+/// Language extension for the diff's file — the local/target filename both sides share.
+fn diff_ext(state: &AppState) -> Option<String> {
+    state
+        .download_target
+        .file_name()
+        .or_else(|| state.preview_local.file_name())
+        .and_then(|n| n.to_str())
+        .and_then(file_ext)
+}
+
+/// The preview body as per-line span vectors: syntax-highlighted when the feature is enabled and
+/// the file type is known, otherwise one plain span per line.
+fn preview_line_spans(state: &AppState) -> Vec<Vec<Span<'static>>> {
+    let lines: Vec<String> = state.diff_text.lines().map(str::to_string).collect();
+    match (state.syntax_highlight, preview_ext(state)) {
+        (true, Some(ext)) => super::highlight::highlight_buffer(&ext, &lines),
+        _ => lines.into_iter().map(|l| vec![Span::raw(l)]).collect(),
+    }
 }
 
 pub(super) fn render_preview(frame: &mut Frame, state: &AppState) {
@@ -157,15 +196,23 @@ pub(super) fn render_preview(frame: &mut Frame, state: &AppState) {
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .padding(Padding::horizontal(1));
+    let line_spans = preview_line_spans(state);
     let paragraph = if state.preview_wrap {
-        Paragraph::new(state.diff_text.clone())
+        // Wrapping needs the full line set; vertical scroll goes through Paragraph (no hscroll).
+        let body = Text::from(line_spans.into_iter().map(Line::from).collect::<Vec<_>>());
+        Paragraph::new(body)
             .scroll((state.diff_scroll, 0))
             .wrap(Wrap { trim: false })
             .block(block)
     } else {
-        Paragraph::new(state.diff_text.clone())
-            .scroll((state.diff_scroll, state.diff_hscroll))
-            .block(block)
+        // Manual horizontal + vertical scroll mirrors diff_view, avoiding the styled-line
+        // redraw artifacts that Paragraph::scroll leaves on coloured spans.
+        let visible: Vec<Line> = line_spans
+            .into_iter()
+            .map(|spans| apply_hscroll_spans(spans, state.diff_hscroll as usize))
+            .skip(state.diff_scroll as usize)
+            .collect();
+        Paragraph::new(Text::from(visible)).block(block)
     };
     frame.render_widget(paragraph, chunks[0]);
     render_footer(frame, chunks[1], "", &footer, colored);
@@ -1044,10 +1091,42 @@ pub(super) fn header_line(line: &str, hscroll: usize) -> Line<'static> {
 /// easy to spot. Scrolling is applied by hand — skip `vscroll` lines and drop `hscroll` leading
 /// chars per line — rather than via `Paragraph::scroll`, whose styled-line handling leaves
 /// redraw artifacts in ratatui 0.26.
-pub(super) fn diff_view(text: &str, vscroll: u16, hscroll: u16) -> Text<'static> {
+///
+/// When `highlight` is on and `ext` names a known language, the unchanged context lines (those
+/// prefixed by a space) are syntax coloured; `-`/`+` lines keep their red/green + word-level
+/// highlighting untouched so the add/delete signal stays dominant. Tabbed context lines are left
+/// plain so their indentation stays aligned with the raw-tab `-`/`+` lines.
+pub(super) fn diff_view_highlighted(
+    text: &str,
+    vscroll: u16,
+    hscroll: u16,
+    ext: Option<&str>,
+    highlight: bool,
+) -> Text<'static> {
     let raw: Vec<&str> = text.lines().collect();
     let hscroll = hscroll as usize;
     let mut result: Vec<Line<'static>> = Vec::with_capacity(raw.len());
+
+    // Pre-highlight the unchanged context lines as one buffer, keyed back by raw line index.
+    let ctx_highlight: std::collections::HashMap<usize, Vec<Span<'static>>> = match (highlight, ext)
+    {
+        (true, Some(ext)) => {
+            let mut idxs = Vec::new();
+            let mut contents = Vec::new();
+            for (idx, l) in raw.iter().enumerate() {
+                if l.starts_with(' ') && !l.contains('\t') {
+                    idxs.push(idx);
+                    contents.push(l[1..].to_string());
+                }
+            }
+            super::highlight::highlight_buffer(ext, &contents)
+                .into_iter()
+                .zip(idxs)
+                .map(|(spans, idx)| (idx, spans))
+                .collect()
+        }
+        _ => std::collections::HashMap::new(),
+    };
 
     let mut i = 0;
     while i < raw.len() {
@@ -1091,6 +1170,13 @@ pub(super) fn diff_view(text: &str, vscroll: u16, hscroll: u16) -> Text<'static>
             }
         } else if line.starts_with("+++") || line.starts_with("---") {
             result.push(header_line(line, hscroll));
+            i += 1;
+        } else if let Some(spans) = ctx_highlight.get(&i) {
+            // Syntax-highlighted context line: re-prepend the space marker, then scroll.
+            let mut line_spans = Vec::with_capacity(spans.len() + 1);
+            line_spans.push(Span::raw(" ".to_string()));
+            line_spans.extend(spans.iter().cloned());
+            result.push(apply_hscroll_spans(line_spans, hscroll));
             i += 1;
         } else {
             let visible: String = line.chars().skip(hscroll).collect();
@@ -1234,8 +1320,16 @@ pub(super) fn render_diff_pane(frame: &mut Frame, area: Rect, state: &AppState) 
         Some(radius) => crate::diff::collapse_context(&state.diff_text, radius),
         None => state.diff_text.clone(),
     };
+    let ext = diff_ext(state);
     frame.render_widget(
-        Paragraph::new(diff_view(&diff_body, state.diff_scroll, state.diff_hscroll)).block(
+        Paragraph::new(diff_view_highlighted(
+            &diff_body,
+            state.diff_scroll,
+            state.diff_hscroll,
+            ext.as_deref(),
+            state.syntax_highlight,
+        ))
+        .block(
             Block::default()
                 .title(diff_title(state))
                 .borders(Borders::ALL)

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -906,7 +906,7 @@ fn diff_context_toggle_flips_effective_radius() {
 #[test]
 fn diff_view_applies_vertical_and_horizontal_scroll() {
     let text = "--- a\n+++ b\nabcdef\n more";
-    let v = diff_view(text, 2, 2); // skip 2 lines, drop 2 leading chars
+    let v = diff_view_highlighted(text, 2, 2, None, false); // skip 2 lines, drop 2 leading chars
     assert_eq!(v.lines.len(), 2);
     assert_eq!(v.lines[0].spans[0].content, "cdef");
 }
@@ -915,9 +915,9 @@ fn diff_view_applies_vertical_and_horizontal_scroll() {
 fn diff_view_inline_highlights_changed_words() {
     // A single-line modification: "hello world" → "hello planet"
     let text = "--- a\n+++ b\n-hello world\n+hello planet\n";
-    let v = diff_view(text, 2, 0); // skip header lines
-                                   // del line: span 0 is "-", unchanged word "hello " is plain red,
-                                   //           changed word "world" is bold red
+    let v = diff_view_highlighted(text, 2, 0, None, false); // skip header lines
+                                                            // del line: span 0 is "-", unchanged word "hello " is plain red,
+                                                            //           changed word "world" is bold red
     assert_eq!(v.lines.len(), 2);
     let del = &v.lines[0];
     let sign = del.spans.iter().find(|s| s.content == "-").unwrap();
@@ -944,6 +944,42 @@ fn diff_view_inline_highlights_changed_words() {
         .find(|s| s.content.trim() == "planet")
         .unwrap();
     assert!(planet.style.add_modifier.contains(Modifier::BOLD));
+}
+
+#[test]
+fn diff_view_highlights_context_lines_for_known_language() {
+    // Context line " let x = 1;" gets syntax colour; the -/+ pair keeps red/green.
+    let text = "--- a\n+++ b\n let x = 1;\n-old\n+new\n";
+    let v = diff_view_highlighted(text, 0, 0, Some("rs"), true);
+    let ctx = v
+        .lines
+        .iter()
+        .find(|l| l.spans.first().map(|s| s.content.as_ref()) == Some(" "))
+        .expect("a context line marked by a leading space span");
+    // `let` is a Rust keyword → magenta somewhere on the context line.
+    assert!(ctx.spans.iter().any(|s| s.style.fg == Some(Color::Magenta)));
+    // The del line stays red, never picks up a syntax colour.
+    let del = v
+        .lines
+        .iter()
+        .find(|l| l.spans.iter().any(|s| s.content == "-"))
+        .unwrap();
+    assert!(del.spans.iter().all(|s| s.style.fg != Some(Color::Magenta)));
+}
+
+#[test]
+fn diff_view_leaves_context_plain_when_highlight_disabled() {
+    let text = "--- a\n+++ b\n let x = 1;\n";
+    let v = diff_view_highlighted(text, 0, 0, Some("rs"), false);
+    assert!(v.lines[2].spans.iter().all(|s| s.style.fg.is_none()));
+}
+
+#[test]
+fn diff_view_skips_tabbed_context_lines() {
+    // A tab in the context line keeps it plain so indentation stays aligned with -/+ lines.
+    let text = "--- a\n+++ b\n \tlet x = 1;\n";
+    let v = diff_view_highlighted(text, 0, 0, Some("rs"), true);
+    assert!(v.lines[2].spans.iter().all(|s| s.style.fg.is_none()));
 }
 
 #[test]


### PR DESCRIPTION
Closes #69.

## What

Colourise file content by language:

- **Preview** (`Space` / `1-9`): full syntax highlighting of the file.
- **Diff**: syntax-highlight the *unchanged context lines* only. The `-`/`+` lines keep their red/green and word-level inline highlighting so additions/removals stay dominant. Tabbed context lines are left plain so their indentation stays aligned with the raw-tab `-`/`+` lines.

Known extensions are highlighted; unknown ones render plain. Honours `NO_COLOR` (disables highlighting only — semantic diff `-`/`+` and other UI colours are unaffected).

## Library: `synoptic`

Chosen over `syntect` to match the project's lean-dependency stance (same reasoning as the `arboard` decision in #70). Pure-Rust, regex-based, **3 tiny transitive deps** (`char_index`, `if_chain`, `nohash-hasher`) — no oniguruma/C, no bundled multi-MB syntax dump.

## Binary-size delta (required by the issue)

Unstripped `cargo build --release`, macOS aarch64:

| | bytes |
|---|---|
| baseline (main) | 2,720,912 |
| with synoptic | 4,638,704 |
| **delta** | **+1,917,792 (+1.83 MiB, +70%)** |

(`syntect` would have been several MB more and pulled heavier deps.)

## Design

- New render-layer module `tui::highlight` maps content → coloured ratatui spans, keeping the domain/render split (no state mutation, no IO).
- `AppState::syntax_highlight` (default on; set from `NO_COLOR` absence in `load_startup_state`) gates the feature; `initial_state` stays env-free for tests.
- Preview uses whole-buffer highlighting (correct across multi-line strings/comments); non-wrap path applies manual scroll like `diff_view` to avoid styled `Paragraph::scroll` artifacts.
- Diff context lines are highlighted as one batched buffer keyed back by line index (best-effort across hunks).

## Known limitations

- Per-frame re-highlighting (no cache); fine for typical gist-sized files.
- Diff context highlighting is per-context-buffer, so a multi-line construct split across hunks may colour approximately.

## Verification

`cargo fmt --check` · `cargo test` (233 passed, +7 new) · `cargo check` · `cargo clippy --all-targets -- -D warnings` — all green.

Demo GIF not re-recorded (storyboard doesn't feature a highlighted file prominently); can add if wanted.