### PR TITLE
docs: tidy the landing page install section

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -80,7 +80,7 @@
   .btn.ghost:hover { border-color: var(--blue); text-decoration: none; }
 
   /* Terminal-style install block */
-  .install { margin: 36px auto 0; max-width: 720px; text-align: left; }
+  .install { margin: 36px auto 0; max-width: 900px; text-align: left; }
   .term {
     background: var(--bg-elev); border: 1px solid var(--border);
     border-radius: 10px; overflow: hidden;
@@ -96,7 +96,35 @@
   .term pre { margin: 0; padding: 16px 18px; overflow-x: auto; font-size: 14px; }
   .term .prompt { color: var(--green); user-select: none; }
   .term .cmd { color: var(--fg); }
-  .hint { margin-top: 10px; font-size: 13px; color: var(--dim); text-align: center; }
+  .hint { margin-top: 12px; font-size: 13px; color: var(--dim); text-align: center; }
+
+  /* Install methods */
+  .methods {
+    margin-top: 16px; display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 12px;
+  }
+  .method.full { grid-column: 1 / -1; }
+  .method {
+    background: var(--bg-card); border: 1px solid var(--border);
+    border-radius: 10px; padding: 13px 15px;
+  }
+  .method .label {
+    display: flex; align-items: center; gap: 9px;
+    font-size: 13px; color: var(--muted); margin: 0 0 9px;
+  }
+  .method .tool {
+    font-family: "JetBrains Mono", monospace; font-size: 11px; font-weight: 600;
+    color: #0b0d17; padding: 1px 7px; border-radius: 5px;
+  }
+  .method .tool.ps    { background: var(--blue); }
+  .method .tool.scoop { background: var(--cyan); }
+  .method .tool.brew  { background: var(--yellow); }
+  .method .tool.cargo { background: var(--purple); }
+  .method code {
+    display: block; font-size: 12.5px; color: var(--fg);
+    background: var(--bg); border: 1px solid var(--border); border-radius: 7px;
+    padding: 9px 11px; overflow-x: auto; white-space: pre;
+  }
 
   /* Sections */
   section { padding: 56px 0; border-bottom: 1px solid var(--border); }
@@ -153,11 +181,27 @@
         <div class="bar"><i class="r"></i><i class="y"></i><i class="g"></i><span>install.sh</span></div>
         <pre><span class="prompt">$ </span><span class="cmd">curl -fsSL https://raw.githubusercontent.com/akunzai/gistui/main/install.sh | bash</span></pre>
       </div>
-      <p class="hint">Detects your platform, verifies the SHA-256 checksum, installs to <code>~/.local/bin</code>. Linux · macOS · Windows (Git Bash).</p>
-      <p class="hint">On Windows (PowerShell): <code>irm https://raw.githubusercontent.com/akunzai/gistui/main/install.ps1 | iex</code></p>
-      <p class="hint">On Windows with <a href="https://scoop.sh">Scoop</a>: <code>scoop bucket add akunzai https://github.com/akunzai/scoop-bucket; scoop install gistui</code></p>
-      <p class="hint">On macOS / Linux with <a href="https://brew.sh">Homebrew</a>: <code>brew install akunzai/tap/gistui</code></p>
-      <p class="hint">With a Rust toolchain from <a href="https://crates.io/crates/gistui">crates.io</a>: <code>cargo install gistui</code></p>
+      <p class="hint">Detects your platform, verifies its SHA-256 checksum, and installs to <code>~/.local/bin</code> — Linux, macOS &amp; Windows (Git Bash).</p>
+      <div class="methods">
+        <div class="method">
+          <div class="label"><span class="tool brew">Homebrew</span> macOS · Linux</div>
+          <code>brew install akunzai/tap/gistui</code>
+        </div>
+        <div class="method">
+          <div class="label"><span class="tool cargo">crates.io</span> Rust</div>
+          <code>cargo install gistui
+cargo binstall gistui</code>
+        </div>
+        <div class="method full">
+          <div class="label"><span class="tool ps">PowerShell</span> Windows</div>
+          <code>irm https://raw.githubusercontent.com/akunzai/gistui/main/install.ps1 | iex</code>
+        </div>
+        <div class="method full">
+          <div class="label"><span class="tool scoop">Scoop</span> Windows</div>
+          <code>scoop bucket add akunzai https://github.com/akunzai/scoop-bucket
+scoop install gistui</code>
+        </div>
+      </div>
     </div>
   </div>
 </header>


### PR DESCRIPTION
## Summary

Tidies the cluttered install section on the landing page (`docs/index.html`). The five stacked, dim hint lines under the install terminal are replaced with an organised card grid.

- **Layout**: `Homebrew` + `crates.io` on top (two columns), `PowerShell` + `Scoop` as full-width cards below.
- **No wrapping**: the install block is widened to 900px so the long `curl` / `irm` / `scoop` commands sit on one line instead of clipping.
- **crates.io**: now also lists `cargo binstall gistui` (no-compile, prebuilt) alongside `cargo install gistui`, matching the README.
- **Scannability**: each method gets a colour-coded monospace tool chip; collapses to a single column on narrow screens.

Reuses the existing Tokyo Night design tokens — no new visual style. Content/styling only; no other files touched.
