### PR TITLE
feat(tui): ~-shortened local paths + horizontal scroll on the Pins screen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "gistui"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gistui"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "MIT"
 description = "A terminal UI for managing GitHub Gists"

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ does not exist (or is not a directory) `gistui` prints an error and exits withou
 Inside the TUI press `?` for the full keymap (it also shows the running version and the
 project repository link); the footer shows the keys relevant to the focused pane.
 
-The left pane lists the files in your current working directory; the right pane lists your
+The left pane lists the files in your current working directory (its title shows the
+directory path with your home directory shortened to `~`); the right pane lists your
 gists. Ranking is **anchor-driven**: one pane is the *anchor* (it drives the ranking) and
 the other pane is ranked against the anchor's current selection. The anchor is shown with a
 `⚓` marker in its title and is **independent of focus** — press `a` to flip it. So you
@@ -127,7 +128,9 @@ Gist pane), `Up`/`Down` (move), and `Left`/`Right` (scroll a long row).
 - `P` — open the **Pins view** listing all pinned pairs with sync-status icons.
   Each row shows one of: `✓` synced · `↑` local newer · `↓` remote newer · `?` unknown,
   plus `(local <age> · gist <age>)` relative modification times.
+  Local paths are shown with the home directory shortened to `~`.
   Keys inside the Pins view:
+  - `↑`/`↓` — move between pins; `←`/`→` — scroll a long local path horizontally.
   - `Enter` — diff the selected pair (read-only; `d`/`u` from the diff to pull/push; `Esc`/`q` returns to the Pins view).
   - `s` — smart-sync (newer side wins by modified time; skips if already identical).
   - `u` — force push (upload local → gist).

--- a/src/config.rs
+++ b/src/config.rs
@@ -81,6 +81,31 @@ pub fn normalize_path(path: &Path) -> Result<PathBuf> {
     }
 }
 
+/// Human-friendly rendering of a local path for TUI display. Replaces the user's
+/// home-directory prefix with `~` and normalizes the suffix to `/` separators (so the
+/// form is short and consistent on every platform, matching git / gh conventions). It is
+/// the display-side symmetry to `normalize_path`'s `~` expansion. Paths outside home, or
+/// when no home is known, render unchanged. This thin wrapper feeds the real home into the
+/// pure [`display_path_with_home`] so the logic stays unit-testable.
+pub fn display_path(path: &Path) -> String {
+    display_path_with_home(path, dirs::home_dir().as_deref())
+}
+
+/// Pure core of [`display_path`] with the home directory injected, so home handling
+/// (including Windows-style separators) is deterministically testable.
+pub fn display_path_with_home(path: &Path, home: Option<&Path>) -> String {
+    if let Some(home) = home {
+        if let Ok(suffix) = path.strip_prefix(home) {
+            if suffix.as_os_str().is_empty() {
+                return "~".to_string();
+            }
+            let suffix = suffix.to_string_lossy().replace('\\', "/");
+            return format!("~/{}", suffix.trim_start_matches('/'));
+        }
+    }
+    path.display().to_string()
+}
+
 /// Resolve the working directory to operate in. `None` keeps the current directory;
 /// `Some(path)` must point at an existing directory (a `~` prefix is expanded) — a missing
 /// path or a non-directory is an error, so the caller can report it and exit before the TUI.
@@ -300,5 +325,58 @@ mod tests {
         std::fs::write(&file, "x").unwrap();
         let err = resolve_working_dir(Some(file)).unwrap_err();
         assert!(err.to_string().contains("not a directory"));
+    }
+
+    #[test]
+    fn display_path_with_home_is_tilde_for_home_root() {
+        let home = Path::new("/Users/alice");
+        assert_eq!(display_path_with_home(home, Some(home)), "~");
+    }
+
+    #[test]
+    fn display_path_with_home_shortens_path_under_home() {
+        let home = Path::new("/Users/alice");
+        let p = home.join("code").join("gistui");
+        assert_eq!(display_path_with_home(&p, Some(home)), "~/code/gistui");
+    }
+
+    #[test]
+    fn display_path_with_home_preserves_spaces() {
+        let home = Path::new("/Users/alice");
+        let p = home.join("My Docs").join("a b.txt");
+        assert_eq!(display_path_with_home(&p, Some(home)), "~/My Docs/a b.txt");
+    }
+
+    #[test]
+    fn display_path_with_home_uses_forward_slashes_in_suffix() {
+        // On Windows the stripped suffix carries `\` separators; the display form
+        // normalizes them to `/`. We exercise the replacement portably by placing a
+        // literal backslash inside a single path component.
+        let home = Path::new("/Users/alice");
+        let p = home.join(r"sub\dir");
+        assert_eq!(display_path_with_home(&p, Some(home)), "~/sub/dir");
+    }
+
+    #[test]
+    fn display_path_with_home_keeps_paths_outside_home() {
+        let home = Path::new("/Users/alice");
+        let p = Path::new("/etc/hosts");
+        assert_eq!(display_path_with_home(p, Some(home)), "/etc/hosts");
+    }
+
+    #[test]
+    fn display_path_with_home_falls_back_without_home() {
+        let p = Path::new("/Users/alice/code");
+        assert_eq!(display_path_with_home(p, None), "/Users/alice/code");
+    }
+
+    #[test]
+    fn display_path_matches_helper_with_real_home() {
+        // The thin wrapper just feeds dirs::home_dir() into the pure helper.
+        if let Some(home) = dirs::home_dir() {
+            let p = home.join("code").join("gistui");
+            assert_eq!(display_path(&p), display_path_with_home(&p, Some(&home)));
+            assert_eq!(display_path(&p), "~/code/gistui");
+        }
     }
 }

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -48,9 +48,17 @@ impl AppState {
             KeyCode::Char('q') | KeyCode::Esc => self.screen = Screen::List,
             KeyCode::Down if self.pins_index + 1 < self.pinned.len() => {
                 self.pins_index += 1;
+                self.pins_hscroll = 0;
             }
             KeyCode::Up if self.pins_index > 0 => {
                 self.pins_index -= 1;
+                self.pins_hscroll = 0;
+            }
+            KeyCode::Right => {
+                self.pins_hscroll = (self.pins_hscroll + 1).min(self.pins_hscroll_max());
+            }
+            KeyCode::Left => {
+                self.pins_hscroll = self.pins_hscroll.saturating_sub(1);
             }
             KeyCode::Enter if !self.pinned.is_empty() => return KeyOutcome::PreviewPinDiff,
             KeyCode::Char('x') if !self.pinned.is_empty() => return KeyOutcome::UnpinAtPin,
@@ -464,6 +472,7 @@ impl AppState {
             KeyCode::Char('?') => self.screen = Screen::Help,
             KeyCode::Char('P') => {
                 self.pins_index = 0;
+                self.pins_hscroll = 0;
                 self.screen = Screen::Pins;
             }
             KeyCode::Char('S') => return KeyOutcome::SyncSelectedPair,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -311,6 +311,7 @@ pub struct AppState {
     pub scan_depth: u32,
     pub local_scanning: bool,
     pub pins_index: usize,
+    pub pins_hscroll: u16,
     pub gists_index: usize,
     pub gists_hscroll: u16,
     pub gists_sort: GistGroupSort,
@@ -537,6 +538,19 @@ impl AppState {
                     .chars()
                     .count()
             })
+            .max()
+            .unwrap_or(0)
+            .saturating_sub(1)
+            .min(u16::MAX as usize) as u16
+    }
+
+    /// Highest horizontal-scroll offset for the Pins screen, bounded by the longest
+    /// displayed local path (the only variable-length, overflow-prone field in a pin row).
+    /// Pure helper modeled on `gists_hscroll_max`.
+    fn pins_hscroll_max(&self) -> u16 {
+        self.pinned
+            .iter()
+            .map(|m| crate::config::display_path(&m.local_path).chars().count())
             .max()
             .unwrap_or(0)
             .saturating_sub(1)
@@ -803,6 +817,7 @@ pub fn initial_state() -> AppState {
         scan_depth: crate::config::AppConfig::default().scan_depth,
         local_scanning: false,
         pins_index: 0,
+        pins_hscroll: 0,
         gists_index: 0,
         gists_hscroll: 0,
         gists_sort: GistGroupSort::Updated,

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -64,6 +64,7 @@ Actions (on the selected local file + gist)
 
 Pinned Mappings screen (P)
   Up/Down    move between pins
+  Left/Right scroll a long local path horizontally (~ = home)
   Enter      diff the selected pair (then d pull / u push from the diff)
   s          smart-sync (newer side wins; skips if already identical)
   u          force push  (upload local → gist)
@@ -227,7 +228,7 @@ pub(super) fn render_pins(frame: &mut Frame, state: &AppState) {
     let hints = if state.pinned.is_empty() {
         "Esc/q back"
     } else {
-        "↑↓ move  ·  Enter diff · s sync · u push · d pull · x unpin  ·  ✓ synced ↑ local-newer ↓ remote-newer ? n/a  ·  Esc/q back"
+        "↑↓ move · ←→ scroll · Enter diff · s sync · u push · d pull · x unpin  ·  ✓ synced ↑ local-newer ↓ remote-newer ? n/a  ·  Esc/q back"
     };
     let (footer, colored) = footer_with_status(state.status.as_deref(), hints);
     let footer_lines = wrap_line_count(&footer, area.width.saturating_sub(2)).max(1);
@@ -256,14 +257,16 @@ pub(super) fn render_pins(frame: &mut Frame, state: &AppState) {
                     ts.map(|t| crate::domain::humanize_age(now - t as i64))
                         .unwrap_or_else(|| "?".to_string())
                 };
-                ListItem::new(format!(
-                    "{}  {}  ↔  {} / {}   (local {} · gist {})",
-                    state.pin_sync_status(i).icon(),
-                    m.local_path.display(),
-                    m.gist_id,
-                    m.gist_filename,
-                    age(lts),
-                    age(rts),
+                ListItem::new(hscroll_str(
+                    &pin_row_label(
+                        state.pin_sync_status(i).icon(),
+                        &m.local_path,
+                        &m.gist_id,
+                        &m.gist_filename,
+                        &age(lts),
+                        &age(rts),
+                    ),
+                    state.pins_hscroll,
                 ))
             })
             .collect()
@@ -626,6 +629,28 @@ pub(super) fn hscroll_str(text: &str, offset: u16) -> String {
     text.chars().skip(offset as usize).collect()
 }
 
+/// Builds a single Pins-screen row. The local path is rendered with `display_path`
+/// (home → `~`) so it stays readable; the full row is horizontally scrollable. Pure so
+/// the path-shortening is unit-testable without a frame.
+pub(super) fn pin_row_label(
+    icon: &str,
+    local_path: &std::path::Path,
+    gist_id: &str,
+    gist_filename: &str,
+    local_age: &str,
+    gist_age: &str,
+) -> String {
+    format!(
+        "{}  {}  ↔  {} / {}   (local {} · gist {})",
+        icon,
+        crate::config::display_path(local_path),
+        gist_id,
+        gist_filename,
+        local_age,
+        gist_age,
+    )
+}
+
 /// How a file-list row should be flagged: 📌 = an existing pinned pair; same-name = bold; else none.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum RowMark {
@@ -851,7 +876,7 @@ pub(super) fn render_list(frame: &mut Frame, state: &AppState) {
     let scanning_marker = if state.local_scanning { " …" } else { "" };
     let local_title = format!(
         "[1] Local · {}{}{} · sort:{}",
-        state.cwd.display(),
+        crate::config::display_path(&state.cwd),
         recursive_marker,
         scanning_marker,
         state.local_sort.label()
@@ -1204,7 +1229,10 @@ pub(super) fn diff_title(state: &AppState) -> String {
             gist_id, filename, ..
         }) => format!("Upload → gist {gist_id} / {filename}"),
         Some(PendingAction::Create { local_path }) => {
-            format!("Create gist from {}", local_path.display())
+            format!(
+                "Create gist from {}",
+                crate::config::display_path(local_path)
+            )
         }
         Some(PendingAction::Delete { gist_id, .. }) => {
             format!("Delete gist {gist_id}")
@@ -1223,12 +1251,15 @@ pub(super) fn diff_title(state: &AppState) -> String {
             if state.preview_local.as_os_str().is_empty()
                 || state.preview_local == state.download_target
             {
-                format!("{label} → {}", state.download_target.display())
+                format!(
+                    "{label} → {}",
+                    crate::config::display_path(&state.download_target)
+                )
             } else {
                 format!(
                     "{label}: {} → {}",
-                    state.preview_local.display(),
-                    state.download_target.display()
+                    crate::config::display_path(&state.preview_local),
+                    crate::config::display_path(&state.download_target)
                 )
             }
         }
@@ -1253,7 +1284,7 @@ pub(super) fn confirm_prompt(state: &AppState) -> String {
             };
             format!(
                 "Create gist from {} ({desc})?  s secret  p public  Esc cancel",
-                local_path.display()
+                crate::config::display_path(local_path)
             )
         }
         Some(PendingAction::Upload {

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -109,8 +109,13 @@ pub(super) fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) ->
                             } else {
                                 match crate::actions::execute_download(&target, &remote, false) {
                                     Ok(()) => {
-                                        state
-                                            .set_status(format!("Downloaded {}", target.display()));
+                                        state.set_status(format!(
+                                            "Downloaded {}",
+                                            target
+                                                .file_name()
+                                                .unwrap_or(target.as_os_str())
+                                                .to_string_lossy()
+                                        ));
                                         record_pin_sync(
                                             &mut state,
                                             &target,
@@ -196,7 +201,7 @@ pub(super) fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) ->
                             state.set_status(format!(
                                 "Created {} gist from {}",
                                 visibility,
-                                local_path.display()
+                                crate::config::display_path(&local_path)
                             ));
                             state.description_input.clear();
                             state.back_to_list();
@@ -457,7 +462,8 @@ pub(super) fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) ->
                         local_path: local_path.clone(),
                     });
 
-                    let local_label = format!("local: {}", local_path.display());
+                    let local_label =
+                        format!("local: {}", crate::config::display_path(&local_path));
                     let gist_label = "(new file)".to_string();
                     state.init_upload_state(
                         &local_path,
@@ -1174,7 +1180,10 @@ fn edit_local(
     terminal.clear()?;
 
     match result {
-        Ok(_) => state.set_status(format!("Edited {}", local.path.display())),
+        Ok(_) => state.set_status(format!(
+            "Edited {}",
+            crate::config::display_path(&local.path)
+        )),
         Err(error) => state.set_status(format!("editor failed: {error}")),
     }
     Ok(())
@@ -1247,7 +1256,13 @@ fn download(state: &mut AppState) {
     let content = state.preview_remote.clone();
     match crate::actions::execute_download(&target, &content, true) {
         Ok(()) => {
-            state.set_status(format!("Downloaded {}", target.display()));
+            state.set_status(format!(
+                "Downloaded {}",
+                target
+                    .file_name()
+                    .unwrap_or(target.as_os_str())
+                    .to_string_lossy()
+            ));
             if let (Some(gid), Some(fname)) = (
                 state.download_gist_id.clone(),
                 state.download_gist_filename.clone(),
@@ -1345,7 +1360,10 @@ fn unpin_selected(state: &mut AppState) {
             state.pinned = config.pinned;
             state.skip_dirs = config.skip_dirs;
             state.scan_depth = config.scan_depth;
-            state.set_status(format!("Unpinned {}", local.path.display()));
+            state.set_status(format!(
+                "Unpinned {}",
+                crate::config::display_path(&local.path)
+            ));
         }
         Err(error) => state.set_status(format!("unpin failed: {error}")),
     }
@@ -1355,7 +1373,7 @@ fn unpin_at_pin_index(state: &mut AppState) {
     let Some(mapping) = state.pinned.get(state.pins_index).cloned() else {
         return;
     };
-    let label = mapping.local_path.display().to_string();
+    let label = crate::config::display_path(&mapping.local_path);
     let result = crate::config::config_path().and_then(|path| {
         let config = crate::config::load_config(&path)?;
         crate::actions::unpin_mapping_exact(&path, config, &mapping.local_path, &mapping.gist_id)

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -2338,6 +2338,139 @@ fn pins_screen_enter_emits_preview_pin_diff() {
     assert_eq!(state.handle_key(KeyCode::Enter), KeyOutcome::PreviewPinDiff);
 }
 
+fn pins_state_with_long_home_path() -> AppState {
+    let mut state = initial_state();
+    state.screen = Screen::Pins;
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/home/u"));
+    state.pinned = vec![PinnedMapping {
+        local_path: home.join("code/very/deeply/nested/project/config.json"),
+        gist_id: "g1".into(),
+        gist_filename: "config.json".into(),
+        direction: None,
+        last_seen_hash: None,
+    }];
+    state.pins_index = 0;
+    state
+}
+
+#[test]
+fn pins_hscroll_starts_at_zero() {
+    assert_eq!(initial_state().pins_hscroll, 0);
+}
+
+#[test]
+fn create_diff_title_shortens_home_path() {
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/home/u"));
+    let mut state = initial_state();
+    state.pending_action = Some(PendingAction::Create {
+        local_path: home.join("notes.txt"),
+    });
+    assert_eq!(diff_title(&state), "Create gist from ~/notes.txt");
+}
+
+#[test]
+fn diff_view_title_shortens_single_home_path() {
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/home/u"));
+    let mut state = initial_state();
+    state.pending_action = None;
+    state.preview_local = PathBuf::new();
+    state.download_target = home.join("notes.txt");
+    assert_eq!(diff_title(&state), "Diff → ~/notes.txt");
+}
+
+#[test]
+fn diff_view_title_shortens_both_home_paths() {
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/home/u"));
+    let mut state = initial_state();
+    state.pending_action = None;
+    state.preview_local = home.join("src").join("a.txt");
+    state.download_target = home.join("b.txt");
+    assert_eq!(diff_title(&state), "Diff: ~/src/a.txt → ~/b.txt");
+}
+
+#[test]
+fn create_confirm_prompt_shortens_home_path() {
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/home/u"));
+    let mut state = initial_state();
+    state.pending_action = Some(PendingAction::Create {
+        local_path: home.join("notes.txt"),
+    });
+    assert!(
+        confirm_prompt(&state).starts_with("Create gist from ~/notes.txt"),
+        "got {}",
+        confirm_prompt(&state)
+    );
+}
+
+#[test]
+fn pin_row_label_shows_home_as_tilde() {
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/home/u"));
+    let label = pin_row_label(
+        "✓",
+        &home.join("code/gistui"),
+        "abc123",
+        "notes.txt",
+        "2h",
+        "3h",
+    );
+    assert!(
+        label.contains("~/code/gistui"),
+        "expected ~ home in label, got {label}"
+    );
+    assert!(!label.contains(home.to_string_lossy().as_ref()));
+}
+
+#[test]
+fn pins_right_scrolls_then_clamps_at_a_bound() {
+    let mut state = pins_state_with_long_home_path();
+    state.handle_key(KeyCode::Right);
+    assert_eq!(state.pins_hscroll, 1, "Right should advance the scroll");
+    // Far past the end clamps to a stable maximum (does not run away).
+    for _ in 0..500 {
+        state.handle_key(KeyCode::Right);
+    }
+    let clamped = state.pins_hscroll;
+    state.handle_key(KeyCode::Right);
+    assert_eq!(state.pins_hscroll, clamped, "scroll must clamp at its max");
+    assert!(clamped > 0, "a long path must be scrollable");
+}
+
+#[test]
+fn pins_left_clamps_at_zero() {
+    let mut state = pins_state_with_long_home_path();
+    state.handle_key(KeyCode::Right);
+    state.handle_key(KeyCode::Left);
+    state.handle_key(KeyCode::Left);
+    assert_eq!(state.pins_hscroll, 0);
+}
+
+#[test]
+fn pins_hscroll_resets_when_selection_moves() {
+    let mut state = pins_state_with_long_home_path();
+    state.pinned.push(PinnedMapping {
+        local_path: PathBuf::from("/tmp/b.txt"),
+        gist_id: "g2".into(),
+        gist_filename: "b.txt".into(),
+        direction: None,
+        last_seen_hash: None,
+    });
+    state.handle_key(KeyCode::Right);
+    assert!(state.pins_hscroll > 0);
+    state.handle_key(KeyCode::Down);
+    assert_eq!(state.pins_hscroll, 0, "moving selection resets hscroll");
+}
+
+#[test]
+fn entering_pins_screen_resets_hscroll() {
+    let mut state = pins_state_with_long_home_path();
+    state.handle_key(KeyCode::Right);
+    assert!(state.pins_hscroll > 0);
+    state.screen = Screen::List;
+    state.handle_key(KeyCode::Char('P'));
+    assert_eq!(state.screen, Screen::Pins);
+    assert_eq!(state.pins_hscroll, 0);
+}
+
 #[test]
 fn list_screen_capital_s_syncs_selected_pair() {
     let mut state = initial_state();


### PR DESCRIPTION
## What

Render local paths in a human-friendly way across the TUI, and make long paths on the **Pins** screen horizontally scrollable.

### `display_path` helper (`config`)
- Collapses the home-directory prefix to `~` and normalizes the suffix to `/` separators — short and consistent on every platform (including Windows), matching git/gh conventions. It is the display-side symmetry to `normalize_path`'s `~` expansion.
- The home directory is injected via a pure `display_path_with_home(path, home)` core, so the logic (Windows-style separators, home root, paths outside home, no-home fallback) is **deterministically unit-tested**. `display_path` is a thin wrapper feeding `dirs::home_dir()`.

### Applied to every user-facing local path
- Local pane title
- Pins-screen rows
- Diff-view title (both the single-path `Diff → …` and two-path `Diff: … → …` forms)
- Create-gist diff title + confirm prompt
- `local:` / `Created` / `Edited` / `Unpinned` status messages
- **`Downloaded` now shows just the filename** (downloads always land in `cwd/<filename>`)

### Pins screen horizontal scroll
- New `pins_hscroll` state + pure `pins_hscroll_max` (bounded by the longest displayed path, modeled on `gists_hscroll_max`).
- `←`/`→` scroll the selected row; `↑`/`↓` and `P` reset the offset.
- Each row is rendered through a pure `pin_row_label` + the existing `hscroll_str`.

### Docs
- `README.md` and the `?` help text updated in lockstep (Pins `←`/`→` scroll, `~` home display).

> Note: this branch also carries the `chore: bump version to v0.8.0` commit.

## Testing
- `cargo fmt --check` ✓
- `cargo test` — 252 + 12 pass (15 new targeted tests, written test-first)
- `cargo clippy --all-targets -- -D warnings` — clean