### PR TITLE
feat: focus-aware filter input with live navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Local file list now has a text filter: `/` filters the focused pane (Local matches path/filename, Gist matches description/id). Filtering supports typing-while-navigating (↑/↓), `Tab` to apply and switch panes, and `Backspace` on an empty query to exit.
+
 ## [0.9.0] — 2026-06-14
 
 - Gist detail view is now tabbed — a `Files │ Comments` strip under the basic info shows one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Local file list now has a text filter: `/` filters the focused pane (Local matches path/filename, Gist matches description/id). Filtering supports typing-while-navigating (↑/↓), `Tab` to apply and switch panes, and `Backspace` on an empty query to exit.
+- The Pinned Mappings screen (`P`) gained the same `/` text filter — matches the local path or gist filename, with live ↑/↓ navigation.
 
 ## [0.9.0] — 2026-06-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "gistui"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gistui"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "MIT"
 description = "A terminal UI for managing GitHub Gists"

--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ Gist pane), `Up`/`Down` (move), and `Left`/`Right` (scroll a long row).
   Local paths are shown with the home directory shortened to `~`.
   Keys inside the Pins view:
   - `↑`/`↓` — move between pins; `←`/`→` — scroll a long local path horizontally.
+  - `/` — filter pins by local path or gist filename; while filtering, `↑`/`↓` move,
+    `Enter` applies, `Esc` clears.
   - `Enter` — diff the selected pair (read-only; `d`/`u` from the diff to pull/push; `Esc`/`q` returns to the Pins view).
   - `s` — smart-sync (newer side wins by modified time; skips if already identical).
   - `u` — force push (upload local → gist).

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Gist pane), `Up`/`Down` (move), and `Left`/`Right` (scroll a long row).
   and scans in the background so the UI stays responsive.
 - `a` — flip the **anchor** (which pane drives match ranking); independent of focus, so you
   can focus the ranked pane to pick a file without the order resetting.
-- `/` filter by text · `v` cycle visibility (all/public/secret) · `s` cycle the **focused
+- `/` filter the focused pane (Local pane matches path/filename; Gist pane matches description/id). While filtering: type to match, ↑/↓ move, Tab applies and switches pane, Enter applies, Esc clears. · `v` cycle visibility (all/public/secret) · `s` cycle the **focused
   pane's** sort (match / name / recent — gists by name/updated, local files by
   name/modified-time) · `t` toggle row view.
 - `Esc`/`q` — go back from an overlay; on the main list, press twice to quit (the first press
@@ -262,7 +262,7 @@ the gist owning the currently selected file. From here you manage gists as a who
   the gist's info as context.) Requires the git credential helper that `gh auth setup-git`
   configures; if it is missing, compaction reports an actionable error pointing you to that command.
 - `s` cycle sort (updated / created) · `v` cycle visibility (all/public/secret) · `/` filter
-  by description or id · `Left`/`Right` scroll a long description.
+  by description or id (↑/↓ move · Enter apply · Esc clear) · `Left`/`Right` scroll a long description.
 - `q`/`Esc` — back to the list.
 
 ## Safety rules

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -44,9 +44,39 @@ impl AppState {
         // One-shot: any key dismisses a lingering sync status; the run_loop IO helper for this
         // key may set a fresh one afterwards (e.g. "already in sync").
         self.status = None;
+        // Inline text filter: live-navigate with arrows; Tab is a no-op (single pane).
+        if self.pins_filtering {
+            match code {
+                KeyCode::Up if self.pins_index > 0 => {
+                    self.pins_index -= 1;
+                    self.pins_hscroll = 0;
+                }
+                KeyCode::Up => {}
+                KeyCode::Down => {
+                    if self.pins_index + 1 < self.visible_pin_indices().len() {
+                        self.pins_index += 1;
+                        self.pins_hscroll = 0;
+                    }
+                }
+                _ => match apply_filter_edit(code, &mut self.pins_filter_query) {
+                    FilterKey::Edited => {
+                        self.pins_index = 0;
+                        self.pins_hscroll = 0;
+                    }
+                    FilterKey::Cleared => {
+                        self.pins_filtering = false;
+                        self.pins_index = 0;
+                        self.pins_hscroll = 0;
+                    }
+                    FilterKey::Exited => self.pins_filtering = false,
+                    FilterKey::Pass => {}
+                },
+            }
+            return KeyOutcome::None;
+        }
         match code {
             KeyCode::Char('q') | KeyCode::Esc => self.screen = Screen::List,
-            KeyCode::Down if self.pins_index + 1 < self.pinned.len() => {
+            KeyCode::Down if self.pins_index + 1 < self.visible_pin_indices().len() => {
                 self.pins_index += 1;
                 self.pins_hscroll = 0;
             }
@@ -60,6 +90,7 @@ impl AppState {
             KeyCode::Left => {
                 self.pins_hscroll = self.pins_hscroll.saturating_sub(1);
             }
+            KeyCode::Char('/') => self.pins_filtering = true,
             KeyCode::Enter if !self.pinned.is_empty() => return KeyOutcome::PreviewPinDiff,
             KeyCode::Char('x') if !self.pinned.is_empty() => return KeyOutcome::UnpinAtPin,
             KeyCode::Char('s') if !self.pinned.is_empty() => return KeyOutcome::SyncPinAuto,

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -467,8 +467,9 @@ impl AppState {
     fn list_move_focused(&mut self, forward: bool) {
         match self.focus {
             FocusPane::Local => {
+                let len = self.visible_locals().len();
                 if forward {
-                    if self.local_index + 1 >= self.locals.len() {
+                    if self.local_index + 1 >= len {
                         return;
                     }
                     self.local_index += 1;

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -340,27 +340,81 @@ impl AppState {
         }
         KeyOutcome::None
     }
+}
 
+/// Outcome of applying one key to a filter query's text (the shared edit transitions
+/// for every inline filter input). Nav keys (Up/Down) and Tab are handled by the caller.
+enum FilterKey {
+    /// Query text changed (char appended or backspace popped a char); caller resets
+    /// the affected pane's selection index + horizontal scroll.
+    Edited,
+    /// Leave filter input, keeping the current query (Enter, or Backspace on empty).
+    Exited,
+    /// Esc: query cleared; caller leaves input and resets index + scroll.
+    Cleared,
+    /// Not a text-edit key (e.g. an arrow or Tab the caller already handled); ignore.
+    Pass,
+}
+
+/// Apply one key to `query` and report the transition. Pure: only mutates `query`.
+fn apply_filter_edit(code: KeyCode, query: &mut String) -> FilterKey {
+    match code {
+        KeyCode::Esc => {
+            query.clear();
+            FilterKey::Cleared
+        }
+        KeyCode::Enter => FilterKey::Exited,
+        KeyCode::Backspace => {
+            if query.pop().is_some() {
+                FilterKey::Edited
+            } else {
+                FilterKey::Exited // already empty -> leave input
+            }
+        }
+        KeyCode::Char(c) => {
+            query.push(c);
+            FilterKey::Edited
+        }
+        _ => FilterKey::Pass,
+    }
+}
+
+impl AppState {
     fn handle_key_filter(&mut self, code: KeyCode) -> KeyOutcome {
+        // Live navigation while typing: arrows move the focused pane's selection.
         match code {
-            KeyCode::Esc => {
-                self.filter_query.clear();
+            KeyCode::Up => {
+                self.list_move_focused(false);
+                return KeyOutcome::None;
+            }
+            KeyCode::Down => {
+                self.list_move_focused(true);
+                return KeyOutcome::None;
+            }
+            // Tab commits (keeps the query), leaves input, and switches pane.
+            KeyCode::Tab => {
                 self.filtering = false;
-                self.gist_index = 0;
-                self.gist_hscroll = 0;
-            }
-            KeyCode::Enter => self.filtering = false,
-            KeyCode::Backspace => {
-                self.filter_query.pop();
-                self.gist_index = 0;
-                self.gist_hscroll = 0;
-            }
-            KeyCode::Char(c) => {
-                self.filter_query.push(c);
-                self.gist_index = 0;
-                self.gist_hscroll = 0;
+                self.focus = match self.focus {
+                    FocusPane::Local => FocusPane::Gist,
+                    FocusPane::Gist => FocusPane::Local,
+                };
+                return KeyOutcome::None;
             }
             _ => {}
+        }
+        let focus = self.focus;
+        let query = match focus {
+            FocusPane::Local => &mut self.local_filter_query,
+            FocusPane::Gist => &mut self.filter_query,
+        };
+        match apply_filter_edit(code, query) {
+            FilterKey::Edited => self.reset_focused_filter_scroll(),
+            FilterKey::Cleared => {
+                self.filtering = false;
+                self.reset_focused_filter_scroll();
+            }
+            FilterKey::Exited => self.filtering = false,
+            FilterKey::Pass => {}
         }
         KeyOutcome::None
     }
@@ -458,6 +512,21 @@ impl AppState {
             _ => {}
         }
         KeyOutcome::None
+    }
+
+    /// Reset the focused pane's selection index and horizontal scroll (used when a
+    /// filter edit changes the visible rows).
+    fn reset_focused_filter_scroll(&mut self) {
+        match self.focus {
+            FocusPane::Local => {
+                self.local_index = 0;
+                self.local_hscroll = 0;
+            }
+            FocusPane::Gist => {
+                self.gist_index = 0;
+                self.gist_hscroll = 0;
+            }
+        }
     }
 
     /// Move the selection in the focused list pane. `forward` advances toward the end of the

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -88,27 +88,33 @@ impl AppState {
             }
             return KeyOutcome::None;
         }
-        // Inline text filter: capture the query until Enter (keep) or Esc (clear).
+        // Inline text filter: live-navigate with arrows; Tab is a no-op (single pane).
         if self.gists_filtering {
             match code {
-                KeyCode::Esc => {
-                    self.gists_filter_query.clear();
-                    self.gists_filtering = false;
-                    self.gists_index = 0;
+                KeyCode::Up if self.gists_index > 0 => {
+                    self.gists_index -= 1;
                     self.gists_hscroll = 0;
                 }
-                KeyCode::Enter => self.gists_filtering = false,
-                KeyCode::Backspace => {
-                    self.gists_filter_query.pop();
-                    self.gists_index = 0;
-                    self.gists_hscroll = 0;
+                KeyCode::Up => {}
+                KeyCode::Down => {
+                    if self.gists_index + 1 < self.visible_gist_groups().len() {
+                        self.gists_index += 1;
+                        self.gists_hscroll = 0;
+                    }
                 }
-                KeyCode::Char(c) => {
-                    self.gists_filter_query.push(c);
-                    self.gists_index = 0;
-                    self.gists_hscroll = 0;
-                }
-                _ => {}
+                _ => match apply_filter_edit(code, &mut self.gists_filter_query) {
+                    FilterKey::Edited => {
+                        self.gists_index = 0;
+                        self.gists_hscroll = 0;
+                    }
+                    FilterKey::Cleared => {
+                        self.gists_filtering = false;
+                        self.gists_index = 0;
+                        self.gists_hscroll = 0;
+                    }
+                    FilterKey::Exited => self.gists_filtering = false,
+                    FilterKey::Pass => {}
+                },
             }
             return KeyOutcome::None;
         }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -264,6 +264,10 @@ pub struct AppState {
     pub local_sort: LocalSort,
     pub filtering: bool,
     pub filter_query: String,
+    /// Text filter for the LOCAL pane (List screen). Independent of `filter_query`
+    /// (the gist pane), so both panes can be filtered at once. Matched against the
+    /// cwd-relative display label, i.e. the exact string shown in the local list.
+    pub local_filter_query: String,
     pub diff_previewed: bool,
     pub diff_text: String,
     pub diff_scroll: u16,
@@ -478,6 +482,14 @@ impl AppState {
         } else {
             unranked_locals(&self.locals)
         };
+        let query = self.local_filter_query.to_lowercase();
+        if !query.is_empty() {
+            ranked.retain(|r| {
+                render::local_row_label(&r.candidate.path, &self.cwd)
+                    .to_lowercase()
+                    .contains(&query)
+            });
+        }
         self.local_sort.apply(&mut ranked);
         ranked
     }
@@ -794,6 +806,7 @@ pub fn initial_state() -> AppState {
         local_sort: LocalSort::Match,
         filtering: false,
         filter_query: String::new(),
+        local_filter_query: String::new(),
         diff_previewed: false,
         diff_text: String::new(),
         diff_scroll: 0,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -306,6 +306,8 @@ pub struct AppState {
     pub local_scanning: bool,
     pub pins_index: usize,
     pub pins_hscroll: u16,
+    pub pins_filtering: bool,
+    pub pins_filter_query: String,
     pub gists_index: usize,
     pub gists_hscroll: u16,
     pub gists_sort: GistGroupSort,
@@ -569,6 +571,36 @@ impl AppState {
             .unwrap_or(0)
             .saturating_sub(1)
             .min(u16::MAX as usize) as u16
+    }
+
+    /// Indices into `self.pinned` that match the Pins-screen text filter, in original
+    /// order. Empty query → every index. Matched against the cwd/home-shortened local
+    /// path plus the gist filename (the meaningful, visible parts of the row).
+    pub fn visible_pin_indices(&self) -> Vec<usize> {
+        let query = self.pins_filter_query.to_lowercase();
+        self.pinned
+            .iter()
+            .enumerate()
+            .filter(|(_, m)| {
+                if query.is_empty() {
+                    return true;
+                }
+                let hay = format!(
+                    "{} {}",
+                    crate::config::display_path(&m.local_path),
+                    m.gist_filename
+                )
+                .to_lowercase();
+                hay.contains(&query)
+            })
+            .map(|(i, _)| i)
+            .collect()
+    }
+
+    /// The true `self.pinned` index of the currently selected Pins row (selection is a
+    /// position within the filtered view).
+    pub fn selected_pin_index(&self) -> Option<usize> {
+        self.visible_pin_indices().get(self.pins_index).copied()
     }
 
     /// Number of files the given gist holds in the current in-memory list. Used to guard
@@ -835,6 +867,8 @@ pub fn initial_state() -> AppState {
         local_scanning: false,
         pins_index: 0,
         pins_hscroll: 0,
+        pins_filtering: false,
+        pins_filter_query: String::new(),
         gists_index: 0,
         gists_hscroll: 0,
         gists_sort: GistGroupSort::Updated,

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -78,6 +78,7 @@ Actions (on the selected local file + gist)
 Pinned Mappings screen (P)
   Up/Down    move between pins
   Left/Right scroll a long local path horizontally (~ = home)
+  /          filter pins by path or filename (↑↓ move · Enter apply · Esc clear)
   Enter      diff the selected pair (then d pull / u push from the diff)
   s          smart-sync (newer side wins; skips if already identical)
   u          force push  (upload local → gist)
@@ -247,15 +248,25 @@ pub(super) fn render_pins(frame: &mut Frame, state: &AppState) {
     let hints = if state.pinned.is_empty() {
         "Esc/q back"
     } else {
-        "↑↓ move · ←→ scroll · Enter diff · s sync · u push · d pull · x unpin  ·  ✓ synced ↑ local-newer ↓ remote-newer ? n/a  ·  Esc/q back"
+        "↑↓ move · ←→ scroll · / filter · Enter diff · s sync · u push · d pull · x unpin  ·  ✓ synced ↑ local-newer ↓ remote-newer ? n/a  ·  Esc/q back"
     };
-    let (footer, colored) = footer_with_status(state.status.as_deref(), hints);
+    let (ftitle, footer, colored) = if state.pins_filtering {
+        (
+            "Filter (↑↓ move · Enter keep · Esc clear)".to_string(),
+            format!("/{}_", state.pins_filter_query),
+            false,
+        )
+    } else {
+        let (footer, colored) = footer_with_status(state.status.as_deref(), hints);
+        (String::new(), footer, colored)
+    };
     let footer_lines = wrap_line_count(&footer, area.width.saturating_sub(2)).max(1);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(3), Constraint::Length(footer_lines + 1)])
         .split(area);
 
+    let visible = state.visible_pin_indices();
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)
@@ -265,12 +276,14 @@ pub(super) fn render_pins(frame: &mut Frame, state: &AppState) {
             ListItem::new("  📌 No pinned mappings found (use p to pin a pair)")
                 .style(Style::default().fg(Color::DarkGray)),
         ]
+    } else if visible.is_empty() {
+        vec![ListItem::new("  🔍 No pins match the filter")
+            .style(Style::default().fg(Color::DarkGray))]
     } else {
-        state
-            .pinned
+        visible
             .iter()
-            .enumerate()
-            .map(|(i, m)| {
+            .map(|&i| {
+                let m = &state.pinned[i];
                 let (lts, rts) = state.pin_mtimes(i);
                 let age = |ts: Option<u64>| {
                     ts.map(|t| crate::domain::humanize_age(now - t as i64))
@@ -291,14 +304,18 @@ pub(super) fn render_pins(frame: &mut Frame, state: &AppState) {
             .collect()
     };
 
-    let selected = (!state.pinned.is_empty()).then_some(state.pins_index);
+    let selected = (!visible.is_empty()).then_some(state.pins_index);
+    let mut title = format!(
+        "Pinned Mappings {}",
+        count_label(visible.len(), state.pinned.len())
+    );
+    if !state.pins_filter_query.is_empty() {
+        title.push_str(&format!(" · /{}", state.pins_filter_query));
+    }
     let list = List::new(items)
         .block(
             Block::default()
-                .title(format!(
-                    "Pinned Mappings {}",
-                    count_label(state.pinned.len(), state.pinned.len())
-                ))
+                .title(title)
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
                 .border_style(Style::default().fg(Color::Cyan))
@@ -316,7 +333,7 @@ pub(super) fn render_pins(frame: &mut Frame, state: &AppState) {
     list_state.select(selected);
     frame.render_stateful_widget(list, chunks[0], &mut list_state);
 
-    render_footer(frame, chunks[1], "", &footer, colored);
+    render_footer(frame, chunks[1], &ftitle, &footer, colored);
 }
 
 pub(super) fn gist_group_row_label(

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -49,7 +49,9 @@ Navigation
 
 List screen
   r          toggle recursive file discovery (skips hidden + configured dirs)
-  /          filter by filename or description
+  /          filter the focused pane (Local = path/filename, Gist = description/id)
+             while filtering: type to match · ↑↓ move · Tab apply + switch pane
+             · Enter apply · Esc clear
   v          cycle gist visibility: all / public / secret
   s          cycle the focused pane's sort: match / name / recent
   t          toggle row view: description / id
@@ -111,7 +113,7 @@ Upload Confirmation screen (u)
 Gist manager (g)
   Up/Down    move between gists
   Left/Right scroll a long description horizontally
-  /          filter gists by description or id
+  /          filter gists by description or id (↑↓ move · Enter apply · Esc clear)
   s          cycle sort: updated / created
   v          cycle visibility: all / public / secret
   e          edit the gist description (Enter apply, Esc cancel)
@@ -358,7 +360,7 @@ pub(super) fn render_gists(frame: &mut Frame, state: &AppState) {
     // result) when present, else the command hints. Only the hints get key colouring.
     let (ftitle, footer, colored) = if state.gists_filtering {
         (
-            "Filter (Enter keep · Esc clear)".to_string(),
+            "Filter (↑↓ move · Enter keep · Esc clear)".to_string(),
             format!("/{}_", state.gists_filter_query),
             false,
         )

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -963,10 +963,11 @@ pub(super) fn render_footer(frame: &mut Frame, area: Rect, title: &str, text: &s
 pub(super) fn render_list(frame: &mut Frame, state: &AppState) {
     let area = frame.area();
     let footer_body = if state.filtering {
-        format!(
-            "filter: {}_   (Enter apply · Esc clear)",
-            state.filter_query
-        )
+        let (pane, query) = match state.focus {
+            FocusPane::Local => ("local", &state.local_filter_query),
+            FocusPane::Gist => ("gist", &state.filter_query),
+        };
+        format!("filter {pane}: {query}_   (Tab next pane · Enter apply · Esc clear)")
     } else {
         match &state.status {
             Some(message) => message.clone(),
@@ -988,6 +989,7 @@ pub(super) fn render_list(frame: &mut Frame, state: &AppState) {
 
     // Show each candidate's path relative to cwd; in flat mode this is just the filename,
     // in recursive mode it includes the subdirectory (e.g. src/utils/helpers.rs).
+    let visible_locals = state.visible_locals();
     let local_items: Vec<ListItem> = if state.local_scanning && state.locals.is_empty() {
         vec![ListItem::new(format!(
             "  {} Scanning files…",
@@ -996,9 +998,11 @@ pub(super) fn render_list(frame: &mut Frame, state: &AppState) {
         .style(Style::default().fg(Color::DarkGray))]
     } else if state.locals.is_empty() {
         vec![ListItem::new("  📭 No local files found").style(Style::default().fg(Color::DarkGray))]
+    } else if visible_locals.is_empty() {
+        vec![ListItem::new("  🔍 No files match the filter")
+            .style(Style::default().fg(Color::DarkGray))]
     } else {
-        state
-            .visible_locals()
+        visible_locals
             .iter()
             .map(|r| {
                 let base = local_row_label(&r.candidate.path, &state.cwd);
@@ -1007,17 +1011,20 @@ pub(super) fn render_list(frame: &mut Frame, state: &AppState) {
             .collect()
     };
     let local_focused = state.focus == FocusPane::Local;
-    let local_selected = (!state.locals.is_empty()).then_some(state.local_index);
+    let local_selected = (!visible_locals.is_empty()).then_some(state.local_index);
     let recursive_marker = if state.local_recursive { " [↓]" } else { "" };
     let scanning_marker = if state.local_scanning { " …" } else { "" };
-    let local_title = format!(
+    let mut local_title = format!(
         "[1] Local {} · {}{}{} · sort:{}",
-        count_label(state.locals.len(), state.locals.len()),
+        count_label(visible_locals.len(), state.locals.len()),
         crate::config::display_path(&state.cwd),
         recursive_marker,
         scanning_marker,
         state.local_sort.label()
     );
+    if !state.local_filter_query.is_empty() {
+        local_title.push_str(&format!(" · /{}", state.local_filter_query));
+    }
     // Mark the pane that currently drives the match ranking (the anchor).
     let local_title = if state.anchor == FocusPane::Local {
         format!("{local_title} · ⚓")

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -795,10 +795,11 @@ pub(super) fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) ->
                     }
                 }
                 KeyOutcome::SyncPinAuto => {
-                    let Some(m) = selected_pin(&state) else {
+                    let Some(pin_idx) = state.selected_pin_index() else {
                         continue;
                     };
-                    match state.pin_sync_status(state.pins_index) {
+                    let m = state.pinned[pin_idx].clone();
+                    match state.pin_sync_status(pin_idx) {
                         crate::domain::SyncStatus::InSync => state.set_status("already in sync"),
                         crate::domain::SyncStatus::Pull => {
                             spawn_pin_pull(&mut state, &mut bg_rx, &m)
@@ -980,7 +981,9 @@ where
 
 /// The pin currently selected in the Pins screen, if any.
 fn selected_pin(state: &AppState) -> Option<crate::domain::PinnedMapping> {
-    state.pinned.get(state.pins_index).cloned()
+    state
+        .selected_pin_index()
+        .and_then(|i| state.pinned.get(i).cloned())
 }
 
 /// Resolve a pin's absolute local path against cwd.
@@ -1389,9 +1392,10 @@ fn unpin_selected(state: &mut AppState) {
 }
 
 fn unpin_at_pin_index(state: &mut AppState) {
-    let Some(mapping) = state.pinned.get(state.pins_index).cloned() else {
+    let Some(idx) = state.selected_pin_index() else {
         return;
     };
+    let mapping = state.pinned[idx].clone();
     let label = crate::config::display_path(&mapping.local_path);
     let result = crate::config::config_path().and_then(|path| {
         let config = crate::config::load_config(&path)?;
@@ -1402,7 +1406,9 @@ fn unpin_at_pin_index(state: &mut AppState) {
             state.pinned = config.pinned;
             state.skip_dirs = config.skip_dirs;
             state.scan_depth = config.scan_depth;
-            state.pins_index = state.pins_index.min(state.pinned.len().saturating_sub(1));
+            state.pins_index = state
+                .pins_index
+                .min(state.visible_pin_indices().len().saturating_sub(1));
             refresh_locals(state);
             state.set_status(format!("Unpinned {label}"));
         }

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -2800,3 +2800,96 @@ fn gists_filter_tab_is_noop() {
     assert!(state.gists_filtering); // still typing
     assert_eq!(state.gists_filter_query, "a"); // unchanged
 }
+
+// ── Pins screen filter ────────────────────────────────────────────────────────
+
+fn state_with_pins(rows: &[(&str, &str, &str)]) -> AppState {
+    let mut state = initial_state();
+    state.cwd = PathBuf::from("/cwd");
+    state.screen = Screen::Pins;
+    state.pinned = rows
+        .iter()
+        .map(|(lp, id, fname)| PinnedMapping {
+            local_path: PathBuf::from(lp),
+            gist_id: (*id).into(),
+            gist_filename: (*fname).into(),
+            direction: None,
+            last_seen_hash: None,
+        })
+        .collect();
+    state
+}
+
+#[test]
+fn visible_pin_indices_filters_by_path_and_filename() {
+    let mut state = state_with_pins(&[
+        ("/cwd/.zshrc", "g1", "zshrc"),
+        ("/cwd/init.lua", "g2", "init.lua"),
+        ("/cwd/notes.md", "g3", "notes.md"),
+    ]);
+    assert_eq!(state.visible_pin_indices(), vec![0, 1, 2]);
+
+    state.pins_filter_query = "lua".into(); // matches filename of row 1
+    assert_eq!(state.visible_pin_indices(), vec![1]);
+
+    state.pins_filter_query = "ZSH".into(); // case-insensitive, matches path of row 0
+    assert_eq!(state.visible_pin_indices(), vec![0]);
+}
+
+#[test]
+fn selected_pin_index_maps_through_filter() {
+    let mut state = state_with_pins(&[
+        ("/cwd/alpha", "g1", "alpha"),
+        ("/cwd/beta", "g2", "beta"),
+        ("/cwd/gamma", "g3", "gamma"),
+    ]);
+    state.pins_filter_query = "gamma".into(); // only row 2 visible
+    state.pins_index = 0; // first (and only) visible row
+    assert_eq!(state.selected_pin_index(), Some(2)); // TRUE index, not 0
+}
+
+#[test]
+fn pins_down_clamps_to_filtered_count() {
+    let mut state = state_with_pins(&[
+        ("/cwd/a", "g1", "a"),
+        ("/cwd/blua", "g2", "blua"),
+        ("/cwd/c", "g3", "c"),
+    ]);
+    state.pins_filter_query = "lua".into(); // 1 visible
+    state.handle_key(KeyCode::Down);
+    assert_eq!(state.pins_index, 0); // clamped to the single filtered row
+}
+
+#[test]
+fn pins_filter_input_behaviors() {
+    let mut state = state_with_pins(&[("/cwd/a", "g1", "a"), ("/cwd/b", "g2", "b")]);
+    state.pins_filtering = true;
+
+    // live nav while typing
+    state.handle_key(KeyCode::Down);
+    assert_eq!(state.pins_index, 1);
+    assert!(state.pins_filtering);
+
+    // Tab is a no-op (single pane)
+    state.handle_key(KeyCode::Char('a'));
+    state.handle_key(KeyCode::Tab);
+    assert!(state.pins_filtering);
+    assert_eq!(state.pins_filter_query, "a");
+
+    // Esc clears + exits
+    state.handle_key(KeyCode::Esc);
+    assert!(!state.pins_filtering);
+    assert_eq!(state.pins_filter_query, "");
+
+    // Backspace on empty exits
+    state.pins_filtering = true;
+    state.handle_key(KeyCode::Backspace);
+    assert!(!state.pins_filtering);
+
+    // Enter keeps query + exits
+    state.pins_filtering = true;
+    state.handle_key(KeyCode::Char('b'));
+    state.handle_key(KeyCode::Enter);
+    assert!(!state.pins_filtering);
+    assert_eq!(state.pins_filter_query, "b");
+}

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -42,6 +42,57 @@ fn state_with_many_files(n: usize) -> AppState {
     state
 }
 
+fn state_with_local_paths(paths: &[&str]) -> AppState {
+    let mut state = initial_state();
+    state.cwd = PathBuf::from("/cwd");
+    state.locals = paths
+        .iter()
+        .map(|p| LocalCandidate {
+            path: PathBuf::from(p),
+            pinned: false,
+            modified: None,
+        })
+        .collect();
+    state
+}
+
+#[test]
+fn local_filter_matches_filename_and_relative_path() {
+    let mut state =
+        state_with_local_paths(&["/cwd/settings.json", "/cwd/src/main.rs", "/cwd/notes.txt"]);
+
+    assert_eq!(state.visible_locals().len(), 3);
+
+    state.local_filter_query = "json".into();
+    let visible: Vec<_> = state
+        .visible_locals()
+        .iter()
+        .map(|r| r.candidate.path.clone())
+        .collect();
+    assert_eq!(visible, vec![PathBuf::from("/cwd/settings.json")]);
+
+    state.local_filter_query = "src/".into();
+    let visible: Vec<_> = state
+        .visible_locals()
+        .iter()
+        .map(|r| r.candidate.path.clone())
+        .collect();
+    assert_eq!(visible, vec![PathBuf::from("/cwd/src/main.rs")]);
+
+    state.local_filter_query = "NOTES".into();
+    assert_eq!(state.visible_locals().len(), 1);
+}
+
+#[test]
+fn local_down_clamps_to_filtered_count() {
+    let mut state = state_with_local_paths(&["/cwd/a.json", "/cwd/b.txt", "/cwd/c.txt"]);
+    state.focus = FocusPane::Local;
+    state.local_filter_query = "json".into(); // only 1 match
+
+    state.handle_key(KeyCode::Down); // would move to index 1 if clamped on raw len
+    assert_eq!(state.local_index, 0); // clamped: only one visible row
+}
+
 fn list_state_with_matches() -> AppState {
     let mut state = initial_state();
     state.locals = vec![

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -2643,3 +2643,101 @@ fn gist_group_row_shows_comment_marker_only_when_present() {
     assert!(!gist_group_row_label(&group, now, GistGroupSort::Updated, 0).contains('💬'));
     assert!(gist_group_row_label(&group, now, GistGroupSort::Updated, 3).contains("💬 3"));
 }
+
+#[test]
+fn list_filter_routes_chars_to_focused_pane() {
+    let mut state = state_with_local_paths(&["/cwd/a.json", "/cwd/b.txt"]);
+    state.focus = FocusPane::Local;
+    state.filtering = true;
+
+    state.handle_key(KeyCode::Char('j'));
+    state.handle_key(KeyCode::Char('s'));
+    assert_eq!(state.local_filter_query, "js");
+    assert_eq!(state.filter_query, ""); // gist pane untouched
+}
+
+#[test]
+fn list_filter_focus_gist_routes_to_gist_query() {
+    let mut state = state_with_local_paths(&["/cwd/a.json"]);
+    state.focus = FocusPane::Gist;
+    state.filtering = true;
+
+    state.handle_key(KeyCode::Char('x'));
+    assert_eq!(state.filter_query, "x");
+    assert_eq!(state.local_filter_query, "");
+}
+
+#[test]
+fn list_filter_navigates_while_typing() {
+    let mut state = state_with_local_paths(&["/cwd/a.txt", "/cwd/b.txt", "/cwd/c.txt"]);
+    state.focus = FocusPane::Local;
+    state.filtering = true;
+
+    state.handle_key(KeyCode::Down);
+    assert_eq!(state.local_index, 1);
+    assert!(state.filtering); // still in filter input
+    state.handle_key(KeyCode::Up);
+    assert_eq!(state.local_index, 0);
+}
+
+#[test]
+fn list_filter_empty_backspace_exits() {
+    let mut state = state_with_local_paths(&["/cwd/a.txt"]);
+    state.focus = FocusPane::Local;
+    state.filtering = true;
+
+    state.handle_key(KeyCode::Char('a'));
+    state.handle_key(KeyCode::Backspace); // back to empty, still filtering
+    assert!(state.filtering);
+    assert_eq!(state.local_filter_query, "");
+    state.handle_key(KeyCode::Backspace); // empty -> exit
+    assert!(!state.filtering);
+}
+
+#[test]
+fn list_filter_tab_commits_and_switches_pane() {
+    let mut state = state_with_local_paths(&["/cwd/a.json"]);
+    state.focus = FocusPane::Local;
+    state.filtering = true;
+    state.handle_key(KeyCode::Char('j'));
+
+    state.handle_key(KeyCode::Tab);
+    assert!(!state.filtering); // committed, left input
+    assert_eq!(state.local_filter_query, "j"); // query kept
+    assert_eq!(state.focus, FocusPane::Gist); // switched pane
+}
+
+#[test]
+fn list_filter_esc_clears_focused_query() {
+    let mut state = state_with_local_paths(&["/cwd/a.json"]);
+    state.focus = FocusPane::Local;
+    state.filtering = true;
+    state.handle_key(KeyCode::Char('j'));
+
+    state.handle_key(KeyCode::Esc);
+    assert!(!state.filtering);
+    assert_eq!(state.local_filter_query, "");
+}
+
+#[test]
+fn list_filter_char_resets_focused_index() {
+    let mut state = state_with_local_paths(&["/cwd/a.txt", "/cwd/ab.txt", "/cwd/abc.txt"]);
+    state.focus = FocusPane::Local;
+    state.filtering = true;
+    state.local_index = 2; // cursor not at top
+
+    state.handle_key(KeyCode::Char('a')); // edit -> reset to top
+    assert_eq!(state.local_index, 0);
+}
+
+#[test]
+fn list_filter_enter_keeps_query_and_exits() {
+    let mut state = state_with_local_paths(&["/cwd/a.json"]);
+    state.focus = FocusPane::Local;
+    state.filtering = true;
+    state.handle_key(KeyCode::Char('j'));
+
+    state.handle_key(KeyCode::Enter);
+    assert!(!state.filtering); // exited input
+    assert_eq!(state.local_filter_query, "j"); // query kept
+}

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -2741,3 +2741,62 @@ fn list_filter_enter_keeps_query_and_exits() {
     assert!(!state.filtering); // exited input
     assert_eq!(state.local_filter_query, "j"); // query kept
 }
+
+fn gists_screen_state() -> AppState {
+    let mut state = initial_state();
+    state.gists = vec![
+        GistFile {
+            gist_id: "g1".into(),
+            description: "alpha".into(),
+            filename: "a.txt".into(),
+            public: false,
+            updated_at: "2026-06-10T00:00:00Z".into(),
+            created_at: "2026-06-01T00:00:00Z".into(),
+        },
+        GistFile {
+            gist_id: "g2".into(),
+            description: "beta".into(),
+            filename: "b.txt".into(),
+            public: false,
+            updated_at: "2026-06-10T00:00:00Z".into(),
+            created_at: "2026-06-01T00:00:00Z".into(),
+        },
+    ];
+    state.screen = Screen::Gists;
+    state
+}
+
+#[test]
+fn gists_filter_navigates_while_typing() {
+    let mut state = gists_screen_state();
+    state.gists_filtering = true;
+
+    state.handle_key(KeyCode::Down);
+    assert_eq!(state.gists_index, 1);
+    assert!(state.gists_filtering);
+    state.handle_key(KeyCode::Up);
+    assert_eq!(state.gists_index, 0);
+}
+
+#[test]
+fn gists_filter_empty_backspace_exits() {
+    let mut state = gists_screen_state();
+    state.gists_filtering = true;
+
+    state.handle_key(KeyCode::Char('a'));
+    state.handle_key(KeyCode::Backspace); // empty again, still filtering
+    assert!(state.gists_filtering);
+    state.handle_key(KeyCode::Backspace); // empty -> exit
+    assert!(!state.gists_filtering);
+}
+
+#[test]
+fn gists_filter_tab_is_noop() {
+    let mut state = gists_screen_state();
+    state.gists_filtering = true;
+    state.handle_key(KeyCode::Char('a'));
+
+    state.handle_key(KeyCode::Tab);
+    assert!(state.gists_filtering); // still typing
+    assert_eq!(state.gists_filter_query, "a"); // unchanged
+}


### PR DESCRIPTION
## Summary

Adds a text filter to every list in the TUI and makes the inline text-filter input smoother and consistent. The `/` filter targets the **focused** pane on the List screen (Local = path/filename, Gist = description/id), the **Gist manager**, and now the **Pinned Mappings** screen — so every list can be narrowed the same way, and while filtering you can navigate without leaving the input.

Recursive local-file discovery (`r`) can surface a large flat list; the local and pins lists previously had no way to narrow them. This unifies the filter UX across all four lists.

## Changes

- **Local pane filter** — `/` filters the focused pane. The local query matches the cwd-relative display label (filename, or relative path in recursive mode); the two queries (local/gist) are independent and apply simultaneously. Navigation clamps to the filtered count.
- **Pins filter** — the Pinned Mappings screen (`P`) gains the same `/` filter, matching the local path or gist filename. Selection resolves through `visible_pin_indices()`/`selected_pin_index()` so unpin/sync/diff act on the **correct** pin under an active filter.
- **Smoother filter input (all screens)** — type to match; `↑/↓` live-navigate without exiting; `Enter` applies + keeps the query; `Esc` clears + exits; `Backspace` on an empty query exits. On the dual-pane List, `Tab` applies + switches pane; on the single-pane Gist-manager / Pins screens, `Tab` is a no-op.
- **Shared helper** — a pure `apply_filter_edit()` backs all filter sites.
- **Render** — each list shows a shown/total count, a "no match" row, and the active query in its title; filter footers are consistent.
- **Docs** — `?` help overlay, README keymap, and `CHANGELOG` (`[Unreleased]`) updated in lockstep.
- **Version** — `Cargo.toml` bumped `0.9.0 → 0.10.0` (final commit) in preparation; the CHANGELOG stays at `[Unreleased]` until the release tag is cut.

## Testing

- [x] `cargo fmt --check`
- [x] `cargo test` (276 unit + 12 integration, all green; new tests cover routing, live nav, Tab semantics, Esc/Enter/Backspace edge cases, filtered-count clamps, and the critical pin index-resolution-through-filter)
- [x] `cargo check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Manual TUI run — not performed; render changes are an untested IO boundary by design, covered by code review. Demo GIF not regenerated (the storyboard doesn't exercise filtering).

## Related Issues

None.