### PR TITLE
fix(tui): bound the in-memory gist preview cache with an LRU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   misleading empty diff.
 - Show a scrollbar on the Diff and Preview panes so position in long diffs and
   large files is visible.
+- Bound the in-memory gist preview cache (LRU, 64 entries) so browsing many or
+  large gists no longer grows memory without limit.
 - Project metadata, README badges, and this changelog for discoverability.
 
 ## [0.7.0] — 2026-06-12

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,6 @@ pub mod diff;
 pub mod domain;
 pub mod gh;
 pub mod local;
+pub mod lru;
 pub mod ranking;
 pub mod tui;

--- a/src/lru.rs
+++ b/src/lru.rs
@@ -1,0 +1,144 @@
+//! A small capacity-bounded LRU cache. Used to cap the in-memory gist content cache so that
+//! previewing many (or large) gists cannot grow memory without bound for the session's
+//! lifetime. Dependency-free: the recency list is a plain `Vec`, so eviction is O(n) in the
+//! capacity — fine because the capacity is small.
+
+use std::collections::HashMap;
+use std::hash::Hash;
+
+/// Least-recently-used cache holding at most `capacity` entries. When an insert would push the
+/// cache past its capacity, the least-recently-used entry is evicted. Both `get` and `insert`
+/// count as a use (they mark the entry most-recently-used).
+#[derive(Debug, Clone)]
+pub struct LruCache<K, V> {
+    map: HashMap<K, V>,
+    /// Keys ordered least- to most-recently used (back = most recent).
+    order: Vec<K>,
+    capacity: usize,
+}
+
+impl<K: Clone + Eq + Hash, V> LruCache<K, V> {
+    /// Create a cache holding at most `capacity` entries. A `capacity` of 0 is clamped to 1 so
+    /// the cache always retains at least the most recent entry.
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            map: HashMap::new(),
+            order: Vec::new(),
+            capacity: capacity.max(1),
+        }
+    }
+
+    /// Number of entries currently held.
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    /// Whether the cache holds no entries.
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    /// Fetch a value, marking it most-recently-used.
+    pub fn get(&mut self, key: &K) -> Option<&V> {
+        if self.map.contains_key(key) {
+            self.touch(key);
+            self.map.get(key)
+        } else {
+            None
+        }
+    }
+
+    /// Insert or replace a value, marking it most-recently-used and evicting the
+    /// least-recently-used entry if that pushes the cache past its capacity.
+    pub fn insert(&mut self, key: K, value: V) {
+        if self.map.insert(key.clone(), value).is_some() {
+            self.touch(&key);
+        } else {
+            self.order.push(key);
+            if self.map.len() > self.capacity {
+                let evicted = self.order.remove(0);
+                self.map.remove(&evicted);
+            }
+        }
+    }
+
+    /// Remove a value, if present, returning it.
+    pub fn remove(&mut self, key: &K) -> Option<V> {
+        if let Some(pos) = self.order.iter().position(|k| k == key) {
+            self.order.remove(pos);
+        }
+        self.map.remove(key)
+    }
+
+    /// Move an existing key to the most-recently-used (back) position.
+    fn touch(&mut self, key: &K) {
+        if let Some(pos) = self.order.iter().position(|k| k == key) {
+            let k = self.order.remove(pos);
+            self.order.push(k);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn evicts_least_recently_used_on_overflow() {
+        let mut cache = LruCache::new(2);
+        cache.insert("a", 1);
+        cache.insert("b", 2);
+        cache.insert("c", 3); // evicts "a" (least recently used)
+
+        assert_eq!(cache.len(), 2);
+        assert_eq!(cache.get(&"a"), None);
+        assert_eq!(cache.get(&"b"), Some(&2));
+        assert_eq!(cache.get(&"c"), Some(&3));
+    }
+
+    #[test]
+    fn get_marks_entry_most_recently_used() {
+        let mut cache = LruCache::new(2);
+        cache.insert("a", 1);
+        cache.insert("b", 2);
+        assert_eq!(cache.get(&"a"), Some(&1)); // "a" is now most recent, "b" is LRU
+        cache.insert("c", 3); // evicts "b", not "a"
+
+        assert_eq!(cache.get(&"a"), Some(&1));
+        assert_eq!(cache.get(&"b"), None);
+        assert_eq!(cache.get(&"c"), Some(&3));
+    }
+
+    #[test]
+    fn reinsert_updates_value_without_growing() {
+        let mut cache = LruCache::new(2);
+        cache.insert("a", 1);
+        cache.insert("a", 9);
+
+        assert_eq!(cache.len(), 1);
+        assert_eq!(cache.get(&"a"), Some(&9));
+    }
+
+    #[test]
+    fn remove_drops_entry_and_frees_a_slot() {
+        let mut cache = LruCache::new(2);
+        cache.insert("a", 1);
+        cache.insert("b", 2);
+        assert_eq!(cache.remove(&"a"), Some(1));
+        assert_eq!(cache.len(), 1);
+
+        cache.insert("c", 3); // fits without evicting "b"
+        assert_eq!(cache.get(&"b"), Some(&2));
+        assert_eq!(cache.get(&"c"), Some(&3));
+    }
+
+    #[test]
+    fn zero_capacity_is_clamped_to_one() {
+        let mut cache = LruCache::new(0);
+        cache.insert("a", 1);
+        cache.insert("b", 2);
+
+        assert_eq!(cache.len(), 1);
+        assert_eq!(cache.get(&"b"), Some(&2));
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -305,7 +305,7 @@ pub struct AppState {
     /// view), taken by the `PreviewContent` IO step; when `None` it falls back to the selected
     /// gist file on the list. Keeps `handle_key` pure: it records the intent, `run_loop` fetches.
     pub preview_request: Option<(String, String)>,
-    pub gist_content_cache: std::collections::HashMap<(String, String), String>,
+    pub gist_content_cache: crate::lru::LruCache<(String, String), String>,
     pub local_recursive: bool,
     pub skip_dirs: Vec<String>,
     pub scan_depth: u32,
@@ -811,7 +811,9 @@ pub fn initial_state() -> AppState {
         preview_gist_key: None,
         preview_return: Screen::List,
         preview_request: None,
-        gist_content_cache: std::collections::HashMap::new(),
+        // Bound the in-memory preview cache so browsing many/large gists can't grow unbounded;
+        // evicted entries are simply re-fetched on demand.
+        gist_content_cache: crate::lru::LruCache::new(64),
         local_recursive: false,
         skip_dirs: crate::config::AppConfig::default().skip_dirs,
         scan_depth: crate::config::AppConfig::default().scan_depth,


### PR DESCRIPTION
## Summary

`AppState.gist_content_cache` was an unbounded `HashMap<(String, String), String>` — every previewed gist file's full content stayed resident for the session, so browsing many or large gists grew memory without limit (#96).

## Changes

- New `src/lru.rs`: a small, dependency-free generic `LruCache` (pure module, unit-tested).
- `AppState.gist_content_cache` is now `LruCache<…>` capped at 64 entries; evicted entries are re-fetched on demand.
- Existing invalidation-on-upload / `R`-refresh (`remove`) behaviour is preserved, so stale content is never served.

Dependency-free per the issue (no `lru` crate); eviction is O(n) in the small capacity.

## Testing

- [x] `cargo fmt --check`
- [x] `cargo test` (5 new LRU unit tests: eviction, recency on get, reinsert, remove, zero-capacity clamp)
- [x] `cargo check`
- [x] `cargo clippy --all-targets -- -D warnings`

## Related Issues

Closes #96