### PR TITLE
feat(ui): gist-detail focus indicator + item counts in titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   active, `(N)` otherwise), matching the existing `Files (N)` / `Comments (N)` style.
 - Gist detail view is now tabbed — a `Files │ Comments` strip under the basic info shows one
   pane at a time (opens on the Files tab; `Tab` switches), instead of stacking both panes.
+- Scrollbar on the gist-detail comments pane (the Diff and Preview panes already had one).
 - Animated spinner on the scanning, loading and working states (replaces the static `⏳`),
   so long-running `gh` operations no longer look frozen.
 - Install from crates.io: `cargo install gistui`, or `cargo binstall gistui` for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Item counts in the Local, Gists and Pins titles (e.g. `Gists (3/12)` when a filter is
   active, `(N)` otherwise), matching the existing `Files (N)` / `Comments (N)` style.
-- Gist detail view shows a `Comments | Files` focus tab strip, so the pane `Tab` drives is
-  visible at a glance instead of only hinted in the footer.
+- Gist detail view is now tabbed — a `Files │ Comments` strip under the basic info shows one
+  pane at a time (opens on the Files tab; `Tab` switches), instead of stacking both panes.
 - Animated spinner on the scanning, loading and working states (replaces the static `⏳`),
   so long-running `gh` operations no longer look frozen.
 - Install from crates.io: `cargo install gistui`, or `cargo binstall gistui` for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Gist detail view shows a `Comments | Files` focus tab strip, so the pane `Tab` drives is
+  visible at a glance instead of only hinted in the footer.
 - Animated spinner on the scanning, loading and working states (replaces the static `⏳`),
   so long-running `gh` operations no longer look frozen.
 - Install from crates.io: `cargo install gistui`, or `cargo binstall gistui` for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Item counts in the Local, Gists and Pins titles (e.g. `Gists (3/12)` when a filter is
+  active, `(N)` otherwise), matching the existing `Files (N)` / `Comments (N)` style.
 - Gist detail view shows a `Comments | Files` focus tab strip, so the pane `Tab` drives is
   visible at a glance instead of only hinted in the footer.
 - Animated spinner on the scanning, loading and working states (replaces the static `⏳`),

--- a/README.md
+++ b/README.md
@@ -208,12 +208,13 @@ Press `g` to open the **gist manager** — a gist-level view (one row per gist) 
 the gist owning the currently selected file. From here you manage gists as a whole:
 
 - `e` — edit the gist's description (type, `Enter` applies, `Esc` cancels).
-- `Enter` — open the **gist detail view**: shows basic info (description, visibility,
-  created/updated age, file count, short id), the file list, and fetched comments.
-  - `Tab` switch focus between the comments pane and the file list.
-  - `↑`/`↓` scroll comments, or move the file cursor when the list is focused · `PageUp`/`PageDown`
+- `Enter` — open the **gist detail view**: a header with basic info (description, visibility,
+  created/updated age, short id) and a `Files │ Comments` tab strip, with the active tab's
+  content below. Opens on the **Files** tab.
+  - `Tab` switch tab between the file list and the comments (only one shows at a time).
+  - `↑`/`↓` move the file cursor (Files tab) or scroll comments (Comments tab) · `PageUp`/`PageDown`
     page either by 10.
-  - `Enter` (file list focused) preview the cursor-selected file — this reaches **any** file,
+  - `Enter` (Files tab) preview the cursor-selected file — this reaches **any** file,
     including the 10th and beyond.
   - `1`–`9` still preview the content of the Nth file directly, full-screen (`↑↓←→` scroll,
     `R` refresh, `w` wrap, `q`/`Esc` back).

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -28,8 +28,9 @@ pub enum Screen {
     GistDetail,
 }
 
-/// Which pane the navigation keys drive in `Screen::GistDetail`. Default `Comments`
-/// preserves the pre-#67 up/down = comment-scroll behavior until the user presses Tab.
+/// Which tab `Screen::GistDetail` shows, and which the navigation keys drive: the file list
+/// or the comments (only one is visible at a time). Defaults to `Files` — the gist's primary
+/// content — with the comments one `Tab` away.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DetailFocus {
     Comments,
@@ -837,7 +838,7 @@ pub fn initial_state() -> AppState {
         detail_comments: None,
         detail_comments_error: None,
         detail_scroll: 0,
-        detail_focus: DetailFocus::Comments,
+        detail_focus: DetailFocus::Files,
         detail_file_cursor: 0,
         compact_return_screen: Screen::Gists,
         spinner_frame: 0,

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -464,27 +464,28 @@ pub(super) fn render_gist_info_and_files(
         format!("Gist: {}", group.description)
     };
     let files = state.gist_filenames(gist_id);
-    let files_focused =
-        state.detail_focus == DetailFocus::Files && state.screen == Screen::GistDetail;
-    let files_title = if files_focused {
-        format!("Files ({})  [focus: ↑↓ select · ⏎ preview]", files.len())
-    } else {
-        format!("Files ({})", files.len())
-    };
-    let mut lines: Vec<Line> = vec![
-        Line::from(gist_info_line(&group, now)),
-        Line::from(""),
-        Line::from(Span::styled(
-            files_title,
-            Style::default().add_modifier(Modifier::BOLD),
-        )),
-    ];
+    let on_detail = state.screen == Screen::GistDetail;
+    let files_focused = state.detail_focus == DetailFocus::Files && on_detail;
+    // On the detail screen a Comments|Files focus strip sits just under the basic info; the
+    // compaction-confirm background reuses this fn without it. The old "[focus: …]" suffix on
+    // the file count is dropped — the strip plus the footer already carry that hint.
+    let mut lines: Vec<Line> = vec![Line::from(gist_info_line(&group, now))];
+    if on_detail {
+        lines.push(detail_focus_tabs_line(state.detail_focus));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        format!("Files ({})", files.len()),
+        Style::default().add_modifier(Modifier::BOLD),
+    )));
     // Number the first nine files so the detail view's 1–9 preview keys are discoverable;
     // any beyond the ninth are bullet-aligned. When the file list is focused, a cursor row
     // is highlighted and the list auto-scrolls to keep it visible.
     let cursor = state.detail_file_cursor.min(files.len().saturating_sub(1));
-    // Visible file rows = area height minus borders(2), info line, blank, "Files (n)" header (3).
-    let visible_rows = (area.height as usize).saturating_sub(5);
+    // Header rows above the file list: info line + (focus strip on the detail screen) + blank
+    // + "Files (n)" header, plus the box borders(2).
+    let header_rows = if on_detail { 4 } else { 3 };
+    let visible_rows = (area.height as usize).saturating_sub(2 + header_rows);
     let offset = file_list_scroll(cursor, visible_rows, files.len());
     for (i, f) in files
         .iter()
@@ -599,6 +600,40 @@ pub(super) fn detail_footer(status: Option<&str>, focus: DetailFocus) -> (String
     footer_with_status(status, hints)
 }
 
+/// The Comments|Files focus index, mirroring `detail_focus`. Pure so the tab selection is
+/// trivially testable and stays in sync with the navigation handler.
+pub(super) fn detail_focus_tab(focus: DetailFocus) -> usize {
+    match focus {
+        DetailFocus::Comments => 0,
+        DetailFocus::Files => 1,
+    }
+}
+
+/// A `Comments │ Files` focus indicator line, with the pane Tab currently drives highlighted.
+/// Rendered just under the gist's basic info (inside the info box) rather than as a floating
+/// strip, so the active focus is visible without a disconnected top row.
+pub(super) fn detail_focus_tabs_line(focus: DetailFocus) -> Line<'static> {
+    let active = detail_focus_tab(focus);
+    let active_style = Style::default()
+        .fg(Color::Black)
+        .bg(Color::Cyan)
+        .add_modifier(Modifier::BOLD);
+    let idle_style = Style::default().fg(Color::DarkGray);
+    let mut spans = Vec::new();
+    for (i, label) in ["Comments", "Files"].iter().enumerate() {
+        if i > 0 {
+            spans.push(Span::styled(" │ ", idle_style));
+        }
+        let style = if i == active {
+            active_style
+        } else {
+            idle_style
+        };
+        spans.push(Span::styled(format!(" {label} "), style));
+    }
+    Line::from(spans)
+}
+
 pub(super) fn render_gist_detail(frame: &mut Frame, state: &AppState) {
     let area = frame.area();
     let (footer, colored) = detail_footer(state.status.as_deref(), state.detail_focus);
@@ -608,10 +643,11 @@ pub(super) fn render_gist_detail(frame: &mut Frame, state: &AppState) {
         .as_deref()
         .map(|id| state.gist_filenames(id).len())
         .unwrap_or(0);
-    // Scale to the file count, but never exceed half the screen nor drop below 5 rows.
+    // Scale to the file count, but never exceed half the screen nor drop below 6 rows
+    // (borders + info line + focus strip + blank + "Files (n)" header).
     let info_height = (files as u16)
-        .saturating_add(5)
-        .clamp(5, (area.height / 2).max(5));
+        .saturating_add(6)
+        .clamp(6, (area.height / 2).max(6));
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -27,6 +27,17 @@ pub(super) fn render(frame: &mut Frame, state: &AppState) {
     }
 }
 
+/// A count suffix for a list title: `(N)` normally, or `(shown/total)` when a filter has
+/// narrowed the list (`shown < total`). Extends the existing `Files (N)` / `Comments (N)`
+/// convention to the other panes consistently.
+pub(super) fn count_label(shown: usize, total: usize) -> String {
+    if shown < total {
+        format!("({shown}/{total})")
+    } else {
+        format!("({total})")
+    }
+}
+
 pub(super) fn render_help(frame: &mut Frame, state: &AppState) {
     // The repo URL and version live in the footer on every screen, so help is keys only.
     let body = "\
@@ -282,7 +293,10 @@ pub(super) fn render_pins(frame: &mut Frame, state: &AppState) {
     let list = List::new(items)
         .block(
             Block::default()
-                .title("Pinned Mappings")
+                .title(format!(
+                    "Pinned Mappings {}",
+                    count_label(state.pinned.len(), state.pinned.len())
+                ))
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
                 .border_style(Style::default().fg(Color::Cyan))
@@ -373,7 +387,8 @@ pub(super) fn render_gists(frame: &mut Frame, state: &AppState) {
 
     let selected = (!groups.is_empty()).then_some(state.gists_index);
     let mut title = format!(
-        "Gists  ·  sort:{}  ·  type:{}",
+        "Gists {}  ·  sort:{}  ·  type:{}",
+        count_label(groups.len(), state.gist_groups().len()),
         state.gists_sort.label(),
         state.gists_type_filter.label()
     );
@@ -921,7 +936,8 @@ pub(super) fn render_list(frame: &mut Frame, state: &AppState) {
     let recursive_marker = if state.local_recursive { " [↓]" } else { "" };
     let scanning_marker = if state.local_scanning { " …" } else { "" };
     let local_title = format!(
-        "[1] Local · {}{}{} · sort:{}",
+        "[1] Local {} · {}{}{} · sort:{}",
+        count_label(state.locals.len(), state.locals.len()),
         crate::config::display_path(&state.cwd),
         recursive_marker,
         scanning_marker,
@@ -969,7 +985,8 @@ pub(super) fn render_list(frame: &mut Frame, state: &AppState) {
     let gist_focused = state.focus == FocusPane::Gist;
     let gist_selected = (!ranked.is_empty()).then_some(state.gist_index);
     let mut gist_title = format!(
-        "[2] Gists · {} · {}",
+        "[2] Gists {} · {} · {}",
+        count_label(ranked.len(), state.gists.len()),
         state.gist_type_filter.label(),
         state.gist_sort.label()
     );

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -631,6 +631,9 @@ pub(super) fn render_gist_comments(frame: &mut Frame, area: Rect, state: &AppSta
         Some(c) if state.detail_comments_error.is_none() => format!("Comments ({})", c.len()),
         _ => "Comments".to_string(),
     };
+    // The scrollbar uses the logical line count, which shares units with `detail_scroll`, so the
+    // thumb position is exact (its size is approximate when long comments soft-wrap).
+    let total_lines = body.len();
     frame.render_widget(
         Paragraph::new(body)
             .scroll((state.detail_scroll, 0))
@@ -644,6 +647,7 @@ pub(super) fn render_gist_comments(frame: &mut Frame, area: Rect, state: &AppSta
             ),
         area,
     );
+    render_text_scrollbar(frame, area, total_lines, state.detail_scroll as usize);
 }
 
 /// Footer text + whether to colourise it: a one-shot `state.status` message (shown plain) when

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -123,8 +123,8 @@ Gist manager (g)
   q / Esc    back to the list
 
 Gist detail (Enter from gist manager)
-  Tab        switch focus between comments and the file list
-  Up/Down    scroll comments, or move the file cursor when the list is focused
+  Tab        switch tab: Files / Comments (one shows at a time; opens on Files)
+  Up/Down    move the file cursor (Files tab) or scroll comments (Comments tab)
   PageUp/Dn  page comments / file cursor by 10
   Enter      preview the cursor-selected file (file list focused)
   1-9        preview the content of the Nth file (full-screen; R refresh, q back)
@@ -463,45 +463,18 @@ pub(super) fn file_list_scroll(cursor: usize, visible_rows: usize, count: usize)
     (cursor + 1).saturating_sub(visible_rows)
 }
 
-pub(super) fn render_gist_info_and_files(
-    frame: &mut Frame,
-    area: Rect,
-    state: &AppState,
-    gist_id: &str,
-) {
-    let Some(group) = state.group_by_id(gist_id) else {
-        return;
-    };
-    let now = unix_now();
-    let title = if group.description.trim().is_empty() {
-        format!("Gist {}", group.id)
-    } else {
-        format!("Gist: {}", group.description)
-    };
-    let files = state.gist_filenames(gist_id);
-    let on_detail = state.screen == Screen::GistDetail;
-    let files_focused = state.detail_focus == DetailFocus::Files && on_detail;
-    // On the detail screen a Comments|Files focus strip sits just under the basic info; the
-    // compaction-confirm background reuses this fn without it. The old "[focus: …]" suffix on
-    // the file count is dropped — the strip plus the footer already carry that hint.
-    let mut lines: Vec<Line> = vec![Line::from(gist_info_line(&group, now))];
-    if on_detail {
-        lines.push(detail_focus_tabs_line(state.detail_focus));
-    }
-    lines.push(Line::from(""));
-    lines.push(Line::from(Span::styled(
-        format!("Files ({})", files.len()),
-        Style::default().add_modifier(Modifier::BOLD),
-    )));
-    // Number the first nine files so the detail view's 1–9 preview keys are discoverable;
-    // any beyond the ninth are bullet-aligned. When the file list is focused, a cursor row
-    // is highlighted and the list auto-scrolls to keep it visible.
-    let cursor = state.detail_file_cursor.min(files.len().saturating_sub(1));
-    // Header rows above the file list: info line + (focus strip on the detail screen) + blank
-    // + "Files (n)" header, plus the box borders(2).
-    let header_rows = if on_detail { 4 } else { 3 };
-    let visible_rows = (area.height as usize).saturating_sub(2 + header_rows);
-    let offset = file_list_scroll(cursor, visible_rows, files.len());
+/// Build the numbered file rows for the gist's file list (detail Files tab and the
+/// compaction-confirm background). The first nine files are numbered to match the 1–9 preview
+/// keys; the rest are bulleted. With `highlight_cursor`, the `cursor` row is reverse-styled.
+/// Windows to `visible_rows` rows starting at `offset`.
+fn file_rows(
+    files: &[String],
+    cursor: usize,
+    offset: usize,
+    visible_rows: usize,
+    highlight_cursor: bool,
+) -> Vec<Line<'static>> {
+    let mut rows = Vec::new();
     for (i, f) in files
         .iter()
         .enumerate()
@@ -513,8 +486,8 @@ pub(super) fn render_gist_info_and_files(
         } else {
             "·".to_string()
         };
-        if files_focused && i == cursor {
-            lines.push(Line::from(Span::styled(
+        if highlight_cursor && i == cursor {
+            rows.push(Line::from(Span::styled(
                 format!("▸ {marker} {f}"),
                 Style::default()
                     .fg(Color::Black)
@@ -522,13 +495,95 @@ pub(super) fn render_gist_info_and_files(
                     .add_modifier(Modifier::BOLD),
             )));
         } else {
-            lines.push(Line::from(format!("  {marker} {f}")));
+            rows.push(Line::from(format!("  {marker} {f}")));
         }
     }
+    rows
+}
+
+/// The gist's title, derived from its description (falling back to the id).
+fn gist_block_title(group: &GistGroup) -> String {
+    if group.description.trim().is_empty() {
+        format!("Gist {}", group.id)
+    } else {
+        format!("Gist: {}", group.description)
+    }
+}
+
+/// Info + file-list block for a gist, used as the compaction-confirm background. (The gist
+/// detail screen renders the info header and the file list as separate blocks so it can tab
+/// between the file list and the comments.)
+pub(super) fn render_gist_info_and_files(
+    frame: &mut Frame,
+    area: Rect,
+    state: &AppState,
+    gist_id: &str,
+) {
+    let Some(group) = state.group_by_id(gist_id) else {
+        return;
+    };
+    let files = state.gist_filenames(gist_id);
+    let mut lines: Vec<Line> = vec![
+        Line::from(gist_info_line(&group, unix_now())),
+        Line::from(""),
+        Line::from(Span::styled(
+            format!("Files ({})", files.len()),
+            Style::default().add_modifier(Modifier::BOLD),
+        )),
+    ];
+    let cursor = state.detail_file_cursor.min(files.len().saturating_sub(1));
+    // Visible file rows = area height minus borders(2), info line, blank, "Files (n)" header (3).
+    let visible_rows = (area.height as usize).saturating_sub(5);
+    let offset = file_list_scroll(cursor, visible_rows, files.len());
+    lines.extend(file_rows(&files, cursor, offset, visible_rows, false));
     frame.render_widget(
         Paragraph::new(lines).block(
             Block::default()
-                .title(title)
+                .title(gist_block_title(&group))
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(Style::default().fg(Color::Cyan))
+                .padding(Padding::horizontal(1)),
+        ),
+        area,
+    );
+}
+
+/// The gist detail header: a block holding the basic-info line and the `Files │ Comments`
+/// focus tabs. The active tab's content is rendered below it.
+fn render_detail_header(frame: &mut Frame, area: Rect, state: &AppState, gist_id: &str) {
+    let Some(group) = state.group_by_id(gist_id) else {
+        return;
+    };
+    let lines = vec![
+        Line::from(gist_info_line(&group, unix_now())),
+        detail_focus_tabs_line(state.detail_focus),
+    ];
+    frame.render_widget(
+        Paragraph::new(lines).block(
+            Block::default()
+                .title(gist_block_title(&group))
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(Style::default().fg(Color::Cyan))
+                .padding(Padding::horizontal(1)),
+        ),
+        area,
+    );
+}
+
+/// The gist detail's Files tab: the numbered, cursor-highlighted, scrollable file list,
+/// titled with the file count.
+fn render_gist_file_list(frame: &mut Frame, area: Rect, state: &AppState, gist_id: &str) {
+    let files = state.gist_filenames(gist_id);
+    let cursor = state.detail_file_cursor.min(files.len().saturating_sub(1));
+    let visible_rows = (area.height as usize).saturating_sub(2);
+    let offset = file_list_scroll(cursor, visible_rows, files.len());
+    let lines = file_rows(&files, cursor, offset, visible_rows, true);
+    frame.render_widget(
+        Paragraph::new(lines).block(
+            Block::default()
+                .title(format!("Files ({})", files.len()))
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
                 .border_style(Style::default().fg(Color::Cyan))
@@ -615,16 +670,17 @@ pub(super) fn detail_footer(status: Option<&str>, focus: DetailFocus) -> (String
     footer_with_status(status, hints)
 }
 
-/// The Comments|Files focus index, mirroring `detail_focus`. Pure so the tab selection is
-/// trivially testable and stays in sync with the navigation handler.
+/// The Files|Comments tab index, mirroring `detail_focus`. Pure so the tab selection is
+/// trivially testable and stays in sync with the navigation handler. Files is the default
+/// tab, so it comes first.
 pub(super) fn detail_focus_tab(focus: DetailFocus) -> usize {
     match focus {
-        DetailFocus::Comments => 0,
-        DetailFocus::Files => 1,
+        DetailFocus::Files => 0,
+        DetailFocus::Comments => 1,
     }
 }
 
-/// A `Comments │ Files` focus indicator line, with the pane Tab currently drives highlighted.
+/// A `Files │ Comments` focus indicator line, with the pane Tab currently drives highlighted.
 /// Rendered just under the gist's basic info (inside the info box) rather than as a floating
 /// strip, so the active focus is visible without a disconnected top row.
 pub(super) fn detail_focus_tabs_line(focus: DetailFocus) -> Line<'static> {
@@ -635,7 +691,7 @@ pub(super) fn detail_focus_tabs_line(focus: DetailFocus) -> Line<'static> {
         .add_modifier(Modifier::BOLD);
     let idle_style = Style::default().fg(Color::DarkGray);
     let mut spans = Vec::new();
-    for (i, label) in ["Comments", "Files"].iter().enumerate() {
+    for (i, label) in ["Files", "Comments"].iter().enumerate() {
         if i > 0 {
             spans.push(Span::styled(" │ ", idle_style));
         }
@@ -653,28 +709,23 @@ pub(super) fn render_gist_detail(frame: &mut Frame, state: &AppState) {
     let area = frame.area();
     let (footer, colored) = detail_footer(state.status.as_deref(), state.detail_focus);
     let footer_lines = wrap_line_count(&footer, area.width.saturating_sub(2)).max(1);
-    let files = state
-        .detail_gist_id
-        .as_deref()
-        .map(|id| state.gist_filenames(id).len())
-        .unwrap_or(0);
-    // Scale to the file count, but never exceed half the screen nor drop below 6 rows
-    // (borders + info line + focus strip + blank + "Files (n)" header).
-    let info_height = (files as u16)
-        .saturating_add(6)
-        .clamp(6, (area.height / 2).max(6));
+    // Fixed 4-row header (borders + basic-info line + focus tabs); the active tab — the file
+    // list or the comments, never both — fills the rest above the footer.
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(info_height),
+            Constraint::Length(4),
             Constraint::Min(3),
             Constraint::Length(footer_lines + 1),
         ])
         .split(area);
     if let Some(id) = state.detail_gist_id.as_deref() {
-        render_gist_info_and_files(frame, chunks[0], state, id);
+        render_detail_header(frame, chunks[0], state, id);
+        match state.detail_focus {
+            DetailFocus::Files => render_gist_file_list(frame, chunks[1], state, id),
+            DetailFocus::Comments => render_gist_comments(frame, chunks[1], state),
+        }
     }
-    render_gist_comments(frame, chunks[1], state);
     render_footer(frame, chunks[2], "", &footer, colored);
 }
 

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -410,7 +410,7 @@ pub(super) fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) ->
                     state.detail_comments = None;
                     state.detail_comments_error = None;
                     state.detail_scroll = 0;
-                    state.detail_focus = DetailFocus::Comments;
+                    state.detail_focus = DetailFocus::Files;
                     state.detail_file_cursor = 0;
 
                     let fetch_id = gist_id.clone();

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -390,6 +390,14 @@ fn detail_focus_tab_tracks_focus() {
 }
 
 #[test]
+fn count_label_plain_unless_filtered() {
+    assert_eq!(count_label(12, 12), "(12)");
+    assert_eq!(count_label(0, 0), "(0)");
+    // Filtered: fewer shown than total.
+    assert_eq!(count_label(3, 12), "(3/12)");
+}
+
+#[test]
 fn spinner_glyph_cycles_through_frames_and_wraps() {
     // Adjacent ticks advance the frame; the cycle wraps after a full revolution.
     assert_ne!(spinner_glyph(0), spinner_glyph(1));

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -162,9 +162,9 @@ fn enter_on_gist_opens_detail() {
 }
 
 #[test]
-fn detail_focus_and_cursor_default_to_comments_and_zero() {
+fn detail_focus_and_cursor_default_to_files_and_zero() {
     let state = initial_state();
-    assert_eq!(state.detail_focus, DetailFocus::Comments);
+    assert_eq!(state.detail_focus, DetailFocus::Files);
     assert_eq!(state.detail_file_cursor, 0);
 }
 
@@ -172,11 +172,11 @@ fn detail_focus_and_cursor_default_to_comments_and_zero() {
 fn detail_tab_toggles_focus() {
     let mut state = state_with_gists();
     state.screen = Screen::GistDetail;
-    assert_eq!(state.detail_focus, DetailFocus::Comments);
-    state.handle_key(KeyCode::Tab);
     assert_eq!(state.detail_focus, DetailFocus::Files);
     state.handle_key(KeyCode::Tab);
     assert_eq!(state.detail_focus, DetailFocus::Comments);
+    state.handle_key(KeyCode::Tab);
+    assert_eq!(state.detail_focus, DetailFocus::Files);
 }
 
 #[test]
@@ -246,6 +246,7 @@ fn detail_q_returns_to_gists() {
 fn detail_scroll_saturates_at_zero() {
     let mut state = state_with_gists();
     state.screen = Screen::GistDetail;
+    state.detail_focus = DetailFocus::Comments;
     state.detail_scroll = 0;
     state.handle_key(KeyCode::Up);
     assert_eq!(state.detail_scroll, 0);
@@ -385,8 +386,8 @@ fn detail_footer_is_focus_aware() {
 
 #[test]
 fn detail_focus_tab_tracks_focus() {
-    assert_eq!(detail_focus_tab(DetailFocus::Comments), 0);
-    assert_eq!(detail_focus_tab(DetailFocus::Files), 1);
+    assert_eq!(detail_focus_tab(DetailFocus::Files), 0);
+    assert_eq!(detail_focus_tab(DetailFocus::Comments), 1);
 }
 
 #[test]

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -384,6 +384,12 @@ fn detail_footer_is_focus_aware() {
 }
 
 #[test]
+fn detail_focus_tab_tracks_focus() {
+    assert_eq!(detail_focus_tab(DetailFocus::Comments), 0);
+    assert_eq!(detail_focus_tab(DetailFocus::Files), 1);
+}
+
+#[test]
 fn spinner_glyph_cycles_through_frames_and_wraps() {
     // Adjacent ticks advance the frame; the cycle wraps after a full revolution.
     assert_ne!(spinner_glyph(0), spinner_glyph(1));


### PR DESCRIPTION
0.9.0 UI-polish (re-scoped #106; folds in #111).

## Changes
1. **Gist-detail focus indicator (closes #106):** a `Comments │ Files` strip rendered **just under the gist's basic info** (inside the info box), highlighting the pane `Tab` drives. The Comments focus had no visual cue before. *(First placed it as a floating top strip; moved it under the basic info per review — looks less disconnected.)*
2. **Item counts in titles (folds in #111):** the Local & Gist panes, gist manager and Pins now show `(N)` — or `(shown/total)` when a filter narrows the list — matching the existing `Files (N)` / `Comments (N)` style. Shared `count_label()` helper.

## Why not Table/Gauge (the original #106)
- **Table (Pins/Gists):** rows scroll horizontally as a whole (`hscroll`) because paths/descriptions overflow; a Table truncates with no per-cell scroll → regresses that.
- **Gauge (diff context):** `c` is a binary radius⇄full toggle already labelled in the footer; no range to gauge.

(Reasoning also on #106.)

## Verification
`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo check`, `cargo test` all green — 260 tests incl. `detail_focus_tab_tracks_focus` and `count_label_plain_unless_filtered`.

## Docs
- CHANGELOG `[Unreleased]`: two bullets (focus strip, item counts).
- No new key → no README/`?`-help change.
- Worth an eyeball in a real terminal (open a gist → Enter → Tab to flip focus; filter the gist manager to see `(shown/total)`).