### PR TITLE
refactor: remove PathSegment and Recent dead ranking signals

### DIFF
--- a/src/ranking.rs
+++ b/src/ranking.rs
@@ -1,6 +1,4 @@
 use crate::domain::{GistFile, LocalCandidate, PinnedMapping};
-use std::collections::HashSet;
-use std::path::Component;
 use std::path::Path;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -14,8 +12,6 @@ pub struct RankedGistFile {
 pub enum MatchReason {
     Pinned,
     ExactFilename,
-    PathSegment,
-    Recent,
 }
 
 pub fn rank_gist_files(
@@ -27,7 +23,6 @@ pub fn rank_gist_files(
         .file_name()
         .and_then(|s| s.to_str())
         .unwrap_or_default();
-    let local_tokens = meaningful_path_tokens(local_path);
 
     let mut ranked: Vec<_> = gist_files
         .iter()
@@ -48,17 +43,6 @@ pub fn rank_gist_files(
             if file.filename == local_filename {
                 score += 1_000;
                 reasons.push(MatchReason::ExactFilename);
-            }
-
-            let gist_tokens = text_tokens(&format!("{} {}", file.description, file.filename));
-            if local_tokens.iter().any(|token| gist_tokens.contains(token)) {
-                score += 250;
-                reasons.push(MatchReason::PathSegment);
-            }
-
-            if !file.updated_at.is_empty() {
-                score += 1;
-                reasons.push(MatchReason::Recent);
             }
 
             RankedGistFile {
@@ -91,8 +75,6 @@ pub fn rank_local_files(
     locals: &[LocalCandidate],
     pinned: &[PinnedMapping],
 ) -> Vec<RankedLocal> {
-    let gist_tokens = text_tokens(&format!("{} {}", gist.description, gist.filename));
-
     let mut ranked: Vec<_> = locals
         .iter()
         .cloned()
@@ -119,12 +101,6 @@ pub fn rank_local_files(
                 reasons.push(MatchReason::ExactFilename);
             }
 
-            let local_tokens = meaningful_path_tokens(&candidate.path);
-            if local_tokens.iter().any(|token| gist_tokens.contains(token)) {
-                score += 250;
-                reasons.push(MatchReason::PathSegment);
-            }
-
             RankedLocal {
                 candidate,
                 score,
@@ -139,32 +115,6 @@ pub fn rank_local_files(
             .then(a.candidate.path.cmp(&b.candidate.path))
     });
     ranked
-}
-
-fn meaningful_path_tokens(path: &Path) -> HashSet<String> {
-    path.components()
-        .filter_map(|component| match component {
-            Component::Normal(value) => value.to_str(),
-            Component::CurDir
-            | Component::ParentDir
-            | Component::RootDir
-            | Component::Prefix(_) => None,
-        })
-        .flat_map(|component| text_tokens(component.trim_start_matches('.')))
-        .filter(|token| !is_common_container_dir(token))
-        .collect()
-}
-
-fn text_tokens(text: &str) -> HashSet<String> {
-    text.to_ascii_lowercase()
-        .split(|c: char| !c.is_ascii_alphanumeric())
-        .filter(|token| token.len() >= 3)
-        .map(String::from)
-        .collect()
-}
-
-fn is_common_container_dir(token: &str) -> bool {
-    matches!(token, "users" | "home" | "tmp" | "var" | "private")
 }
 
 #[cfg(test)]
@@ -204,7 +154,7 @@ mod tests {
     }
 
     #[test]
-    fn exact_filename_beats_path_hint() {
+    fn exact_filename_ranks_above_no_match() {
         let local = PathBuf::from("/Users/me/.claude/settings.json");
         let files = vec![
             gist("a", "claude config", "other.json"),
@@ -213,24 +163,6 @@ mod tests {
 
         let ranked = rank_gist_files(&local, &files, &[]);
         assert_eq!(ranked[0].file.gist_id, "b");
-    }
-
-    #[test]
-    fn dot_prefixed_config_directory_can_match_path_segment() {
-        let local = PathBuf::from("/Users/me/.claude/settings.json");
-        let files = vec![gist("a", "claude config", "other.json")];
-
-        let ranked = rank_gist_files(&local, &files, &[]);
-        assert!(ranked[0].reasons.contains(&MatchReason::PathSegment));
-    }
-
-    #[test]
-    fn short_ancestor_token_does_not_match_unrelated_words() {
-        let local = PathBuf::from("/Users/me/project/config.json");
-        let files = vec![gist("a", "theme notes", "readme.md")];
-
-        let ranked = rank_gist_files(&local, &files, &[]);
-        assert!(!ranked[0].reasons.contains(&MatchReason::PathSegment));
     }
 
     #[test]
@@ -244,15 +176,6 @@ mod tests {
         let ranked = rank_gist_files(&local, &files, &[]);
         assert_eq!(ranked[0].file.filename, "alpha.txt");
         assert_eq!(ranked[1].file.filename, "zeta.txt");
-    }
-
-    #[test]
-    fn no_path_segment_reason_for_unrelated_tokens() {
-        let local = PathBuf::from("/Users/me/.claude/settings.json");
-        let files = vec![gist("a", "editor theme", "readme.md")];
-
-        let ranked = rank_gist_files(&local, &files, &[]);
-        assert!(!ranked[0].reasons.contains(&MatchReason::PathSegment));
     }
 
     fn local(path: &str) -> LocalCandidate {

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1172,9 +1172,7 @@ fn row_mark_same_name_when_exact_filename_only() {
     assert_eq!(row_mark(&[MatchReason::ExactFilename]), RowMark::SameName);
 }
 #[test]
-fn row_mark_none_for_weak_matches() {
-    assert_eq!(row_mark(&[MatchReason::PathSegment]), RowMark::None);
-    assert_eq!(row_mark(&[MatchReason::Recent]), RowMark::None);
+fn row_mark_none_for_empty_reasons() {
     assert_eq!(row_mark(&[]), RowMark::None);
 }
 


### PR DESCRIPTION
## Summary

- `PathSegment` (+250) only affected sort order — no visual indicator was shown, making the implicit reordering surprising and invisible to the user
- `Recent` (+1) was a practical no-op: every gist carries a non-empty `updated_at`, so all gists got the point equally

Ranking now uses only `Pinned` and `ExactFilename`, with alphabetical tie-breaking. The list order is now fully predictable from what users can see.

**Removed:**
- `MatchReason::PathSegment` and `MatchReason::Recent` variants
- `meaningful_path_tokens`, `text_tokens`, `is_common_container_dir` helper functions
- 3 tests that covered the removed signals

## Test plan

- [x] `cargo test` — 259 passed (−3 from removed PathSegment tests)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Verify pinned gists still sort first, exact-filename matches still bold