### PR TITLE
feat: document crates.io install and add cargo-binstall metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Install from crates.io: `cargo install gistui`, or `cargo binstall gistui` for the
+  prebuilt release binaries.
+
 ## [0.8.0] — 2026-06-14
 
 - Scrollbars on the Diff and Preview panes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,12 +69,12 @@ until the registry token is set.
 
 **Post-publish docs** (add once the crate is live):
 
-- [ ] Add a crates.io badge under the README title:
+- [x] Add a crates.io badge under the README title:
   ```markdown
   [![crates.io](https://img.shields.io/crates/v/gistui.svg)](https://crates.io/crates/gistui)
   ```
-- [ ] Add a `cargo install gistui` option to the README install section.
-- [ ] Add `[package.metadata.binstall]` and verify `cargo binstall --dry-run gistui` (see issue #93).
+- [x] Add a `cargo install gistui` option to the README install section.
+- [x] Add `[package.metadata.binstall]` and verify `cargo binstall --dry-run gistui` (see issue #93).
 
 **Ongoing:** each release is a `vX.Y.Z` tag matching `Cargo.toml`; the tag triggers both the binary release (`release.yml`) and the crates.io publish (`publish.yml`). Remember to bump the [Homebrew tap](https://github.com/akunzai/homebrew-tap) formula too.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,14 @@ exclude = [
     "/.gitignore",
 ]
 
+# Let `cargo binstall gistui` reuse the GitHub Release assets built by release.yml
+# (`gistui-vX.Y.Z-<target>.tar.gz`, `.zip` on Windows; each archive holds a
+# `gistui-vX.Y.Z-<target>/` dir with the binary). Takes effect from the next
+# published version onward.
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/gistui-v{ version }-{ target }{ archive-suffix }"
+bin-dir = "gistui-v{ version }-{ target }/{ bin }{ binary-ext }"
+
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # gistui
 
 [![CI](https://github.com/akunzai/gistui/actions/workflows/ci.yml/badge.svg)](https://github.com/akunzai/gistui/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/gistui.svg)](https://crates.io/crates/gistui)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 A terminal UI for managing GitHub Gists. Browse, diff, download, upload, create, edit, and
@@ -76,6 +77,22 @@ Then extract it and put `gistui` somewhere on your `PATH`, e.g. on macOS/Linux:
 ```bash
 tar -xzf gistui-<version>-<target>.tar.gz
 install -m 755 gistui-<version>-<target>/gistui ~/.local/bin/gistui
+```
+
+### crates.io
+
+With a Rust toolchain, install the published crate from
+[crates.io](https://crates.io/crates/gistui):
+
+```bash
+cargo install gistui
+```
+
+Or grab the same checksummed release binaries without compiling, via
+[`cargo binstall`](https://github.com/cargo-bins/cargo-binstall):
+
+```bash
+cargo binstall gistui
 ```
 
 ### Build from source

--- a/docs/index.html
+++ b/docs/index.html
@@ -155,6 +155,7 @@
       </div>
       <p class="hint">Detects your platform, verifies the SHA-256 checksum, installs to <code>~/.local/bin</code>. Linux · macOS · Windows (Git Bash).</p>
       <p class="hint">On macOS / Linux with <a href="https://brew.sh">Homebrew</a>: <code>brew install akunzai/tap/gistui</code></p>
+      <p class="hint">With a Rust toolchain from <a href="https://crates.io/crates/gistui">crates.io</a>: <code>cargo install gistui</code></p>
     </div>
   </div>
 </header>


### PR DESCRIPTION
## Summary

Follow-up to #100, now that `gistui` is published on [crates.io](https://crates.io/crates/gistui). Completes the **Post-publish docs** checklist from that PR / CONTRIBUTING.md.

## Changes

- **README**: crates.io version badge under the title; new **crates.io** install section with `cargo install gistui` and `cargo binstall gistui`.
- **`Cargo.toml`**: `[package.metadata.binstall]` so `cargo binstall gistui` reuses the GitHub Release assets built by `release.yml` (`gistui-vX.Y.Z-<target>.{tar.gz,zip}`, each holding a `gistui-vX.Y.Z-<target>/` dir). Snippet per #93.
- **`docs/index.html`**: `cargo install gistui` hint on the landing page.
- **`CONTRIBUTING.md`**: tick the three post-publish boxes.
- **`CHANGELOG.md`**: Unreleased bullet for the new install methods.

## Verification

- Gate green: `cargo fmt --check`, `cargo test` (12 passed), `cargo check`, `cargo clippy --all-targets -- -D warnings`.
- `cargo metadata` confirms the `binstall` table parses.
- **Not runtime-verified:** `cargo-binstall` isn't installed locally, and `cargo binstall --dry-run gistui` would read the already-published `0.8.0` (which lacks this metadata). The metadata only takes effect from the **next** published version (`v0.8.1`+); worth a `cargo binstall --dry-run gistui` check after the next release.

## Related

Refs #93. Follow-up to #100.