### PR TITLE
docs: document Homebrew install (akunzai/tap)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   large files is visible.
 - Bound the in-memory gist preview cache (LRU, 64 entries) so browsing many or
   large gists no longer grows memory without limit.
+- Install via Homebrew: `brew install akunzai/tap/gistui` (new `akunzai/homebrew-tap` tap).
 - Project metadata, README badges, and this changelog for discoverability.
 
 ## [0.7.0] — 2026-06-12

--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ be installed and authenticated wherever you run `gistui`.
 
 ## Installation
 
+### Homebrew (macOS / Linux)
+
+```bash
+brew install akunzai/tap/gistui
+```
+
+This installs `gistui` (and its `gh` dependency) from the
+[`akunzai/homebrew-tap`](https://github.com/akunzai/homebrew-tap) tap. The fully-qualified
+name trusts only this formula — Homebrew 6.0.0+ requires non-official taps to be trusted
+before their code runs; see the tap README for the `brew tap` + short-name flow and the
+`Brewfile` `trusted:` option.
+
 ### Download a prebuilt binary (recommended)
 
 Each [release](https://github.com/akunzai/gistui/releases/latest) attaches prebuilt,

--- a/docs/index.html
+++ b/docs/index.html
@@ -154,6 +154,7 @@
         <pre><span class="prompt">$ </span><span class="cmd">curl -fsSL https://raw.githubusercontent.com/akunzai/gistui/main/install.sh | bash</span></pre>
       </div>
       <p class="hint">Detects your platform, verifies the SHA-256 checksum, installs to <code>~/.local/bin</code>. Linux · macOS · Windows (Git Bash).</p>
+      <p class="hint">On macOS / Linux with <a href="https://brew.sh">Homebrew</a>: <code>brew install akunzai/tap/gistui</code></p>
     </div>
   </div>
 </header>


### PR DESCRIPTION
## Summary

`gistui` is now installable via Homebrew from the new [`akunzai/homebrew-tap`](https://github.com/akunzai/homebrew-tap):

```bash
brew install akunzai/tap/gistui
```

## Changes

- **README**: new "Homebrew (macOS / Linux)" install section. Notes that the fully-qualified name trusts only this formula (Homebrew 6.0.0+ tap trust) and links the tap README for the `brew tap` + short-name flow.
- **Landing page** (`docs/index.html`): a Homebrew line in the hero install block.
- **CHANGELOG**: an `## [Unreleased]` entry for the new install channel.

## Related

Refs #93 (distribution channels). The personal Homebrew tap is now live, trusted locally, and documented; crates.io publish and a possible homebrew-core formula remain open there.