### PR TITLE
fix: make pin times consistent between Pins list and diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `?` help is now contextual: it opens the current screen's keys (and is reachable from the Pins, Gist manager, and Gist detail screens, not just the list), with `Tab` to browse an index of all topics instead of scrolling one long page.
 - Local file list now has a text filter: `/` filters the focused pane (Local matches path/filename, Gist matches description/id). Filtering supports typing-while-navigating (↑/↓), `Tab` to apply and switch panes, and `Backspace` on an empty query to exit.
 - The Pinned Mappings screen (`P`) gained the same `/` text filter — matches the local path or gist filename, with live ↑/↓ navigation.
+- Pin times are now consistent between the Pins list and the diff view: pins pointing outside the scanned working directory show the real local mtime (and a correct ↑/↓ sync status) instead of `?`, and the pin diff header shows the gist's update time instead of `unknown`.
 
 ## [0.9.0] — 2026-06-14
 

--- a/src/local.rs
+++ b/src/local.rs
@@ -9,6 +9,16 @@ use std::path::Path;
 /// returned (original behaviour). When `recursive` is true the tree is
 /// walked up to 10 levels deep; hidden directories (name starts with `.`)
 /// and names in `skip_dirs` are skipped.
+/// File modification time as Unix seconds, or `None` when it can't be read
+/// (missing file, permission error, or a pre-epoch timestamp).
+pub fn file_mtime_secs(path: &Path) -> Option<u64> {
+    std::fs::metadata(path)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs())
+}
+
 pub fn discover_local_candidates(
     cwd: &Path,
     pinned: &[PinnedMapping],
@@ -36,11 +46,7 @@ pub fn discover_local_candidates(
         .into_iter()
         .map(|path| {
             let pinned_match = pinned.iter().any(|m| m.local_path == path);
-            let modified = std::fs::metadata(&path)
-                .and_then(|m| m.modified())
-                .ok()
-                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                .map(|d| d.as_secs());
+            let modified = file_mtime_secs(&path);
             LocalCandidate {
                 path,
                 pinned: pinned_match,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1020,7 +1020,9 @@ pub fn run() -> Result<()> {
 }
 
 impl AppState {
-    /// `(local_ts, remote_ts)` Unix-seconds for `pinned[index]`, from in-memory data.
+    /// `(local_ts, remote_ts)` Unix-seconds for `pinned[index]`. The remote side comes
+    /// from the matching gist's in-memory `updated_at`; the local side prefers the
+    /// discovered candidate's mtime and falls back to stat-ing the path on disk.
     pub fn pin_mtimes(&self, index: usize) -> (Option<u64>, Option<u64>) {
         let Some(m) = self.pinned.get(index) else {
             return (None, None);
@@ -1030,14 +1032,21 @@ impl AppState {
         } else {
             self.cwd.join(&m.local_path)
         };
-        let local_ts = self.locals.iter().find_map(|c| {
-            let cabs = if c.path.is_absolute() {
-                c.path.clone()
-            } else {
-                self.cwd.join(&c.path)
-            };
-            (cabs == local_abs).then_some(c.modified).flatten()
-        });
+        let local_ts = self
+            .locals
+            .iter()
+            .find_map(|c| {
+                let cabs = if c.path.is_absolute() {
+                    c.path.clone()
+                } else {
+                    self.cwd.join(&c.path)
+                };
+                (cabs == local_abs).then_some(c.modified).flatten()
+            })
+            // Pins can point outside cwd (or into skipped/too-deep dirs), so they
+            // never appear in `self.locals`. Fall back to stat-ing the path so the
+            // Pins list and sync status still reflect the real mtime.
+            .or_else(|| crate::local::file_mtime_secs(&local_abs));
         let remote_ts = self.gists.iter().find_map(|g| {
             (g.gist_id == m.gist_id && g.filename == m.gist_filename)
                 .then(|| crate::domain::parse_rfc3339_to_unix(&g.updated_at))

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -1063,12 +1063,20 @@ fn spawn_pin_diff(state: &mut AppState, bg_rx: &mut BgRx, m: &crate::domain::Pin
     let local_abs = pin_local_abs(state, m);
     let gist_id = m.gist_id.clone();
     let filename = m.gist_filename.clone();
+    // Pull the real `updated_at` from the loaded gists so the diff header shows the
+    // gist mtime (matching the Pins list) instead of "unknown".
+    let updated_at = state
+        .gists
+        .iter()
+        .find(|g| g.gist_id == gist_id && g.filename == filename)
+        .map(|g| g.updated_at.clone())
+        .unwrap_or_default();
     let gist_file = GistFile {
         gist_id: gist_id.clone(),
         description: String::new(),
         filename: filename.clone(),
         public: false,
-        updated_at: String::new(),
+        updated_at,
         created_at: String::new(),
     };
     let (local_label, gist_label) = diff_labels(Some(&local_abs), &gist_file);

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -2991,3 +2991,28 @@ fn help_index_question_mark_exits_help() {
     assert_eq!(state.screen, Screen::Pins);
     assert!(!state.help_index_open);
 }
+
+#[test]
+fn pin_mtimes_local_falls_back_to_disk_when_not_discovered() {
+    // A pin pointing outside cwd is absent from state.locals, but the Pins list
+    // and sync status should still reflect the file's real mtime by stat-ing it.
+    let dir = tempfile::tempdir().unwrap();
+    let outside = dir.path().join("settings.json");
+    std::fs::write(&outside, "{}").unwrap();
+
+    let mut state = initial_state();
+    state.locals.clear();
+    state.pinned = vec![crate::domain::PinnedMapping {
+        local_path: outside.clone(),
+        gist_id: "g1".into(),
+        gist_filename: "settings.json".into(),
+        direction: None,
+        last_seen_hash: None,
+    }];
+
+    let (local_ts, _remote_ts) = state.pin_mtimes(0);
+    assert!(
+        local_ts.is_some(),
+        "local mtime should fall back to disk for pins outside cwd"
+    );
+}


### PR DESCRIPTION
## Summary

Two display inconsistencies in the Pins screen, both fixed:

- **Local time `?` vs real mtime.** Pins pointing outside the scanned working directory (or into skipped/too-deep dirs) never appear in the discovered local candidates, so the Pins list showed `local ?` and a `? (n/a)` sync status — yet the diff view, which stats the path directly, showed a real mtime. `pin_mtimes` now falls back to stat-ing the path when the candidate isn't discovered, so the list age and the ↑/↓ sync status match the diff.
- **Gist time `unknown` in the pin diff.** `spawn_pin_diff` built a stub `GistFile` with an empty `updated_at`, so the diff header read `(unknown)` even though the Pins list resolves the real time from `state.gists`. It now populates `updated_at` from the loaded gists.

Also extracts the local mtime→unix helper (`file_mtime_secs`) so discovery and the pin fallback share one code path.

## Test plan

- Added `pin_mtimes_local_falls_back_to_disk_when_not_discovered` (red→green).
- `cargo fmt --check`, `cargo test` (286 pass), `cargo check`, `cargo clippy --all-targets -- -D warnings` — all clean.