### PR TITLE
feat(ui): animate the in-progress spinner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Animated spinner on the scanning, loading and working states (replaces the static `⏳`),
+  so long-running `gh` operations no longer look frozen.
 - Install from crates.io: `cargo install gistui`, or `cargo binstall gistui` for the
   prebuilt release binaries.
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -341,6 +341,9 @@ pub struct AppState {
     pub detail_file_cursor: usize,
     /// Screen to return to after a compaction confirm is cancelled/finished (Gists or GistDetail).
     pub compact_return_screen: Screen,
+    /// Monotonic tick advanced once per event-loop iteration (~150ms); drives the in-progress
+    /// spinner animation. Wraps freely — only its value modulo the frame count is observed.
+    pub spinner_frame: usize,
 }
 
 fn unranked_gists(gists: Vec<GistFile>) -> Vec<RankedGistFile> {
@@ -837,6 +840,7 @@ pub fn initial_state() -> AppState {
         detail_focus: DetailFocus::Comments,
         detail_file_cursor: 0,
         compact_return_screen: Screen::Gists,
+        spinner_frame: 0,
     }
 }
 

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -23,7 +23,7 @@ pub(super) fn render(frame: &mut Frame, state: &AppState) {
         Screen::GistDetail => render_gist_detail(frame, state),
     }
     if let Some(ref msg) = state.bg_task_msg {
-        render_loading_overlay(frame, msg);
+        render_loading_overlay(frame, msg, state.spinner_frame);
     }
 }
 
@@ -863,7 +863,11 @@ pub(super) fn render_list(frame: &mut Frame, state: &AppState) {
     // Show each candidate's path relative to cwd; in flat mode this is just the filename,
     // in recursive mode it includes the subdirectory (e.g. src/utils/helpers.rs).
     let local_items: Vec<ListItem> = if state.local_scanning && state.locals.is_empty() {
-        vec![ListItem::new("  ⏳ Scanning files…").style(Style::default().fg(Color::DarkGray))]
+        vec![ListItem::new(format!(
+            "  {} Scanning files…",
+            spinner_glyph(state.spinner_frame)
+        ))
+        .style(Style::default().fg(Color::DarkGray))]
     } else if state.locals.is_empty() {
         vec![ListItem::new("  📭 No local files found").style(Style::default().fg(Color::DarkGray))]
     } else {
@@ -904,7 +908,11 @@ pub(super) fn render_list(frame: &mut Frame, state: &AppState) {
 
     let ranked = state.ranked_gists();
     let gist_items: Vec<ListItem> = if state.loading && ranked.is_empty() {
-        vec![ListItem::new("  ⏳ Loading gists…").style(Style::default().fg(Color::DarkGray))]
+        vec![ListItem::new(format!(
+            "  {} Loading gists…",
+            spinner_glyph(state.spinner_frame)
+        ))
+        .style(Style::default().fg(Color::DarkGray))]
     } else if ranked.is_empty() {
         let message = if !state.filter_query.is_empty() {
             ListItem::new("  🔍 No gists match the filter")
@@ -1487,9 +1495,21 @@ pub(super) fn render_centered_modal(frame: &mut Frame, title: &str, body: &str, 
     );
 }
 
+/// Frames for the in-progress spinner, advanced by `AppState::spinner_frame` (one step per
+/// event-loop tick, ~150ms). Braille dots are as widely supported as the emoji already used
+/// across the UI (📭/🔍/⏳), so no ASCII fallback is added here.
+const SPINNER_FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/// The spinner glyph for the given tick. `frame` may be any value; it is reduced modulo the
+/// frame count.
+pub(super) fn spinner_glyph(frame: usize) -> &'static str {
+    SPINNER_FRAMES[frame % SPINNER_FRAMES.len()]
+}
+
 /// A centered "Working…" box shown while a blocking `gh` action runs.
-pub(super) fn render_loading_overlay(frame: &mut Frame, msg: &str) {
-    render_centered_modal(frame, "Working…", &format!("⏳ {msg}"), Color::Cyan);
+pub(super) fn render_loading_overlay(frame: &mut Frame, msg: &str, spinner_frame: usize) {
+    let body = format!("{} {msg}", spinner_glyph(spinner_frame));
+    render_centered_modal(frame, "Working…", &body, Color::Cyan);
 }
 
 /// Civil date (year, month, day) from a day count since the Unix epoch — Howard Hinnant's

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -11,6 +11,9 @@ pub(super) fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) ->
 
     loop {
         terminal.draw(|frame| render(frame, &state))?;
+        // Advance the spinner once per iteration; the poll below caps the loop at ~150ms, so
+        // in-progress states (scanning/loading/working) animate even with no input.
+        state.spinner_frame = state.spinner_frame.wrapping_add(1);
 
         // Absorb the background gist list once it arrives.
         if state.loading {

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -384,6 +384,17 @@ fn detail_footer_is_focus_aware() {
 }
 
 #[test]
+fn spinner_glyph_cycles_through_frames_and_wraps() {
+    // Adjacent ticks advance the frame; the cycle wraps after a full revolution.
+    assert_ne!(spinner_glyph(0), spinner_glyph(1));
+    assert_eq!(spinner_glyph(0), spinner_glyph(10));
+    assert_eq!(spinner_glyph(3), spinner_glyph(13));
+    // Every position in one revolution yields a distinct glyph.
+    let frames: std::collections::HashSet<_> = (0..10).map(spinner_glyph).collect();
+    assert_eq!(frames.len(), 10);
+}
+
+#[test]
 fn context_gist_id_uses_detail_id_on_detail_screen() {
     let mut state = state_with_gists();
     state.screen = Screen::GistDetail;


### PR DESCRIPTION
First 0.9.0 UI-polish item.

## Changes (closes #105)
Replace the static `⏳` on the **scanning**, **loading** and **working** states with a braille spinner (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`) so long-running `gh` operations no longer look frozen.

- `AppState::spinner_frame` — a monotonic tick advanced once per event-loop iteration in `run_loop`. The existing `event::poll(150ms)` already redraws on every tick, so the animation needed **no event-loop restructuring**.
- `spinner_glyph(frame)` — a pure helper (reduces `frame` mod the frame count); used by the two list placeholders and the `render_loading_overlay` modal.

## Verification
`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo check`, `cargo test` all green — 258 tests incl. a new `spinner_glyph_cycles_through_frames_and_wraps`.

## Docs
- CHANGELOG `[Unreleased]` bullet added (`enhancement`).
- No keymap/screen change, so no README/`?`-help updates.
- **Demo GIF not regenerated:** the spinner is a transient loading animation the scripted storyboard doesn't pause on, so re-recording would only add nondeterministic binary churn. Happy to regenerate if you'd prefer.