### PR TITLE
docs(site): add a 'Why gistui?' section to the landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -167,6 +167,27 @@
   </div>
 </section>
 
+<section id="why">
+  <div class="wrap">
+    <h2>Why gistui?</h2>
+    <p class="sub">A real workflow around your Gists — not just another API wrapper.</p>
+    <div class="grid">
+      <div class="card">
+        <h3>vs. <code>gh gist</code></h3>
+        <p>The official CLI is non-interactive and text-only. gistui adds a full TUI: visual word-level diffs, anchor-driven ranking of gists against your working directory, and one-key pinned sync.</p>
+      </div>
+      <div class="card">
+        <h3>vs. the web UI</h3>
+        <p>Never leave the terminal. Work directly against your local files and pair gists with the directory you launched from — no browser tabs, no copy-paste round trips.</p>
+      </div>
+      <div class="card">
+        <h3>Safe &amp; private</h3>
+        <p>An existing file is never overwritten without a diff and a <kbd>y</kbd>/<kbd>n</kbd> confirm, and no GitHub token is ever stored — authentication is delegated to <code>gh</code>.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
 <section id="features">
   <div class="wrap">
     <h2>What it does</h2>


### PR DESCRIPTION
## Summary

The README gained a "Why gistui?" value-prop section (#91/#92), but the GitHub Pages landing page (`docs/index.html`) only covered the features ("What it does"), not the positioning. This mirrors the README so the site and README stay in lockstep on messaging.

## Changes

- New `#why` section in `docs/index.html`, inserted between the demo and "What it does": three cards — **vs `gh gist`**, **vs the web UI**, and **Safe & private** — reusing the existing `.grid`/`.card` styles.

## Notes

- Landing page is served from `main` `/docs` (legacy Pages), so this goes live on merge.
- Marketing/docs only; no changelog entry (per the `## [Unreleased]` convention, exempt).

## Related

Follows #92 (README "Why gistui?").