### PR TITLE
docs: document Scoop install and tap/bucket auto-updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ until the registry token is set.
 - [x] Add a `cargo install gistui` option to the README install section.
 - [x] Add `[package.metadata.binstall]` and verify `cargo binstall --dry-run gistui` (see issue #93).
 
-**Ongoing:** each release is a `vX.Y.Z` tag matching `Cargo.toml`; the tag triggers both the binary release (`release.yml`) and the crates.io publish (`publish.yml`). Remember to bump the [Homebrew tap](https://github.com/akunzai/homebrew-tap) formula too.
+**Ongoing:** each release is a `vX.Y.Z` tag matching `Cargo.toml`; the tag triggers both the binary release (`release.yml`) and the crates.io publish (`publish.yml`). The [Homebrew tap](https://github.com/akunzai/homebrew-tap) and [Scoop bucket](https://github.com/akunzai/scoop-bucket) both update themselves via their scheduled workflows (`brew livecheck` bump / `checkver` + `autoupdate` Excavator), so neither needs a manual bump on release.
 
 ## Reporting Issues
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ To pin a release or change the install directory, invoke it as a script block:
 > the WSL launcher and installs the **Linux** binary inside WSL. Use `install.ps1` for a native
 > Windows install, or run `install.sh` from [Git Bash](https://gitforwindows.org).
 
+### Scoop (Windows)
+
+With [Scoop](https://scoop.sh), install from the
+[`akunzai/scoop-bucket`](https://github.com/akunzai/scoop-bucket) bucket — it handles `PATH`,
+updates, and the `gh` dependency for you:
+
+```powershell
+scoop bucket add akunzai https://github.com/akunzai/scoop-bucket
+scoop install gistui
+```
+
 ### Download a prebuilt binary (recommended)
 
 Each [release](https://github.com/akunzai/gistui/releases/latest) attaches prebuilt,

--- a/docs/index.html
+++ b/docs/index.html
@@ -155,6 +155,7 @@
       </div>
       <p class="hint">Detects your platform, verifies the SHA-256 checksum, installs to <code>~/.local/bin</code>. Linux · macOS · Windows (Git Bash).</p>
       <p class="hint">On Windows (PowerShell): <code>irm https://raw.githubusercontent.com/akunzai/gistui/main/install.ps1 | iex</code></p>
+      <p class="hint">On Windows with <a href="https://scoop.sh">Scoop</a>: <code>scoop bucket add akunzai https://github.com/akunzai/scoop-bucket; scoop install gistui</code></p>
       <p class="hint">On macOS / Linux with <a href="https://brew.sh">Homebrew</a>: <code>brew install akunzai/tap/gistui</code></p>
       <p class="hint">With a Rust toolchain from <a href="https://crates.io/crates/gistui">crates.io</a>: <code>cargo install gistui</code></p>
     </div>


### PR DESCRIPTION
## Summary

Documents the new [`akunzai/scoop-bucket`](https://github.com/akunzai/scoop-bucket) Scoop bucket as a native Windows install option, and records that both the Homebrew tap and the Scoop bucket now keep themselves up to date.

```powershell
scoop bucket add akunzai https://github.com/akunzai/scoop-bucket
scoop install gistui
```

- **README**: new **Scoop (Windows)** section under Installation.
- **Landing page** (`docs/index.html`): Scoop install hint.
- **CONTRIBUTING**: the [Homebrew tap](https://github.com/akunzai/homebrew-tap) and [Scoop bucket](https://github.com/akunzai/scoop-bucket) both self-update via their scheduled workflows (`brew livecheck` bump / `checkver` + `autoupdate` Excavator), so releases need no manual bump.

Each distribution repo (manifest/formula + auto-update workflows) is set up separately in its own repository.

Refs #116.
