### PR TITLE
docs: crate metadata, README badges, value prop, and CHANGELOG

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ Pure, testable domain logic is kept separate from impure shell/filesystem adapte
 - Fold same-scope follow-up fixes into the original commit (amend) rather than adding `fix typo` / `review fix` commits.
 - Every PR MUST carry a release-note category label (`enhancement`, `bug`, `documentation`, `dependencies`, or `skip-changelog`) — GitHub groups auto-generated release notes by these via `.github/release.yml`.
 - When a change adds or alters a user-facing key, screen, or feature, update `README.md` (the Actions/keymap and Safety sections) and the `?` help text in `tui.rs` **in the same PR** — keep docs and behavior in lockstep.
+- Any user-facing feature or bug fix MUST add a concise bullet under the `## [Unreleased]` section of `CHANGELOG.md` **in the same PR**. Keep it one line, summarising the user-visible effect (GitHub Releases stays the authoritative, detailed source — see the file header). Changes labelled `skip-changelog` or purely internal (dependency bumps, refactors, test-only, typo fixes) do not need an entry.
 - Versioning (SemVer): stay on `0.x` while the keymap/feature surface is still evolving; only cut `1.0.0` once it has gone several releases without a breaking UX change. A release is a `vX.Y.Z` tag matching `Cargo.toml`, which triggers `.github/workflows/release.yml` to build and attach the platform binaries the README `install.sh` expects.
 
 ## Claude Code compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,66 @@
+# Changelog
+
+All notable changes are summarised here. Each release links to its full,
+auto-generated notes on the [GitHub Releases][releases] page, which remains the
+authoritative source.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+(currently `0.x` while the keymap/feature surface is still evolving).
+
+## [Unreleased]
+
+- Write the redact edit buffer to the system temp dir so leftover files never
+  pollute the working directory.
+- Surface local file-read errors on the status line instead of showing a
+  misleading empty diff.
+- Project metadata, README badges, and this changelog for discoverability.
+
+## [0.7.0] — 2026-06-12
+
+Cursor-based file selection in the gist detail view, preview line-wrap toggle,
+copy gist URL / file content to the clipboard, syntax-highlighted preview and
+diff, and PageUp/PageDown scrolling. Plus a GitHub Pages landing page.
+[Full notes](https://github.com/akunzai/gistui/releases/tag/v0.7.0).
+
+## [0.6.0] — 2026-06-12
+
+Preview file content with number keys in the detail view; HTTPS clone during
+compaction to avoid SSH passphrase prompts.
+[Full notes](https://github.com/akunzai/gistui/releases/tag/v0.6.0).
+
+## [0.5.0] — 2026-06-11
+
+Gist detail view with comments, anchor-driven list ranking with pinned/same-name
+markers, and Windows key-repeat fix.
+[Full notes](https://github.com/akunzai/gistui/releases/tag/v0.5.0).
+
+## [0.4.0] — 2026-06-11
+
+UI refresh, gist revision compaction, quit guard, and pane-oriented Enter diff
+preview.
+[Full notes](https://github.com/akunzai/gistui/releases/tag/v0.4.0).
+
+## [0.3.0] — 2026-06-10
+
+Gist-level manager (edit description, remove a file, sort/filter), create with a
+description, fully async per-action `gh` fetches, edit/redact before upload with
+JSON pretty-print, one-key pinned sync, collapsible diff context, and a
+working-directory path argument.
+[Full notes](https://github.com/akunzai/gistui/releases/tag/v0.3.0).
+
+## [0.2.0] — 2026-06-09
+
+Paginate beyond 100 gists, delete with confirmation, cross-platform release
+binaries, ratatui 0.30 migration, recursive discovery toggle, a pins view, and
+word-level inline diff highlighting.
+[Full notes](https://github.com/akunzai/gistui/releases/tag/v0.2.0).
+
+## [0.1.0] — 2026-06-09
+
+Initial MVP: browse and rank gists against the working directory, coloured diff,
+download/upload/create/pin/preview, filtering and sorting, off-thread loading
+with an on-disk cache, and the overwrite-confirm safety gate.
+[Full notes](https://github.com/akunzai/gistui/releases/tag/v0.1.0).
+
+[releases]: https://github.com/akunzai/gistui/releases

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 license = "MIT"
 description = "A terminal UI for managing GitHub Gists"
 repository = "https://github.com/akunzai/gistui"
+homepage = "https://akunzai.github.io/gistui/"
+keywords = ["tui", "gist", "github", "cli", "terminal"]
+categories = ["command-line-utilities"]
 
 [dependencies]
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -1,10 +1,23 @@
 # gistui
 
+[![CI](https://github.com/akunzai/gistui/actions/workflows/ci.yml/badge.svg)](https://github.com/akunzai/gistui/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
 A terminal UI for managing GitHub Gists. Browse, diff, download, upload, create, edit, and
 pin your gists — and pair them with files in your working directory — all through the
 GitHub CLI (`gh`).
 
-![gistui demo](docs/demo.gif)
+![gistui demo](https://raw.githubusercontent.com/akunzai/gistui/main/docs/demo.gif)
+
+## Why gistui?
+
+- **vs. `gh gist`** — the official CLI is non-interactive and text-only. `gistui` adds a
+  full TUI: visual word-level diffs, anchor-driven ranking of gists against your working
+  directory, and one-key pinned sync.
+- **vs. the web UI** — never leave the terminal, work directly against your local files, and
+  pair gists with the directory you launched from.
+- **Safe by default** — an existing file is never overwritten without first showing the diff
+  and a `y/n` confirmation; no tokens are stored (auth is delegated to `gh`).
 
 ## Requirements
 


### PR DESCRIPTION
## Summary

Low-risk discoverability improvements (no publishing step required), plus a convention to keep the new changelog current.

## Changes

- `Cargo.toml`: `keywords`, `categories`, and `homepage` (points to the project site https://akunzai.github.io/gistui/, distinct from `repository`).
- `README.md`: CI + license badges; demo GIF now an absolute raw URL (renders on crates.io / docs.rs); new "Why gistui?" value-prop section.
- `CHANGELOG.md`: per-release summaries linking to GitHub Releases (authoritative source, no double-maintenance).
- `AGENTS.md`: new convention — user-facing features/bugfixes must add a one-line bullet under `## [Unreleased]` in `CHANGELOG.md` in the same PR (`skip-changelog`/internal changes exempt). Lands with the file it governs.

Note: the README intentionally omits a Website link (it lives in the repo About — see commit d4625aa); the site is surfaced via `homepage` metadata instead. `CLAUDE.md` is a symlink to `AGENTS.md`, so the convention is shared.

## Testing

- [x] `cargo fmt --check`
- [x] `cargo check`
- [x] Markdown links/paths reviewed

## Related Issues

Closes #91