### PR TITLE
chore: make the crate publishable and automate crates.io publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,45 @@
+name: Publish to crates.io
+
+# Publishes the crate when a vX.Y.Z tag is pushed (the same tags that drive
+# release.yml). No-ops gracefully until the CARGO_REGISTRY_TOKEN secret is set, so
+# tagging a release never fails CI before crates.io is wired up. Can also be run
+# manually for the very first publish via the Actions tab (workflow_dispatch).
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: cargo publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Verify tag matches Cargo.toml version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          crate="$(cargo metadata --no-deps --format-version 1 | grep -o '"version":"[^"]*"' | head -1 | cut -d'"' -f4)"
+          if [ "$tag" != "$crate" ]; then
+            echo "::error::Tag v$tag does not match Cargo.toml version $crate"
+            exit 1
+          fi
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          if [ -z "${CARGO_REGISTRY_TOKEN:-}" ]; then
+            echo "::notice::CARGO_REGISTRY_TOKEN not set — skipping crates.io publish."
+            exit 0
+          fi
+          cargo publish

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,36 @@ Key points:
 3. Open a PR against `main`; the CI gate must be green.
 4. **Label the PR** so it lands in the right release-note section (`.github/release.yml`): `enhancement` (Features), `bug` (Bug Fixes), `documentation` (Documentation), `dependencies`, or `skip-changelog` to omit it. Unlabeled PRs fall under "Other Changes".
 
+## Releasing & publishing to crates.io
+
+The crate is packaging-ready (`cargo publish --dry-run` passes; `Cargo.toml` `exclude`
+keeps the demo harness, site assets and CI config out of the published tarball). Publishing
+is automated by `.github/workflows/publish.yml`, which runs on each `vX.Y.Z` tag and no-ops
+until the registry token is set.
+
+**One-time crates.io setup** (owner):
+
+- [ ] Create a [crates.io](https://crates.io) account (sign in with GitHub) and verify your email.
+- [ ] Generate a scoped API token (Account Settings → API Tokens) with `publish-new` + `publish-update`, scoped to the `gistui` crate once it exists.
+- [ ] Add it as a repository secret named `CARGO_REGISTRY_TOKEN` (Settings → Secrets and variables → Actions).
+
+**First publish:**
+
+- [ ] Confirm `Cargo.toml` `version` is correct and `cargo publish --dry-run` is clean.
+- [ ] Either push the matching tag (`git tag vX.Y.Z && git push origin vX.Y.Z`) — `publish.yml` then publishes — or run the **Publish to crates.io** workflow manually (Actions tab → Run workflow), or publish locally with `cargo publish`.
+- [ ] Verify the crate at `https://crates.io/crates/gistui` and that docs.rs built.
+
+**Post-publish docs** (add once the crate is live):
+
+- [ ] Add a crates.io badge under the README title:
+  ```markdown
+  [![crates.io](https://img.shields.io/crates/v/gistui.svg)](https://crates.io/crates/gistui)
+  ```
+- [ ] Add a `cargo install gistui` option to the README install section.
+- [ ] Add `[package.metadata.binstall]` and verify `cargo binstall --dry-run gistui` (see issue #93).
+
+**Ongoing:** each release is a `vX.Y.Z` tag matching `Cargo.toml`; the tag triggers both the binary release (`release.yml`) and the crates.io publish (`publish.yml`). Remember to bump the [Homebrew tap](https://github.com/akunzai/homebrew-tap) formula too.
+
 ## Reporting Issues
 
 Use the [bug report](.github/ISSUE_TEMPLATE/bug_report.yml) or [feature request](.github/ISSUE_TEMPLATE/feature_request.yml) templates.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,17 @@ repository = "https://github.com/akunzai/gistui"
 homepage = "https://akunzai.github.io/gistui/"
 keywords = ["tui", "gist", "github", "cli", "terminal"]
 categories = ["command-line-utilities"]
+# Keep the published crate lean: ship the source, docs and license but not the
+# demo harness, site assets, CI config or install script. The README's demo GIF is
+# referenced by absolute URL, so it still renders on crates.io without shipping it.
+exclude = [
+    "/.github",
+    "/docs",
+    "/scripts",
+    "/install.sh",
+    "/CLAUDE.md",
+    "/.gitignore",
+]
 
 [dependencies]
 anyhow = "1"


### PR DESCRIPTION
## Summary

Prepares gistui for its first crates.io release. The actual account/token/publish is left to the owner — see the checklist below.

## Changes

- **`Cargo.toml`**: `exclude` the demo harness, `docs/` site assets (incl. the 708 KB images), `.github/`, `install.sh` and the `CLAUDE.md` symlink. `cargo publish --dry-run` now packages **30 files (~102 KiB compressed)** and builds cleanly.
- **`.github/workflows/publish.yml`**: publishes on each `vX.Y.Z` tag. Gated on a `CARGO_REGISTRY_TOKEN` secret, so it **no-ops (never fails CI)** until the registry is wired up; also runnable via `workflow_dispatch` for the first publish. Verifies the tag matches `Cargo.toml`. No untrusted input in `run:` blocks.
- **`CONTRIBUTING.md`**: a "Releasing & publishing to crates.io" checklist.

## Owner checklist (registration / token — your part)

**One-time setup**
- [x] Create a crates.io account (GitHub sign-in) + verify email.
- [x] Generate a scoped API token (`publish-new` + `publish-update`).
- [x] Add it as repo secret `CARGO_REGISTRY_TOKEN`.

**First publish**
- [x] `cargo publish --dry-run` clean (already verified here).
- [x] Push the `vX.Y.Z` tag (auto-publishes) **or** run the workflow manually **or** `cargo publish` locally.
- [x] Verify `crates.io/crates/gistui` + docs.rs build.

**Post-publish docs follow-up** (snippets in CONTRIBUTING.md)
- [x] crates.io version badge in README.
- [x] `cargo install gistui` in the README install section.
- [ ] `[package.metadata.binstall]` + verify `cargo binstall --dry-run`.

## Related

Refs #93.