### PR TITLE
docs: extract the release runbook into RELEASING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,35 +48,9 @@ Key points:
 3. Open a PR against `main`; the CI gate must be green.
 4. **Label the PR** so it lands in the right release-note section (`.github/release.yml`): `enhancement` (Features), `bug` (Bug Fixes), `documentation` (Documentation), `dependencies`, or `skip-changelog` to omit it. Unlabeled PRs fall under "Other Changes".
 
-## Releasing & publishing to crates.io
+## Releasing
 
-The crate is packaging-ready (`cargo publish --dry-run` passes; `Cargo.toml` `exclude`
-keeps the demo harness, site assets and CI config out of the published tarball). Publishing
-is automated by `.github/workflows/publish.yml`, which runs on each `vX.Y.Z` tag and no-ops
-until the registry token is set.
-
-**One-time crates.io setup** (owner):
-
-- [ ] Create a [crates.io](https://crates.io) account (sign in with GitHub) and verify your email.
-- [ ] Generate a scoped API token (Account Settings → API Tokens) with `publish-new` + `publish-update`, scoped to the `gistui` crate once it exists.
-- [ ] Add it as a repository secret named `CARGO_REGISTRY_TOKEN` (Settings → Secrets and variables → Actions).
-
-**First publish:**
-
-- [ ] Confirm `Cargo.toml` `version` is correct and `cargo publish --dry-run` is clean.
-- [ ] Either push the matching tag (`git tag vX.Y.Z && git push origin vX.Y.Z`) — `publish.yml` then publishes — or run the **Publish to crates.io** workflow manually (Actions tab → Run workflow), or publish locally with `cargo publish`.
-- [ ] Verify the crate at `https://crates.io/crates/gistui` and that docs.rs built.
-
-**Post-publish docs** (add once the crate is live):
-
-- [x] Add a crates.io badge under the README title:
-  ```markdown
-  [![crates.io](https://img.shields.io/crates/v/gistui.svg)](https://crates.io/crates/gistui)
-  ```
-- [x] Add a `cargo install gistui` option to the README install section.
-- [x] Add `[package.metadata.binstall]` and verify `cargo binstall --dry-run gistui` (see issue #93).
-
-**Ongoing:** each release is a `vX.Y.Z` tag matching `Cargo.toml`; the tag triggers both the binary release (`release.yml`) and the crates.io publish (`publish.yml`). The [Homebrew tap](https://github.com/akunzai/homebrew-tap) and [Scoop bucket](https://github.com/akunzai/scoop-bucket) both update themselves via their scheduled workflows (`brew livecheck` bump / `checkver` + `autoupdate` Excavator), so neither needs a manual bump on release.
+Maintainers: see [RELEASING.md](RELEASING.md) for the release and crates.io publish process.
 
 ## Reporting Issues
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,35 @@
+# Releasing
+
+The maintainer/owner runbook for cutting a gistui release. Contributors don't need any of
+this — see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## How a release works
+
+A release is a `vX.Y.Z` git tag that matches `Cargo.toml`'s `version`. Pushing the tag
+triggers the full pipeline:
+
+- `.github/workflows/release.yml` — builds and attaches the platform binaries.
+- `.github/workflows/publish.yml` — publishes the crate to
+  [crates.io](https://crates.io/crates/gistui).
+
+The crate is published and the `CARGO_REGISTRY_TOKEN` secret is configured, so the publish
+step runs automatically on tag. The downstream package definitions update themselves on a
+schedule — no manual bump on release:
+
+- [Homebrew tap](https://github.com/akunzai/homebrew-tap) — `brew livecheck` scheduled bump.
+- [Scoop bucket](https://github.com/akunzai/scoop-bucket) — `checkver` + `autoupdate` Excavator.
+
+Packaging stays lean via `Cargo.toml` `exclude` (the demo harness, site assets and CI config
+are kept out of the published tarball); `cargo publish --dry-run` validates the tarball.
+
+## Cutting a release
+
+1. Bump `version` in `Cargo.toml` (and refresh `Cargo.lock`); confirm `cargo publish --dry-run`
+   is clean.
+2. In `CHANGELOG.md`, rename the `## [Unreleased]` section to a dated `## [X.Y.Z] — YYYY-MM-DD`
+   heading and add its release link reference at the bottom.
+3. Merge to `main` (CI gate green).
+4. Tag and push: `git tag vX.Y.Z && git push origin vX.Y.Z`.
+5. Verify: the GitHub release has the binaries, [crates.io](https://crates.io/crates/gistui)
+   shows the new version (and docs.rs built), and the Homebrew tap / Scoop bucket pick it up
+   on their next scheduled run.


### PR DESCRIPTION
## Summary

The `## Releasing & publishing to crates.io` section lived in `CONTRIBUTING.md`, but it is a maintainer/owner runbook — not something contributors need. This moves it to a new `RELEASING.md` and refreshes it to current reality.

## Changes

- New `RELEASING.md`: a forward-looking "how to cut a release" runbook.
  - crates.io is **already published** and `CARGO_REGISTRY_TOKEN` is configured, so publishing runs automatically on a `vX.Y.Z` tag — dropped the stale one-time-setup / first-publish `[ ]` checklists that presented finished work as pending.
  - Documents that the Homebrew tap and Scoop bucket auto-update on a schedule (no manual bump).
  - Concise step list for actually cutting a release (bump, date CHANGELOG, merge, tag, verify).
- `CONTRIBUTING.md`: the section is replaced with a short `## Releasing` pointer to `RELEASING.md`.

No behavior or build change; docs only.

## Related Issues

None.