### PR TITLE
feat: contextual help with topic sub-screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `?` help is now contextual: it opens the current screen's keys (and is reachable from the Pins, Gist manager, and Gist detail screens, not just the list), with `Tab` to browse an index of all topics instead of scrolling one long page.
 - Local file list now has a text filter: `/` filters the focused pane (Local matches path/filename, Gist matches description/id). Filtering supports typing-while-navigating (↑/↓), `Tab` to apply and switch panes, and `Backspace` on an empty query to exit.
 - The Pinned Mappings screen (`P`) gained the same `/` text filter — matches the local path or gist filename, with live ↑/↓ navigation.
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ side instead. Ranked rows are flagged with `📌` (an existing pinned pair) or *
 same-filename candidate). Browse with `Tab` (switch pane) or `1`/`2` (jump to the Local /
 Gist pane), `Up`/`Down` (move), and `Left`/`Right` (scroll a long row).
 
+Press `?` in the app for the full keymap — it now opens the **current screen's** keys, and
+`Tab` browses all topics (List, Pins, Gist manager, Gist detail, Diff, Preview, …).
+
+<details>
+<summary>Full keymap (all actions & per-screen keys)</summary>
+
 ### Actions
 
 - `Enter` (on a gist) — preview the unified diff between the selected local file and the
@@ -266,6 +272,8 @@ the gist owning the currently selected file. From here you manage gists as a who
 - `s` cycle sort (updated / created) · `v` cycle visibility (all/public/secret) · `/` filter
   by description or id (↑/↓ move · Enter apply · Esc clear) · `Left`/`Right` scroll a long description.
 - `q`/`Esc` — back to the list.
+
+</details>
 
 ## Safety rules
 

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -21,23 +21,65 @@ impl AppState {
         }
     }
 
+    /// Open the Help screen on the topic for the current screen, remembering where to return.
+    fn open_help(&mut self) {
+        self.help_return = self.screen;
+        self.help_topic = HelpTopic::for_screen(self.screen);
+        self.help_index_open = false;
+        self.help_scroll = 0;
+        self.screen = Screen::Help;
+    }
+
     fn handle_key_help(&mut self, code: KeyCode) -> KeyOutcome {
-        match code {
-            KeyCode::Down => {
-                self.help_scroll = self.help_scroll.saturating_add(1);
-                KeyOutcome::None
+        let topics = HelpTopic::all();
+        if self.help_index_open {
+            match code {
+                KeyCode::Up => self.help_index_sel = self.help_index_sel.saturating_sub(1),
+                KeyCode::Down => {
+                    if self.help_index_sel + 1 < topics.len() {
+                        self.help_index_sel += 1;
+                    }
+                }
+                KeyCode::Enter => {
+                    self.help_topic = topics[self.help_index_sel];
+                    self.help_index_open = false;
+                    self.help_scroll = 0;
+                }
+                KeyCode::Char(c @ '1'..='8') => {
+                    self.help_topic = topics[(c as u8 - b'1') as usize];
+                    self.help_index_open = false;
+                    self.help_scroll = 0;
+                }
+                KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => {
+                    self.screen = self.help_return;
+                    self.help_index_open = false;
+                    self.help_scroll = 0;
+                }
+                _ => {}
             }
-            KeyCode::Up => {
-                self.help_scroll = self.help_scroll.saturating_sub(1);
-                KeyOutcome::None
-            }
-            _ => {
-                // Any other key just closes the help overlay back to the list.
-                self.screen = Screen::List;
-                self.help_scroll = 0;
-                KeyOutcome::None
+        } else {
+            match code {
+                KeyCode::Down => self.help_scroll = self.help_scroll.saturating_add(1),
+                KeyCode::Up => self.help_scroll = self.help_scroll.saturating_sub(1),
+                KeyCode::Tab => {
+                    self.help_index_sel = topics
+                        .iter()
+                        .position(|&t| t == self.help_topic)
+                        .unwrap_or(0);
+                    self.help_index_open = true;
+                }
+                KeyCode::Char(c @ '1'..='8') => {
+                    self.help_topic = topics[(c as u8 - b'1') as usize];
+                    self.help_scroll = 0;
+                }
+                KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => {
+                    self.screen = self.help_return;
+                    self.help_scroll = 0;
+                }
+                _ => {}
             }
         }
+        KeyOutcome::None
     }
 
     fn handle_key_pins(&mut self, code: KeyCode) -> KeyOutcome {
@@ -96,6 +138,7 @@ impl AppState {
             KeyCode::Char('s') if !self.pinned.is_empty() => return KeyOutcome::SyncPinAuto,
             KeyCode::Char('u') if !self.pinned.is_empty() => return KeyOutcome::SyncPinPush,
             KeyCode::Char('d') if !self.pinned.is_empty() => return KeyOutcome::SyncPinPull,
+            KeyCode::Char('?') => self.open_help(),
             _ => {}
         }
         KeyOutcome::None
@@ -219,6 +262,7 @@ impl AppState {
                     self.screen = Screen::Confirm;
                 }
             }
+            KeyCode::Char('?') => self.open_help(),
             _ => {}
         }
         KeyOutcome::None
@@ -294,6 +338,7 @@ impl AppState {
                     }
                 }
             }
+            KeyCode::Char('?') => self.open_help(),
             _ => {}
         }
         KeyOutcome::None
@@ -514,7 +559,7 @@ impl AppState {
             }
             KeyCode::Char('/') => self.filtering = true,
             KeyCode::Char('y') => return KeyOutcome::CopyGistUrl,
-            KeyCode::Char('?') => self.screen = Screen::Help,
+            KeyCode::Char('?') => self.open_help(),
             KeyCode::Char('P') => {
                 self.pins_index = 0;
                 self.pins_hscroll = 0;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -28,6 +28,61 @@ pub enum Screen {
     GistDetail,
 }
 
+/// A help topic — one per key-dense area. Ordered for the index list and `1`-`8` quick-jump.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HelpTopic {
+    List,
+    Pins,
+    GistManager,
+    GistDetail,
+    Diff,
+    Preview,
+    Upload,
+    General,
+}
+
+impl HelpTopic {
+    /// All topics in index / quick-jump order.
+    pub fn all() -> [HelpTopic; 8] {
+        use HelpTopic::*;
+        [
+            List,
+            Pins,
+            GistManager,
+            GistDetail,
+            Diff,
+            Preview,
+            Upload,
+            General,
+        ]
+    }
+
+    /// Short title shown in the index and the topic-view block title.
+    pub fn title(self) -> &'static str {
+        match self {
+            HelpTopic::List => "List screen",
+            HelpTopic::Pins => "Pinned Mappings",
+            HelpTopic::GistManager => "Gist manager",
+            HelpTopic::GistDetail => "Gist detail",
+            HelpTopic::Diff => "Diff view",
+            HelpTopic::Preview => "Preview",
+            HelpTopic::Upload => "Upload confirmation",
+            HelpTopic::General => "General",
+        }
+    }
+
+    /// The topic to open when `?` is pressed on a given screen. Non-key-dense screens
+    /// fall back to the List topic.
+    pub fn for_screen(screen: Screen) -> HelpTopic {
+        match screen {
+            Screen::Pins => HelpTopic::Pins,
+            Screen::Gists => HelpTopic::GistManager,
+            Screen::GistDetail => HelpTopic::GistDetail,
+            _ => HelpTopic::List,
+        }
+    }
+}
+
 /// Which tab `Screen::GistDetail` shows, and which the navigation keys drive: the file list
 /// or the comments (only one is visible at a time). Defaults to `Files` — the gist's primary
 /// content — with the comments one `Tab` away.
@@ -321,6 +376,14 @@ pub struct AppState {
     /// other key clears it. Prevents an accidental single-key exit.
     pub quit_armed: bool,
     pub help_scroll: u16,
+    /// Screen to return to when leaving Help (mirrors `preview_return` / `diff_return`).
+    pub help_return: Screen,
+    /// The topic shown in the Help screen's topic view.
+    pub help_topic: HelpTopic,
+    /// When true the Help screen shows the topic index instead of a topic body.
+    pub help_index_open: bool,
+    /// Highlighted row in the Help topic index.
+    pub help_index_sel: usize,
     pub upload_original_content: String,
     pub upload_edited_content: Option<String>,
     pub upload_json_pretty: bool,
@@ -880,6 +943,10 @@ pub fn initial_state() -> AppState {
         bg_task_msg: None,
         quit_armed: false,
         help_scroll: 0,
+        help_return: Screen::List,
+        help_topic: HelpTopic::List,
+        help_index_open: false,
+        help_index_sel: 0,
         upload_original_content: String::new(),
         upload_edited_content: None,
         upload_json_pretty: false,

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -38,9 +38,10 @@ pub(super) fn count_label(shown: usize, total: usize) -> String {
     }
 }
 
-pub(super) fn render_help(frame: &mut Frame, state: &AppState) {
-    // The repo URL and version live in the footer on every screen, so help is keys only.
-    let body = "\
+fn help_topic_body(topic: HelpTopic) -> &'static str {
+    match topic {
+        HelpTopic::List => {
+            "\
 Navigation
   Tab        switch pane (Local / Gists)
   1 / 2      jump to the Local / Gist pane
@@ -73,9 +74,10 @@ Actions (on the selected local file + gist)
   X          remove the selected file from its gist (y/n confirm)
   g          open the gist manager (edit description, delete gist)
   e          edit the local file in $EDITOR
-  y          copy the selected gist's URL to the system clipboard
-
-Pinned Mappings screen (P)
+  y          copy the selected gist's URL to the system clipboard"
+        }
+        HelpTopic::Pins => {
+            "\
   Up/Down    move between pins
   Left/Right scroll a long local path horizontally (~ = home)
   /          filter pins by path or filename (↑↓ move · Enter apply · Esc clear)
@@ -85,33 +87,10 @@ Pinned Mappings screen (P)
   d          force pull  (download gist → local, diff + y/n confirm)
   x          unpin the selected pair
   status     ✓ synced · ↑ local newer · ↓ remote newer · ? unknown
-  Each row shows (local <age> · gist <age>) relative modification times.
-
-Diff view (Enter / d / u)
-  Up/Down/Left/Right  scroll the diff
-  PageUp/Dn  scroll the diff by 10 lines
-  c          toggle context: configured radius <-> full file (remembered)
-  d / u      download / upload from the diff
-  syntax     unchanged context lines are syntax-highlighted by file type
-  Esc / q    back
-
-Full-screen preview (Space, or 1-9 in the detail view)
-  Up/Down/Left/Right  scroll (Left/Right only when wrap is off)
-  PageUp/Dn  scroll by 10 lines
-  w          toggle soft line wrapping (remembered for the session)
-  y          copy the gist URL · Y copy the file content to the clipboard
-  syntax     known file types are syntax-highlighted
-  R          re-fetch the content
-  Esc / q    back
-
-Upload Confirmation screen (u)
-  y          confirm and execute the upload
-  n / Esc    cancel the upload
-  e          edit / redact the upload content in $EDITOR before upload
-  p          (JSON only) toggle pretty-print formatting
-  s          (JSON only) toggle recursive key sorting
-
-Gist manager (g)
+  Each row shows (local <age> · gist <age>) relative modification times."
+        }
+        HelpTopic::GistManager => {
+            "\
   Up/Down    move between gists
   Left/Right scroll a long description horizontally
   /          filter gists by description or id (↑↓ move · Enter apply · Esc clear)
@@ -123,9 +102,10 @@ Gist manager (g)
   y          copy the gist's URL to the system clipboard
   c          compact revisions: squash history to one commit (force-push, y/n confirm)
   X          delete the entire gist and all its files (y/n confirm)
-  q / Esc    back to the list
-
-Gist detail (Enter from gist manager)
+  q / Esc    back to the list"
+        }
+        HelpTopic::GistDetail => {
+            "\
   Tab        switch tab: Files / Comments (one shows at a time; opens on Files)
   Up/Down    move the file cursor (Files tab) or scroll comments (Comments tab)
   PageUp/Dn  page comments / file cursor by 10
@@ -135,24 +115,88 @@ Gist detail (Enter from gist manager)
   o          open the gist in your web browser
   y          copy the gist's URL to the system clipboard
   X          delete the entire gist and all its files (y/n confirm)
-  q / Esc    back to the gist manager
-
-General
+  q / Esc    back to the gist manager"
+        }
+        HelpTopic::Diff => {
+            "\
+  Up/Down/Left/Right  scroll the diff
+  PageUp/Dn  scroll the diff by 10 lines
+  c          toggle context: configured radius <-> full file (remembered)
+  d / u      download / upload from the diff
+  syntax     unchanged context lines are syntax-highlighted by file type
+  Esc / q    back"
+        }
+        HelpTopic::Preview => {
+            "\
+  Up/Down/Left/Right  scroll (Left/Right only when wrap is off)
+  PageUp/Dn  scroll by 10 lines
+  w          toggle soft line wrapping (remembered for the session)
+  y          copy the gist URL · Y copy the file content to the clipboard
+  syntax     known file types are syntax-highlighted
+  R          re-fetch the content
+  Esc / q    back"
+        }
+        HelpTopic::Upload => {
+            "\
+  y          confirm and execute the upload
+  n / Esc    cancel the upload
+  e          edit / redact the upload content in $EDITOR before upload
+  p          (JSON only) toggle pretty-print formatting
+  s          (JSON only) toggle recursive key sorting"
+        }
+        HelpTopic::General => {
+            "\
   Esc / q    close an overlay; from the list, press twice to quit the app
   ?          show this help
   Up/Down    scroll this help text
-  NO_COLOR   set this env var to disable syntax highlighting (preview + diff)";
+  NO_COLOR   set this env var to disable syntax highlighting (preview + diff)"
+        }
+    }
+}
 
-    frame.render_widget(
-        Paragraph::new(body).scroll((state.help_scroll, 0)).block(
-            Block::default()
-                .title("Help (Up/Down scroll) — press any other key to close")
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded)
-                .padding(Padding::horizontal(1)),
-        ),
-        frame.area(),
-    );
+pub(super) fn render_help(frame: &mut Frame, state: &AppState) {
+    if state.help_index_open {
+        let items: Vec<ListItem> = HelpTopic::all()
+            .iter()
+            .enumerate()
+            .map(|(i, t)| ListItem::new(format!("  {}  {}", i + 1, t.title())))
+            .collect();
+        let list = List::new(items)
+            .block(
+                Block::default()
+                    .title("Help — pick a topic (1-8 / ↑↓ Enter · Esc back)")
+                    .borders(Borders::ALL)
+                    .border_type(BorderType::Rounded)
+                    .padding(Padding::horizontal(1)),
+            )
+            .highlight_style(
+                Style::default()
+                    .bg(Color::Cyan)
+                    .fg(Color::Black)
+                    .add_modifier(Modifier::BOLD),
+            )
+            .highlight_symbol("▶ ");
+        let mut list_state = ListState::default();
+        list_state.select(Some(state.help_index_sel));
+        frame.render_stateful_widget(list, frame.area(), &mut list_state);
+    } else {
+        let title = format!(
+            "Help · {} — Tab topics · ↑↓ scroll · Esc back",
+            state.help_topic.title()
+        );
+        frame.render_widget(
+            Paragraph::new(help_topic_body(state.help_topic))
+                .scroll((state.help_scroll, 0))
+                .block(
+                    Block::default()
+                        .title(title)
+                        .borders(Borders::ALL)
+                        .border_type(BorderType::Rounded)
+                        .padding(Padding::horizontal(1)),
+                ),
+            frame.area(),
+        );
+    }
 }
 
 /// Lowercase file extension of a filename or path string, if any.
@@ -248,7 +292,7 @@ pub(super) fn render_pins(frame: &mut Frame, state: &AppState) {
     let hints = if state.pinned.is_empty() {
         "Esc/q back"
     } else {
-        "↑↓ move · ←→ scroll · / filter · Enter diff · s sync · u push · d pull · x unpin  ·  ✓ synced ↑ local-newer ↓ remote-newer ? n/a  ·  Esc/q back"
+        "↑↓ move · ←→ scroll · / filter · Enter diff · s sync · u push · d pull · x unpin · ? help  ·  ✓ synced ↑ local-newer ↓ remote-newer ? n/a  ·  Esc/q back"
     };
     let (ftitle, footer, colored) = if state.pins_filtering {
         (
@@ -386,7 +430,7 @@ pub(super) fn render_gists(frame: &mut Frame, state: &AppState) {
     } else {
         (
             String::new(),
-            "↑↓ move · ←→ scroll · Enter detail · / filter · s sort · v type · e desc · o browser · c compact · X delete · q back"
+            "↑↓ move · ←→ scroll · Enter detail · / filter · s sort · v type · e desc · o browser · c compact · X delete · ? help · q back"
                 .to_string(),
             true,
         )
@@ -704,10 +748,10 @@ pub(super) fn footer_with_status(status: Option<&str>, hints: &str) -> (String, 
 pub(super) fn detail_footer(status: Option<&str>, focus: DetailFocus) -> (String, bool) {
     let hints = match focus {
         DetailFocus::Comments => {
-            "Tab files · ↑↓ scroll · 1-9 preview · c compact · o browser · X delete · q back"
+            "Tab files · ↑↓ scroll · 1-9 preview · c compact · o browser · X delete · ? help · q back"
         }
         DetailFocus::Files => {
-            "Tab comments · ↑↓ select · ⏎ preview · 1-9 preview · c compact · o browser · X delete · q back"
+            "Tab comments · ↑↓ select · ⏎ preview · 1-9 preview · c compact · o browser · X delete · ? help · q back"
         }
     };
     footer_with_status(status, hints)

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -958,24 +958,23 @@ fn page_up_saturates_at_top_in_diff() {
 }
 
 #[test]
-fn question_opens_help_and_any_key_closes_it() {
+fn question_opens_contextual_help_from_list() {
     let mut state = initial_state();
     state.handle_key(KeyCode::Char('?'));
     assert_eq!(state.screen, Screen::Help);
-    // Arrow keys scroll help instead of closing
+    assert_eq!(state.help_topic, HelpTopic::List);
+    assert_eq!(state.help_return, Screen::List);
+    assert!(!state.help_index_open);
+    // Arrow keys scroll help
     state.handle_key(KeyCode::Down);
     assert_eq!(state.screen, Screen::Help);
     assert_eq!(state.help_scroll, 1);
     state.handle_key(KeyCode::Up);
     assert_eq!(state.screen, Screen::Help);
     assert_eq!(state.help_scroll, 0);
-    // Other keys close help
-    assert_eq!(state.handle_key(KeyCode::Char('x')), KeyOutcome::None);
-    assert_eq!(state.screen, Screen::List);
-    // Closing resets scroll
-    state.screen = Screen::Help;
+    // Esc closes help and resets scroll
     state.help_scroll = 5;
-    state.handle_key(KeyCode::Char('q'));
+    state.handle_key(KeyCode::Esc);
     assert_eq!(state.screen, Screen::List);
     assert_eq!(state.help_scroll, 0);
 }
@@ -2913,4 +2912,82 @@ fn help_topic_for_screen_maps_key_dense_screens() {
         HelpTopic::GistDetail
     );
     assert_eq!(HelpTopic::for_screen(Screen::Diff), HelpTopic::List);
+}
+
+#[test]
+fn question_mark_opens_contextual_help_from_pins() {
+    let mut state = initial_state();
+    state.screen = Screen::Pins;
+    state.handle_key(KeyCode::Char('?'));
+    assert_eq!(state.screen, Screen::Help);
+    assert_eq!(state.help_topic, HelpTopic::Pins);
+    assert_eq!(state.help_return, Screen::Pins);
+    assert!(!state.help_index_open);
+}
+
+#[test]
+fn help_topic_view_tab_opens_index_at_current_topic() {
+    let mut state = initial_state();
+    state.screen = Screen::Help;
+    state.help_topic = HelpTopic::GistManager; // index 2
+    state.handle_key(KeyCode::Tab);
+    assert!(state.help_index_open);
+    assert_eq!(state.help_index_sel, 2);
+}
+
+#[test]
+fn help_topic_view_number_switches_topic() {
+    let mut state = initial_state();
+    state.screen = Screen::Help;
+    state.help_topic = HelpTopic::List;
+    state.help_scroll = 5;
+    state.handle_key(KeyCode::Char('2')); // 2 -> Pins (index 1)
+    assert_eq!(state.help_topic, HelpTopic::Pins);
+    assert_eq!(state.help_scroll, 0);
+    assert!(!state.help_index_open);
+}
+
+#[test]
+fn help_topic_view_esc_returns_to_origin() {
+    let mut state = initial_state();
+    state.screen = Screen::Help;
+    state.help_return = Screen::Gists;
+    state.handle_key(KeyCode::Esc);
+    assert_eq!(state.screen, Screen::Gists);
+}
+
+#[test]
+fn help_index_navigates_and_enter_opens_topic() {
+    let mut state = initial_state();
+    state.screen = Screen::Help;
+    state.help_index_open = true;
+    state.help_index_sel = 0;
+    state.handle_key(KeyCode::Down); // -> 1
+    state.handle_key(KeyCode::Down); // -> 2 (GistManager)
+    assert_eq!(state.help_index_sel, 2);
+    state.handle_key(KeyCode::Enter);
+    assert!(!state.help_index_open);
+    assert_eq!(state.help_topic, HelpTopic::GistManager);
+}
+
+#[test]
+fn help_index_esc_returns_to_origin() {
+    let mut state = initial_state();
+    state.screen = Screen::Help;
+    state.help_index_open = true;
+    state.help_return = Screen::List;
+    state.handle_key(KeyCode::Esc);
+    assert_eq!(state.screen, Screen::List);
+    assert!(!state.help_index_open);
+}
+
+#[test]
+fn help_index_question_mark_exits_help() {
+    let mut state = initial_state();
+    state.screen = Screen::Help;
+    state.help_index_open = true;
+    state.help_return = Screen::Pins;
+    state.handle_key(KeyCode::Char('?'));
+    assert_eq!(state.screen, Screen::Pins);
+    assert!(!state.help_index_open);
 }

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -2893,3 +2893,24 @@ fn pins_filter_input_behaviors() {
     assert!(!state.pins_filtering);
     assert_eq!(state.pins_filter_query, "b");
 }
+
+#[test]
+fn help_topic_all_is_ordered_and_titled() {
+    let all = HelpTopic::all();
+    assert_eq!(all.len(), 8);
+    assert_eq!(all[0], HelpTopic::List);
+    assert_eq!(all[7], HelpTopic::General);
+    assert_eq!(HelpTopic::Pins.title(), "Pinned Mappings");
+}
+
+#[test]
+fn help_topic_for_screen_maps_key_dense_screens() {
+    assert_eq!(HelpTopic::for_screen(Screen::List), HelpTopic::List);
+    assert_eq!(HelpTopic::for_screen(Screen::Pins), HelpTopic::Pins);
+    assert_eq!(HelpTopic::for_screen(Screen::Gists), HelpTopic::GistManager);
+    assert_eq!(
+        HelpTopic::for_screen(Screen::GistDetail),
+        HelpTopic::GistDetail
+    );
+    assert_eq!(HelpTopic::for_screen(Screen::Diff), HelpTopic::List);
+}


### PR DESCRIPTION
## Summary

The `?` help was one ~98-line scrollable page listing every screen's keys at once. It's now **contextual**: pressing `?` opens the keys for the screen you're on, and `Tab` opens an index to browse all topics. The long README Usage section is folded behind `<details>`.

## Changes

- **Contextual entry** — `?` opens the current screen's topic. Wired into the key-dense screens: List, Pins, Gist manager, Gist detail (Diff/Preview/Confirm keep their footer hints; their topics are still browsable from the index).
- **Two-mode Help screen** — topic view (`↑↓` scroll · `Tab` → index · `1`–`8` quick-jump · `Esc`/`q`/`?` back to the originating screen) and index view (a selectable list of the 8 topics: List, Pins, Gist manager, Gist detail, Diff, Preview, Upload, General).
- **No content lost** — the existing help text is split verbatim into per-topic bodies (regrouped only; the 8 topic bodies concatenate to the old page exactly).
- **README** — keeps a concise Usage core, adds a pointer to the in-app `?`, and folds the detailed keymap into a `<details>` block.
- `?` help reachable from Pins/Gist manager/Gist detail (previously only the list).

## Testing

- [x] `cargo fmt --check`
- [x] `cargo test` (285 unit + 12 integration; new tests cover the topic/index state machine, `?` from each screen, `Tab`→index round-trip, `1`–`8` jump, Esc-to-origin)
- [x] `cargo check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Manual TUI run — not performed; `render.rs` is an untested IO boundary by design, covered by code review.

## Related Issues

None.