### PR TITLE
fix(tui): write redact temp file to system temp dir

### DIFF
--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -1204,9 +1204,8 @@ fn edit_upload_buffer(
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_nanos())
         .unwrap_or(0);
-    let temp_file_path = state
-        .cwd
-        .join(format!(".gistui_redact_{timestamp}_{filename}"));
+    let temp_file_path =
+        std::env::temp_dir().join(format!(".gistui_redact_{timestamp}_{filename}"));
 
     let current_content = state.content_to_upload();
     if let Err(e) = std::fs::write(&temp_file_path, &current_content) {


### PR DESCRIPTION
## Summary

The redact edit buffer (`edit_upload_buffer`) wrote its temp file into the working directory (`state.cwd`) as `.gistui_redact_<timestamp>_<filename>`. It is removed after the editor exits, but if the editor or process is interrupted before cleanup, the file leaked into the project directory.

## Changes

- `src/tui/run_loop.rs`: build the temp path from `std::env::temp_dir()` instead of `state.cwd`.

## Testing

- [x] `cargo fmt --check`
- [x] `cargo test`
- [x] `cargo check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] Manually verified in the TUI (if applicable)

## Related Issues

Closes #87