### PR TITLE
feat(tui): PageUp/PageDown scrolling in preview and diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Gist pane), `Up`/`Down` (move), and `Left`/`Right` (scroll a long row).
   `diff_context` config, default 3) and the full file. The choice is remembered (persisted
   to config). Unchanged context lines are **syntax-highlighted** by file type; the `-`/`+`
   lines keep their red/green and word-level highlighting so additions/removals stay obvious.
+  Scroll with the arrow keys, or `PageUp`/`PageDown` to jump 10 lines at a time.
 - `d` (on a gist) — download it into the cwd as `./<gist-filename>`. A brand-new file is
   written directly; an existing one is shown as a diff and overwritten only after a `y`/`n`
   confirmation.
@@ -139,8 +140,9 @@ Gist pane), `Up`/`Down` (move), and `Left`/`Right` (scroll a long row).
   clipboard. Works on the list, the gist manager, the detail view, and the preview overlay.
 - `Space` (on a gist) — preview the gist's raw content in a scrollable overlay (`R` to
   force-refresh, bypassing the session cache; `w` to toggle soft line wrapping for long lines,
-  remembered for the session). Known file types are **syntax-highlighted** by extension. Inside
-  the preview, `y` copies the gist URL and `Y` copies the full file content to the clipboard.
+  remembered for the session). Known file types are **syntax-highlighted** by extension. Scroll
+  with the arrow keys, or `PageUp`/`PageDown` to jump 10 lines at a time. Inside the preview, `y`
+  copies the gist URL and `Y` copies the full file content to the clipboard.
 - `r` — toggle **recursive** local file discovery; the pane title shows `[↓]` while active
   and scans in the background so the UI stays responsive.
 - `a` — flip the **anchor** (which pane drives match ranking); independent of focus, so you

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -1,6 +1,11 @@
 use super::*;
 use crossterm::event::KeyCode;
 
+/// Lines moved per PageUp/PageDown in the scrollable views. Matches the gist-detail paging step
+/// (`detail_nav(10)`); `handle_key` is pure and cannot read the viewport height, so a fixed step
+/// keeps paging predictable without threading terminal size into the key logic.
+const PAGE_SCROLL: u16 = 10;
+
 impl AppState {
     pub fn handle_key(&mut self, code: KeyCode) -> KeyOutcome {
         match self.screen {
@@ -319,6 +324,8 @@ impl AppState {
             KeyCode::Char('Y') => return KeyOutcome::CopyPreviewContent,
             KeyCode::Down => self.scroll_diff_down(),
             KeyCode::Up => self.scroll_diff_up(),
+            KeyCode::PageDown => self.scroll_diff_page_down(PAGE_SCROLL),
+            KeyCode::PageUp => self.scroll_diff_page_up(PAGE_SCROLL),
             KeyCode::Right => self.scroll_diff_right(),
             KeyCode::Left => self.scroll_diff_left(),
             _ => {}
@@ -586,6 +593,8 @@ impl AppState {
             }
             KeyCode::Down => self.scroll_diff_down(),
             KeyCode::Up => self.scroll_diff_up(),
+            KeyCode::PageDown => self.scroll_diff_page_down(PAGE_SCROLL),
+            KeyCode::PageUp => self.scroll_diff_page_up(PAGE_SCROLL),
             KeyCode::Right => self.scroll_diff_right(),
             KeyCode::Left => self.scroll_diff_left(),
             // Identical files have nothing to sync, so download/upload are not offered.
@@ -618,6 +627,14 @@ impl AppState {
             }
             KeyCode::Up => {
                 self.scroll_diff_up();
+                return KeyOutcome::None;
+            }
+            KeyCode::PageDown => {
+                self.scroll_diff_page_down(PAGE_SCROLL);
+                return KeyOutcome::None;
+            }
+            KeyCode::PageUp => {
+                self.scroll_diff_page_up(PAGE_SCROLL);
                 return KeyOutcome::None;
             }
             KeyCode::Right => {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -714,6 +714,22 @@ impl AppState {
         self.diff_scroll = self.diff_scroll.saturating_sub(1);
     }
 
+    /// Page the diff/preview down by `lines`, clamped to the same bottom as `scroll_diff_down`.
+    pub fn scroll_diff_page_down(&mut self, lines: u16) {
+        let max = self
+            .diff_text
+            .lines()
+            .count()
+            .saturating_sub(1)
+            .min(u16::MAX as usize) as u16;
+        self.diff_scroll = self.diff_scroll.saturating_add(lines).min(max);
+    }
+
+    /// Page the diff/preview up by `lines`, saturating at the top.
+    pub fn scroll_diff_page_up(&mut self, lines: u16) {
+        self.diff_scroll = self.diff_scroll.saturating_sub(lines);
+    }
+
     pub fn scroll_diff_right(&mut self) {
         let max = self
             .diff_text

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -74,6 +74,7 @@ Pinned Mappings screen (P)
 
 Diff view (Enter / d / u)
   Up/Down/Left/Right  scroll the diff
+  PageUp/Dn  scroll the diff by 10 lines
   c          toggle context: configured radius <-> full file (remembered)
   d / u      download / upload from the diff
   syntax     unchanged context lines are syntax-highlighted by file type
@@ -81,6 +82,7 @@ Diff view (Enter / d / u)
 
 Full-screen preview (Space, or 1-9 in the detail view)
   Up/Down/Left/Right  scroll (Left/Right only when wrap is off)
+  PageUp/Dn  scroll by 10 lines
   w          toggle soft line wrapping (remembered for the session)
   y          copy the gist URL · Y copy the file content to the clipboard
   syntax     known file types are syntax-highlighted
@@ -178,9 +180,9 @@ pub(super) fn render_preview(frame: &mut Frame, state: &AppState) {
     let area = frame.area();
     // A `R`-refresh fetch error (set via state.status) must surface here, not be swallowed.
     let hints = if state.preview_wrap {
-        "↑↓ scroll  ·  w wrap [on]  ·  y/Y copy url/content  ·  R refresh  ·  Esc/q back"
+        "↑↓ PgUp/Dn scroll  ·  w wrap [on]  ·  y/Y copy url/content  ·  R refresh  ·  Esc/q back"
     } else {
-        "↑↓←→ scroll  ·  w wrap [off]  ·  y/Y copy url/content  ·  R refresh  ·  Esc/q back"
+        "↑↓←→ PgUp/Dn scroll  ·  w wrap [off]  ·  y/Y copy url/content  ·  R refresh  ·  Esc/q back"
     };
     let (footer, colored) = footer_with_status(state.status.as_deref(), hints);
     let footer_lines = wrap_line_count(&footer, area.width.saturating_sub(2)).max(1);
@@ -1353,10 +1355,10 @@ pub(super) fn render_diff(frame: &mut Frame, state: &AppState) {
     };
     let footer = if state.diff_identical {
         format!(
-            "Files are identical — nothing to sync  ·  ↑↓←→ scroll  ·  {context}  ·  Esc/q back"
+            "Files are identical — nothing to sync  ·  ↑↓←→ PgUp/Dn scroll  ·  {context}  ·  Esc/q back"
         )
     } else {
-        format!("↑↓←→ scroll  ·  d download  ·  u upload  ·  {context}  ·  Esc/q back")
+        format!("↑↓←→ PgUp/Dn scroll  ·  d download  ·  u upload  ·  {context}  ·  Esc/q back")
     };
 
     let area = frame.area();

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -852,6 +852,35 @@ fn preview_scrolls_with_arrows() {
 }
 
 #[test]
+fn page_keys_jump_by_ten_clamped_to_bounds() {
+    let mut state = initial_state();
+    state.screen = Screen::Preview;
+    // 30 lines → bottom is line 29 (count - 1).
+    state.diff_text = (0..30)
+        .map(|i| format!("l{i}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    state.handle_key(KeyCode::PageDown);
+    assert_eq!(state.diff_scroll, 10);
+    // A second page-down would reach 20; a third clamps at the 29-line bottom, not 30.
+    state.handle_key(KeyCode::PageDown);
+    state.handle_key(KeyCode::PageDown);
+    assert_eq!(state.diff_scroll, 29);
+    state.handle_key(KeyCode::PageUp);
+    assert_eq!(state.diff_scroll, 19);
+}
+
+#[test]
+fn page_up_saturates_at_top_in_diff() {
+    let mut state = initial_state();
+    state.screen = Screen::Diff;
+    state.diff_text = "a\nb\nc".into();
+    state.diff_scroll = 1;
+    state.handle_key(KeyCode::PageUp);
+    assert_eq!(state.diff_scroll, 0);
+}
+
+#[test]
 fn question_opens_help_and_any_key_closes_it() {
     let mut state = initial_state();
     state.handle_key(KeyCode::Char('?'));


### PR DESCRIPTION
## What

Arrow-key scrolling is slow through long files. Add **PageUp/PageDown** to jump 10 lines at a time in:

- the full-screen **preview** (`Space` / `1-9`),
- the **diff** view (`Enter` / `d` / `u`),
- the **confirm** screen (scrolls the diff behind the y/n modal).

The step matches the gist-detail paging (`detail_nav(10)`), so paging is consistent across the app.

## How

- Two clamped helpers on `AppState` — `scroll_diff_page_down(lines)` / `scroll_diff_page_up(lines)` — reusing the same bottom cap as `scroll_diff_down`.
- Bound to `KeyCode::PageUp`/`PageDown` in `handle_key_preview`, `handle_key_diff`, and `handle_key_confirm`.
- `handle_key` is pure and can't read the viewport height, so the step is a fixed `PAGE_SCROLL` constant (10) rather than a true viewport page — keeps the key logic testable without threading terminal size through it.

## Docs

README (preview + diff bullets), the `?` help, and the preview/diff footer hints updated in lockstep.

## Verification

`cargo fmt --check` · `cargo test` (235 passed, +2 new) · `cargo check` · `cargo clippy --all-targets -- -D warnings` — all green.

Demo GIF not re-recorded: the storyboard has no scrolling segment, so a pure new-keybinding change produces no visible diff in the GIF.