### PR TITLE
feat: cursor-aware editing for description + filter inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Local file list now has a text filter: `/` filters the focused pane (Local matches path/filename, Gist matches description/id). Filtering supports typing-while-navigating (↑/↓), `Tab` to apply and switch panes, and `Backspace` on an empty query to exit.
 - The Pinned Mappings screen (`P`) gained the same `/` text filter — matches the local path or gist filename, with live ↑/↓ navigation.
 - Pin times are now consistent between the Pins list and the diff view: pins pointing outside the scanned working directory show the real local mtime (and a correct ↑/↓ sync status) instead of `?`, and the pin diff header shows the gist's update time instead of `unknown`.
+- Inline text inputs (gist description editor and every `/` filter) are now full single-line editors: `←`/`→`/`Home`/`End` move the cursor and `Backspace`/`Del` delete around it, with a block cursor showing its real position — no more deleting back to fix an earlier character.
 
 ## [0.9.0] — 2026-06-14
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,8 @@ Press `?` in the app for the full keymap — it now opens the **current screen's
   - `e` — edit / redact the upload content in `$EDITOR` before upload (does NOT mutate the local file).
   - `p` / `s` — (JSON only) toggle pretty-print / recursive key sorting on the upload buffer.
 - `n` (on a local file) — create a new gist from it: type an optional description, then
-  choose `s` secret or `p` public.
+  choose `s` secret or `p` public. The description field is a full line editor —
+  `←`/`→`/`Home`/`End` move the cursor, `Backspace`/`Del` delete around it.
 - `X` (on a gist) — remove the selected file from its gist after a `y`/`n` confirmation.
   Deleting a whole gist lives in the **gist manager** (`g`); a gist's only file can't be
   removed (delete the gist instead).
@@ -212,7 +213,7 @@ Press `?` in the app for the full keymap — it now opens the **current screen's
   Keys inside the Pins view:
   - `↑`/`↓` — move between pins; `←`/`→` — scroll a long local path horizontally.
   - `/` — filter pins by local path or gist filename; while filtering, `↑`/`↓` move,
-    `Enter` applies, `Esc` clears.
+    `Enter` applies, `Esc` clears, and `←`/`→`/`Home`/`End`/`Del` edit the query text.
   - `Enter` — diff the selected pair (read-only; `d`/`u` from the diff to pull/push; `Esc`/`q` returns to the Pins view).
   - `s` — smart-sync (newer side wins by modified time; skips if already identical).
   - `u` — force push (upload local → gist).
@@ -232,7 +233,7 @@ Press `?` in the app for the full keymap — it now opens the **current screen's
   and scans in the background so the UI stays responsive.
 - `a` — flip the **anchor** (which pane drives match ranking); independent of focus, so you
   can focus the ranked pane to pick a file without the order resetting.
-- `/` filter the focused pane (Local pane matches path/filename; Gist pane matches description/id). While filtering: type to match, ↑/↓ move, Tab applies and switches pane, Enter applies, Esc clears. · `v` cycle visibility (all/public/secret) · `s` cycle the **focused
+- `/` filter the focused pane (Local pane matches path/filename; Gist pane matches description/id). While filtering: type to match, ↑/↓ move, Tab applies and switches pane, Enter applies, Esc clears, and ←/→/Home/End/Del edit the query text. · `v` cycle visibility (all/public/secret) · `s` cycle the **focused
   pane's** sort (match / name / recent — gists by name/updated, local files by
   name/modified-time) · `t` toggle row view.
 - `Esc`/`q` — go back from an overlay; on the main list, press twice to quit (the first press
@@ -247,7 +248,8 @@ unranked so you can still preview and download into the current directory.
 Press `g` to open the **gist manager** — a gist-level view (one row per gist) that lands on
 the gist owning the currently selected file. From here you manage gists as a whole:
 
-- `e` — edit the gist's description (type, `Enter` applies, `Esc` cancels).
+- `e` — edit the gist's description (type, `Enter` applies, `Esc` cancels;
+  `←`/`→`/`Home`/`End`/`Del` edit text mid-string instead of only at the end).
 - `Enter` — open the **gist detail view**: a header with basic info (description, visibility,
   created/updated age, short id) and a `Files │ Comments` tab strip, with the active tab's
   content below. Opens on the **Files** tab.
@@ -270,7 +272,7 @@ the gist owning the currently selected file. From here you manage gists as a who
   the gist's info as context.) Requires the git credential helper that `gh auth setup-git`
   configures; if it is missing, compaction reports an actionable error pointing you to that command.
 - `s` cycle sort (updated / created) · `v` cycle visibility (all/public/secret) · `/` filter
-  by description or id (↑/↓ move · Enter apply · Esc clear) · `Left`/`Right` scroll a long description.
+  by description or id (↑/↓ move · Enter apply · Esc clear · ←/→/Home/End/Del edit query) · `Left`/`Right` scroll a long description.
 - `q`/`Esc` — back to the list.
 
 </details>

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -111,7 +111,7 @@ impl AppState {
                         self.pins_hscroll = 0;
                     }
                     FilterKey::Exited => self.pins_filtering = false,
-                    FilterKey::Pass => {}
+                    FilterKey::Moved | FilterKey::Pass => {}
                 },
             }
             return KeyOutcome::None;
@@ -154,11 +154,9 @@ impl AppState {
                     self.description_input.clear();
                 }
                 KeyCode::Enter => return KeyOutcome::ApplyDescription,
-                KeyCode::Backspace => {
-                    self.description_input.pop();
+                _ => {
+                    self.description_input.apply_edit(code);
                 }
-                KeyCode::Char(c) => self.description_input.push(c),
-                _ => {}
             }
             return KeyOutcome::None;
         }
@@ -187,7 +185,7 @@ impl AppState {
                         self.gists_hscroll = 0;
                     }
                     FilterKey::Exited => self.gists_filtering = false,
-                    FilterKey::Pass => {}
+                    FilterKey::Moved | FilterKey::Pass => {}
                 },
             }
             return KeyOutcome::None;
@@ -224,7 +222,7 @@ impl AppState {
             KeyCode::Char('e') => {
                 if let Some(group) = groups.get(self.gists_index) {
                     self.editing_description = true;
-                    self.description_input = group.description.clone();
+                    self.description_input.set(group.description.clone());
                 }
             }
             KeyCode::Enter if self.gists_index < groups.len() => {
@@ -434,30 +432,29 @@ enum FilterKey {
     Exited,
     /// Esc: query cleared; caller leaves input and resets index + scroll.
     Cleared,
-    /// Not a text-edit key (e.g. an arrow or Tab the caller already handled); ignore.
+    /// Only the cursor moved (←/→/Home/End): caller stays in input, no re-rank.
+    Moved,
+    /// Not a text-edit key (e.g. Up/Down or Tab the caller already handled); ignore.
     Pass,
 }
 
 /// Apply one key to `query` and report the transition. Pure: only mutates `query`.
-fn apply_filter_edit(code: KeyCode, query: &mut String) -> FilterKey {
+/// Text editing (insert/delete/cursor movement) is delegated to [`TextInput`]; this
+/// only owns the filter-specific Esc/Enter/empty-Backspace exit policy.
+fn apply_filter_edit(code: KeyCode, query: &mut TextInput) -> FilterKey {
     match code {
         KeyCode::Esc => {
             query.clear();
             FilterKey::Cleared
         }
         KeyCode::Enter => FilterKey::Exited,
-        KeyCode::Backspace => {
-            if query.pop().is_some() {
-                FilterKey::Edited
-            } else {
-                FilterKey::Exited // already empty -> leave input
-            }
-        }
-        KeyCode::Char(c) => {
-            query.push(c);
-            FilterKey::Edited
-        }
-        _ => FilterKey::Pass,
+        // Backspace on an already-empty query leaves the input (keeps the old shortcut).
+        KeyCode::Backspace if query.is_empty() => FilterKey::Exited,
+        _ => match query.apply_edit(code) {
+            EditResult::Changed => FilterKey::Edited,
+            EditResult::Moved => FilterKey::Moved,
+            EditResult::Ignored => FilterKey::Pass,
+        },
     }
 }
 
@@ -496,7 +493,7 @@ impl AppState {
                 self.reset_focused_filter_scroll();
             }
             FilterKey::Exited => self.filtering = false,
-            FilterKey::Pass => {}
+            FilterKey::Moved | FilterKey::Pass => {}
         }
         KeyOutcome::None
     }
@@ -808,32 +805,36 @@ impl AppState {
     }
 
     fn handle_key_confirm(&mut self, code: KeyCode) -> KeyOutcome {
-        match code {
-            KeyCode::Down => {
-                self.scroll_diff_down();
-                return KeyOutcome::None;
+        // While typing the create flow's description, arrows drive the text cursor (handled
+        // below), not the background diff scroll.
+        if !self.editing_description {
+            match code {
+                KeyCode::Down => {
+                    self.scroll_diff_down();
+                    return KeyOutcome::None;
+                }
+                KeyCode::Up => {
+                    self.scroll_diff_up();
+                    return KeyOutcome::None;
+                }
+                KeyCode::PageDown => {
+                    self.scroll_diff_page_down(PAGE_SCROLL);
+                    return KeyOutcome::None;
+                }
+                KeyCode::PageUp => {
+                    self.scroll_diff_page_up(PAGE_SCROLL);
+                    return KeyOutcome::None;
+                }
+                KeyCode::Right => {
+                    self.scroll_diff_right();
+                    return KeyOutcome::None;
+                }
+                KeyCode::Left => {
+                    self.scroll_diff_left();
+                    return KeyOutcome::None;
+                }
+                _ => {}
             }
-            KeyCode::Up => {
-                self.scroll_diff_up();
-                return KeyOutcome::None;
-            }
-            KeyCode::PageDown => {
-                self.scroll_diff_page_down(PAGE_SCROLL);
-                return KeyOutcome::None;
-            }
-            KeyCode::PageUp => {
-                self.scroll_diff_page_up(PAGE_SCROLL);
-                return KeyOutcome::None;
-            }
-            KeyCode::Right => {
-                self.scroll_diff_right();
-                return KeyOutcome::None;
-            }
-            KeyCode::Left => {
-                self.scroll_diff_left();
-                return KeyOutcome::None;
-            }
-            _ => {}
         }
         match self.pending_action.clone() {
             Some(PendingAction::Download) => match code {
@@ -870,11 +871,9 @@ impl AppState {
                     self.description_input.clear();
                     self.back_to_list();
                 }
-                KeyCode::Backspace => {
-                    self.description_input.pop();
+                _ => {
+                    self.description_input.apply_edit(code);
                 }
-                KeyCode::Char(c) => self.description_input.push(c),
-                _ => {}
             },
             Some(PendingAction::Create { .. }) => match code {
                 // Step 2: choose visibility (the description is kept in description_input).

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -318,11 +318,11 @@ pub struct AppState {
     pub gist_sort: GistSort,
     pub local_sort: LocalSort,
     pub filtering: bool,
-    pub filter_query: String,
+    pub filter_query: TextInput,
     /// Text filter for the LOCAL pane (List screen). Independent of `filter_query`
     /// (the gist pane), so both panes can be filtered at once. Matched against the
     /// cwd-relative display label, i.e. the exact string shown in the local list.
-    pub local_filter_query: String,
+    pub local_filter_query: TextInput,
     pub diff_previewed: bool,
     pub diff_text: String,
     pub diff_scroll: u16,
@@ -362,15 +362,15 @@ pub struct AppState {
     pub pins_index: usize,
     pub pins_hscroll: u16,
     pub pins_filtering: bool,
-    pub pins_filter_query: String,
+    pub pins_filter_query: TextInput,
     pub gists_index: usize,
     pub gists_hscroll: u16,
     pub gists_sort: GistGroupSort,
     pub gists_type_filter: GistTypeFilter,
     pub gists_filtering: bool,
-    pub gists_filter_query: String,
+    pub gists_filter_query: TextInput,
     pub editing_description: bool,
-    pub description_input: String,
+    pub description_input: TextInput,
     pub bg_task_msg: Option<String>,
     /// Set after the first `q`/`Esc` on the main list; a second press confirms the quit. Any
     /// other key clears it. Prevents an accidental single-key exit.
@@ -900,8 +900,8 @@ pub fn initial_state() -> AppState {
         gist_sort: GistSort::Match,
         local_sort: LocalSort::Match,
         filtering: false,
-        filter_query: String::new(),
-        local_filter_query: String::new(),
+        filter_query: TextInput::default(),
+        local_filter_query: TextInput::default(),
         diff_previewed: false,
         diff_text: String::new(),
         diff_scroll: 0,
@@ -931,15 +931,15 @@ pub fn initial_state() -> AppState {
         pins_index: 0,
         pins_hscroll: 0,
         pins_filtering: false,
-        pins_filter_query: String::new(),
+        pins_filter_query: TextInput::default(),
         gists_index: 0,
         gists_hscroll: 0,
         gists_sort: GistGroupSort::Updated,
         gists_type_filter: GistTypeFilter::All,
         gists_filtering: false,
-        gists_filter_query: String::new(),
+        gists_filter_query: TextInput::default(),
         editing_description: false,
-        description_input: String::new(),
+        description_input: TextInput::default(),
         bg_task_msg: None,
         quit_armed: false,
         help_scroll: 0,
@@ -1074,6 +1074,8 @@ use render::*;
 mod keys;
 mod run_loop;
 use run_loop::run_loop;
+mod text_input;
+pub use text_input::{EditResult, TextInput};
 
 #[cfg(test)]
 mod tests;

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -52,7 +52,7 @@ List screen
   r          toggle recursive file discovery (skips hidden + configured dirs)
   /          filter the focused pane (Local = path/filename, Gist = description/id)
              while filtering: type to match · ↑↓ move · Tab apply + switch pane
-             · Enter apply · Esc clear
+             · Enter apply · Esc clear · ←/→/Home/End move · Del
   v          cycle gist visibility: all / public / secret
   s          cycle the focused pane's sort: match / name / recent
   t          toggle row view: description / id
@@ -81,6 +81,7 @@ Actions (on the selected local file + gist)
   Up/Down    move between pins
   Left/Right scroll a long local path horizontally (~ = home)
   /          filter pins by path or filename (↑↓ move · Enter apply · Esc clear)
+             ←/→/Home/End move the text cursor · Del deletes ahead
   Enter      diff the selected pair (then d pull / u push from the diff)
   s          smart-sync (newer side wins; skips if already identical)
   u          force push  (upload local → gist)
@@ -97,6 +98,7 @@ Actions (on the selected local file + gist)
   s          cycle sort: updated / created
   v          cycle visibility: all / public / secret
   e          edit the gist description (Enter apply, Esc cancel)
+             ←/→/Home/End move the text cursor · Del deletes ahead
   Enter      open the gist detail view (info, file list, comments)
   o          open the gist in your web browser
   y          copy the gist's URL to the system clipboard
@@ -377,7 +379,16 @@ pub(super) fn render_pins(frame: &mut Frame, state: &AppState) {
     list_state.select(selected);
     frame.render_stateful_widget(list, chunks[0], &mut list_state);
 
-    render_footer(frame, chunks[1], &ftitle, &footer, colored);
+    if state.pins_filtering {
+        render_footer_line(
+            frame,
+            chunks[1],
+            &ftitle,
+            input_line("/", &state.pins_filter_query, ""),
+        );
+    } else {
+        render_footer(frame, chunks[1], &ftitle, &footer, colored);
+    }
 }
 
 pub(super) fn gist_group_row_label(
@@ -499,13 +510,24 @@ pub(super) fn render_gists(frame: &mut Frame, state: &AppState) {
     list_state.select(selected);
     frame.render_stateful_widget(list, chunks[0], &mut list_state);
 
-    render_footer(frame, chunks[1], &ftitle, &footer, colored);
+    if state.gists_filtering {
+        render_footer_line(
+            frame,
+            chunks[1],
+            &ftitle,
+            input_line("/", &state.gists_filter_query, ""),
+        );
+    } else {
+        render_footer(frame, chunks[1], &ftitle, &footer, colored);
+    }
 
     if state.editing_description {
-        render_centered_modal(
+        render_centered_modal_input(
             frame,
             "Edit description (Enter apply · Esc cancel)",
-            &format!("{}_", state.description_input),
+            "",
+            &state.description_input,
+            "",
             Color::Cyan,
         );
     }
@@ -1023,6 +1045,47 @@ pub(super) fn render_footer(frame: &mut Frame, area: Rect, title: &str, text: &s
     );
 }
 
+/// Like [`render_footer`] but draws a prebuilt styled `line`, used for active text inputs
+/// so the cursor can be reverse-highlighted at its real position.
+pub(super) fn render_footer_line(frame: &mut Frame, area: Rect, title: &str, line: Line) {
+    frame.render_widget(
+        Paragraph::new(line)
+            .wrap(Wrap { trim: true })
+            .block(footer_block(title)),
+        area,
+    );
+}
+
+/// A styled line for an active inline text input: `prefix`, then the input text with a
+/// reverse-video block cursor at its real position, then `suffix`. A cursor at the end
+/// reverses a trailing space so the caret is always visible.
+pub(super) fn input_line(prefix: &str, input: &TextInput, suffix: &str) -> Line<'static> {
+    let chars: Vec<char> = input.chars().collect();
+    let cursor = input.cursor().min(chars.len());
+    let rev = Style::default().add_modifier(Modifier::REVERSED);
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    if !prefix.is_empty() {
+        spans.push(Span::raw(prefix.to_string()));
+    }
+    let before: String = chars[..cursor].iter().collect();
+    if !before.is_empty() {
+        spans.push(Span::raw(before));
+    }
+    if cursor < chars.len() {
+        spans.push(Span::styled(chars[cursor].to_string(), rev));
+        let after: String = chars[cursor + 1..].iter().collect();
+        if !after.is_empty() {
+            spans.push(Span::raw(after));
+        }
+    } else {
+        spans.push(Span::styled(" ".to_string(), rev));
+    }
+    if !suffix.is_empty() {
+        spans.push(Span::raw(suffix.to_string()));
+    }
+    Line::from(spans)
+}
+
 pub(super) fn render_list(frame: &mut Frame, state: &AppState) {
     let area = frame.area();
     let footer_body = if state.filtering {
@@ -1152,7 +1215,20 @@ pub(super) fn render_list(frame: &mut Frame, state: &AppState) {
         gist_selected,
     );
 
-    render_footer(frame, chunks[1], "", &footer_body, footer_is_command);
+    if state.filtering {
+        let (pane, query) = match state.focus {
+            FocusPane::Local => ("local", &state.local_filter_query),
+            FocusPane::Gist => ("gist", &state.filter_query),
+        };
+        let line = input_line(
+            &format!("filter {pane}: "),
+            query,
+            "   (Tab next pane · Enter apply · Esc clear)",
+        );
+        render_footer_line(frame, chunks[1], "", line);
+    } else {
+        render_footer(frame, chunks[1], "", &footer_body, footer_is_command);
+    }
 }
 
 pub(super) fn render_pane(
@@ -1478,13 +1554,21 @@ pub(super) fn diff_title(state: &AppState) -> String {
     }
 }
 
+/// Label and trailing hint around the create flow's description input. Shared so
+/// `confirm_prompt` (plain text / tests) and `render_confirm` (the cursor-aware modal)
+/// can't drift apart.
+pub(super) const CREATE_DESC_PREFIX: &str = "Description (optional): ";
+pub(super) const CREATE_DESC_SUFFIX: &str = "   ·  Enter next  ·  Esc cancel";
+
 /// The prompt shown inside the centered confirm modal — one line per pending action,
 /// listing the keys that resolve it. Pure so it can be unit-tested.
 pub(super) fn confirm_prompt(state: &AppState) -> String {
     match &state.pending_action {
         Some(PendingAction::Create { .. }) if state.editing_description => {
+            // `_` is the plain-text caret; the rendered modal draws a reverse-video
+            // cursor at its real position instead (see render_confirm).
             format!(
-                "Description (optional): {}_   ·  Enter next  ·  Esc cancel",
+                "{CREATE_DESC_PREFIX}{}_{CREATE_DESC_SUFFIX}",
                 state.description_input
             )
         }
@@ -1652,7 +1736,22 @@ pub(super) fn render_confirm(frame: &mut Frame, state: &AppState) {
         _ => render_diff_pane(frame, frame.area(), state),
     }
     let (title, border) = confirm_modal_style(state);
-    render_centered_modal(frame, title, &confirm_prompt(state), border);
+    // The create flow's description step is an active text input, so it needs the
+    // reverse-video cursor; every other confirm prompt is static text.
+    if matches!(state.pending_action, Some(PendingAction::Create { .. }))
+        && state.editing_description
+    {
+        render_centered_modal_input(
+            frame,
+            title,
+            CREATE_DESC_PREFIX,
+            &state.description_input,
+            CREATE_DESC_SUFFIX,
+            border,
+        );
+    } else {
+        render_centered_modal(frame, title, &confirm_prompt(state), border);
+    }
 }
 
 pub(super) fn is_json_file(path: &std::path::Path) -> bool {
@@ -1662,8 +1761,8 @@ pub(super) fn is_json_file(path: &std::path::Path) -> bool {
         .unwrap_or(false)
 }
 
-pub(super) fn render_centered_modal(frame: &mut Frame, title: &str, body: &str, border: Color) {
-    let area = frame.area();
+/// Centered modal rect sized to fit `body` (clamped to the frame).
+fn centered_modal_rect(area: Rect, body: &str) -> Rect {
     let max_width = area.width.saturating_sub(2).max(1);
     let width = ((area.width as u32 * 60 / 100) as u16).clamp(max_width.min(20), max_width);
     // Inner text width = box width minus the two border columns and the horizontal padding.
@@ -1671,24 +1770,52 @@ pub(super) fn render_centered_modal(frame: &mut Frame, title: &str, body: &str, 
     let body_lines = wrap_line_count(body, inner_width).max(1);
     let max_height = area.height.saturating_sub(2).max(1);
     let height = (body_lines + 2).clamp(max_height.min(3), max_height);
-    let rect = Rect {
+    Rect {
         x: area.width.saturating_sub(width) / 2,
         y: area.height.saturating_sub(height) / 2,
         width,
         height,
-    };
+    }
+}
+
+fn modal_block(title: &str, border: Color) -> Block<'static> {
+    Block::default()
+        .title(title.to_string())
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(border))
+        .padding(Padding::horizontal(1))
+}
+
+pub(super) fn render_centered_modal(frame: &mut Frame, title: &str, body: &str, border: Color) {
+    let rect = centered_modal_rect(frame.area(), body);
     frame.render_widget(Clear, rect);
     frame.render_widget(
         Paragraph::new(body.to_string())
             .wrap(Wrap { trim: true })
-            .block(
-                Block::default()
-                    .title(title.to_string())
-                    .borders(Borders::ALL)
-                    .border_type(BorderType::Rounded)
-                    .border_style(Style::default().fg(border))
-                    .padding(Padding::horizontal(1)),
-            ),
+            .block(modal_block(title, border)),
+        rect,
+    );
+}
+
+/// Centered modal whose body is an active text input (`prefix` + text-with-cursor +
+/// `suffix`), so the description editor shows the caret at its real position.
+pub(super) fn render_centered_modal_input(
+    frame: &mut Frame,
+    title: &str,
+    prefix: &str,
+    input: &TextInput,
+    suffix: &str,
+    border: Color,
+) {
+    // Size from the plain text plus one column for the (possibly trailing) cursor cell.
+    let plain = format!("{prefix}{input} {suffix}");
+    let rect = centered_modal_rect(frame.area(), &plain);
+    frame.render_widget(Clear, rect);
+    frame.render_widget(
+        Paragraph::new(input_line(prefix, input, suffix))
+            .wrap(Wrap { trim: true })
+            .block(modal_block(title, border)),
         rect,
     );
 }

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -587,7 +587,7 @@ pub(super) fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) ->
                     else {
                         continue;
                     };
-                    let description = state.description_input.clone();
+                    let description = state.description_input.to_string();
                     let plan = crate::actions::create_command(&local_path, public, &description);
 
                     spawn_bg(&mut state, &mut bg_rx, "Creating gist…", move || {
@@ -724,7 +724,7 @@ pub(super) fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) ->
                         continue;
                     };
                     let gist_id = group.id.clone();
-                    let description = state.description_input.clone();
+                    let description = state.description_input.to_string();
                     let plan = crate::actions::edit_description_command(&gist_id, &description);
                     state.editing_description = false;
                     state.description_input.clear();

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -2166,6 +2166,78 @@ fn gist_view_e_edits_description_with_prefill_and_enter_applies() {
 }
 
 #[test]
+fn input_line_reverses_the_char_under_the_cursor() {
+    let mut input = TextInput::from("abc");
+    input.left(); // ab|c → cursor on 'c'
+    let line = input_line("/", &input, "");
+    // Exactly one span carries the reverse-video cursor, and it's the char at the cursor.
+    let reversed: Vec<&str> = line
+        .spans
+        .iter()
+        .filter(|s| s.style.add_modifier.contains(Modifier::REVERSED))
+        .map(|s| s.content.as_ref())
+        .collect();
+    assert_eq!(reversed, vec!["c"]);
+    let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+    assert_eq!(text, "/abc");
+}
+
+#[test]
+fn input_line_cursor_at_end_reverses_trailing_space() {
+    let input = TextInput::from("ab");
+    let line = input_line("", &input, "");
+    let reversed: Vec<&str> = line
+        .spans
+        .iter()
+        .filter(|s| s.style.add_modifier.contains(Modifier::REVERSED))
+        .map(|s| s.content.as_ref())
+        .collect();
+    assert_eq!(reversed, vec![" "]);
+}
+
+#[test]
+fn gist_view_description_edits_mid_string_with_cursor_keys() {
+    let mut state = state_with_two_gists();
+    state.screen = Screen::Gists;
+    state.gists_index = 0;
+    state.handle_key(KeyCode::Char('e'));
+    assert_eq!(state.description_input, "My Ghostty config");
+    // Jump to the start, step right past "My", and insert without retyping the rest.
+    state.handle_key(KeyCode::Home);
+    state.handle_key(KeyCode::Right);
+    state.handle_key(KeyCode::Right);
+    state.handle_key(KeyCode::Char(' '));
+    state.handle_key(KeyCode::Char('o'));
+    state.handle_key(KeyCode::Char('w'));
+    state.handle_key(KeyCode::Char('n'));
+    assert_eq!(state.description_input, "My own Ghostty config");
+    // Delete removes the char at the cursor (the space before "Ghostty").
+    state.handle_key(KeyCode::Delete);
+    assert_eq!(state.description_input, "My ownGhostty config");
+}
+
+#[test]
+fn create_description_edits_mid_string_with_cursor_keys() {
+    let mut state = initial_state();
+    state.pending_action = Some(PendingAction::Create {
+        local_path: PathBuf::from("notes.txt"),
+    });
+    state.editing_description = true;
+    state.screen = Screen::Confirm;
+    for c in "helo".chars() {
+        state.handle_key(KeyCode::Char(c));
+    }
+    // Fix the typo: go back one char and insert the missing 'l'.
+    state.handle_key(KeyCode::Left);
+    state.handle_key(KeyCode::Char('l'));
+    assert_eq!(state.description_input, "hello");
+    // Enter advances to the visibility step without losing the text.
+    state.handle_key(KeyCode::Enter);
+    assert!(!state.editing_description);
+    assert_eq!(state.description_input, "hello");
+}
+
+#[test]
 fn gist_view_esc_cancels_description_edit() {
     let mut state = state_with_two_gists();
     state.screen = Screen::Gists;

--- a/src/tui/text_input.rs
+++ b/src/tui/text_input.rs
@@ -1,0 +1,304 @@
+use crossterm::event::KeyCode;
+use std::ops::Deref;
+
+/// A single-line text buffer with a char-indexed cursor, shared by every inline text
+/// input (the gist description editor and the `/` filters). The cursor is kept within
+/// `[0, char_len]` and always on a char boundary, so multi-byte (e.g. CJK) input is safe.
+///
+/// `Deref<Target = str>` and `Display` let read sites treat it like the old `String`
+/// (`is_empty`, `to_lowercase`, `&input` as `&str`, `format!("{input}")`); only the
+/// mutating paths go through the explicit editing methods.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TextInput {
+    value: String,
+    /// Number of chars before the cursor (0 = line start, char_len = line end).
+    cursor: usize,
+}
+
+/// What [`TextInput::apply_edit`] did with a key, so filter callers can tell a text
+/// change (which must re-rank/reset) from a pure cursor move (which must not) from a
+/// key the input didn't consume.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EditResult {
+    /// The text changed (insert or delete).
+    Changed,
+    /// Only the cursor moved.
+    Moved,
+    /// Not an editing key; the caller should handle it.
+    Ignored,
+}
+
+impl TextInput {
+    /// Cursor position as a char count from the line start.
+    pub fn cursor(&self) -> usize {
+        self.cursor
+    }
+
+    fn char_len(&self) -> usize {
+        self.value.chars().count()
+    }
+
+    /// Byte offset of char index `i` (clamped to the end for `i >= char_len`).
+    fn byte_at(&self, i: usize) -> usize {
+        self.value
+            .char_indices()
+            .nth(i)
+            .map(|(b, _)| b)
+            .unwrap_or(self.value.len())
+    }
+
+    /// Insert `c` at the cursor and advance past it.
+    pub fn insert(&mut self, c: char) {
+        let at = self.byte_at(self.cursor);
+        self.value.insert(at, c);
+        self.cursor += 1;
+    }
+
+    /// Delete the char before the cursor; returns whether anything was removed.
+    pub fn backspace(&mut self) -> bool {
+        if self.cursor == 0 {
+            return false;
+        }
+        let start = self.byte_at(self.cursor - 1);
+        let end = self.byte_at(self.cursor);
+        self.value.replace_range(start..end, "");
+        self.cursor -= 1;
+        true
+    }
+
+    /// Delete the char at the cursor; returns whether anything was removed.
+    pub fn delete(&mut self) -> bool {
+        if self.cursor >= self.char_len() {
+            return false;
+        }
+        let start = self.byte_at(self.cursor);
+        let end = self.byte_at(self.cursor + 1);
+        self.value.replace_range(start..end, "");
+        true
+    }
+
+    /// Move the cursor one char left; returns whether it moved.
+    pub fn left(&mut self) -> bool {
+        if self.cursor == 0 {
+            return false;
+        }
+        self.cursor -= 1;
+        true
+    }
+
+    /// Move the cursor one char right; returns whether it moved.
+    pub fn right(&mut self) -> bool {
+        if self.cursor >= self.char_len() {
+            return false;
+        }
+        self.cursor += 1;
+        true
+    }
+
+    /// Move the cursor to the line start; returns whether it moved.
+    pub fn home(&mut self) -> bool {
+        if self.cursor == 0 {
+            return false;
+        }
+        self.cursor = 0;
+        true
+    }
+
+    /// Move the cursor to the line end; returns whether it moved.
+    pub fn end(&mut self) -> bool {
+        let len = self.char_len();
+        if self.cursor == len {
+            return false;
+        }
+        self.cursor = len;
+        true
+    }
+
+    /// Clear the text and reset the cursor to the start.
+    pub fn clear(&mut self) {
+        self.value.clear();
+        self.cursor = 0;
+    }
+
+    /// Replace the whole value, placing the cursor at the end (used when opening the
+    /// description editor pre-filled with the gist's current description).
+    pub fn set(&mut self, value: impl Into<String>) {
+        self.value = value.into();
+        self.cursor = self.char_len();
+    }
+
+    /// Apply one editing key. `Esc`/`Enter` are intentionally NOT handled here — each
+    /// caller owns those (filters clear/exit; the description editor applies/cancels).
+    pub fn apply_edit(&mut self, code: KeyCode) -> EditResult {
+        match code {
+            KeyCode::Char(c) => {
+                self.insert(c);
+                EditResult::Changed
+            }
+            KeyCode::Backspace => bool_to_change(self.backspace()),
+            KeyCode::Delete => bool_to_change(self.delete()),
+            KeyCode::Left => bool_to_move(self.left()),
+            KeyCode::Right => bool_to_move(self.right()),
+            KeyCode::Home => bool_to_move(self.home()),
+            KeyCode::End => bool_to_move(self.end()),
+            _ => EditResult::Ignored,
+        }
+    }
+}
+
+fn bool_to_change(changed: bool) -> EditResult {
+    if changed {
+        EditResult::Changed
+    } else {
+        EditResult::Ignored
+    }
+}
+
+fn bool_to_move(moved: bool) -> EditResult {
+    if moved {
+        EditResult::Moved
+    } else {
+        EditResult::Ignored
+    }
+}
+
+impl Deref for TextInput {
+    type Target = str;
+    fn deref(&self) -> &str {
+        &self.value
+    }
+}
+
+impl std::fmt::Display for TextInput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.value)
+    }
+}
+
+impl From<&str> for TextInput {
+    fn from(value: &str) -> Self {
+        let mut input = Self::default();
+        input.set(value.to_string());
+        input
+    }
+}
+
+impl From<String> for TextInput {
+    fn from(value: String) -> Self {
+        let mut input = Self::default();
+        input.set(value);
+        input
+    }
+}
+
+impl PartialEq<str> for TextInput {
+    fn eq(&self, other: &str) -> bool {
+        self.value == other
+    }
+}
+
+impl PartialEq<&str> for TextInput {
+    fn eq(&self, other: &&str) -> bool {
+        self.value == *other
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn typed(s: &str) -> TextInput {
+        let mut input = TextInput::default();
+        for c in s.chars() {
+            input.insert(c);
+        }
+        input
+    }
+
+    #[test]
+    fn insert_at_cursor_after_moving_left() {
+        let mut input = typed("ac");
+        assert!(input.left()); // between a|c
+        input.insert('b');
+        assert_eq!(&*input, "abc");
+        assert_eq!(input.cursor(), 2);
+    }
+
+    #[test]
+    fn backspace_removes_char_before_cursor() {
+        let mut input = typed("abc");
+        assert!(input.left()); // ab|c
+        assert!(input.backspace()); // a|c
+        assert_eq!(&*input, "ac");
+        assert_eq!(input.cursor(), 1);
+    }
+
+    #[test]
+    fn backspace_at_start_is_noop() {
+        let mut input = typed("ab");
+        input.home();
+        assert!(!input.backspace());
+        assert_eq!(&*input, "ab");
+    }
+
+    #[test]
+    fn delete_removes_char_at_cursor() {
+        let mut input = typed("abc");
+        input.home(); // |abc
+        assert!(input.delete()); // |bc
+        assert_eq!(&*input, "bc");
+        assert_eq!(input.cursor(), 0);
+    }
+
+    #[test]
+    fn delete_at_end_is_noop() {
+        let mut input = typed("ab");
+        assert!(!input.delete());
+        assert_eq!(&*input, "ab");
+    }
+
+    #[test]
+    fn cursor_movement_clamps_at_bounds() {
+        let mut input = typed("ab");
+        assert!(!input.right()); // already at end
+        assert!(input.home());
+        assert!(!input.left()); // already at start
+        assert!(input.end());
+        assert_eq!(input.cursor(), 2);
+    }
+
+    #[test]
+    fn edits_respect_multibyte_char_boundaries() {
+        // Two CJK chars (3 bytes each); editing must not slice a UTF-8 sequence.
+        let mut input = typed("中文");
+        assert_eq!(input.cursor(), 2);
+        assert!(input.left()); // 中|文
+        input.insert('x'); // 中x文
+        assert_eq!(&*input, "中x文");
+        assert!(input.backspace()); // 中|文
+        assert_eq!(&*input, "中文");
+        assert_eq!(input.cursor(), 1);
+    }
+
+    #[test]
+    fn set_places_cursor_at_end_and_clear_resets() {
+        let mut input = TextInput::default();
+        input.set("hello");
+        assert_eq!(input.cursor(), 5);
+        input.clear();
+        assert_eq!(&*input, "");
+        assert_eq!(input.cursor(), 0);
+    }
+
+    #[test]
+    fn apply_edit_classifies_keys() {
+        let mut input = typed("ab");
+        assert_eq!(input.apply_edit(KeyCode::Char('c')), EditResult::Changed);
+        assert_eq!(input.apply_edit(KeyCode::Left), EditResult::Moved);
+        assert_eq!(input.apply_edit(KeyCode::Backspace), EditResult::Changed);
+        assert_eq!(input.apply_edit(KeyCode::Esc), EditResult::Ignored);
+        // Backspace with nothing before the cursor is a no-op, not a change.
+        input.home();
+        assert_eq!(input.apply_edit(KeyCode::Backspace), EditResult::Ignored);
+    }
+}


### PR DESCRIPTION
## Summary

The gist description editor (create + gist manager) and every `/` filter were append-only — you could only `Backspace` from the end and retype, never move back to fix an earlier character. This makes them proper single-line editors.

- **Shared `TextInput`** (`src/tui/text_input.rs`): a char-indexed, UTF-8/CJK-safe buffer with `insert` / `backspace` / `delete` / `left` / `right` / `home` / `end`, plus an `apply_edit(KeyCode)` core. `Deref<Target = str>` + `Display` keep read sites unchanged; only mutations go through methods.
- **Keys:** `←`/`→`/`Home`/`End` move the cursor, `Backspace`/`Del` delete around it, chars insert at the cursor. Filters keep their existing `Esc` clear / `Enter` apply / empty-`Backspace` exit policy; a pure cursor move no longer resets the list selection.
- **Render:** the caret is a reverse-video block cursor at its real position, for both the filter footers and the description modal (was a fixed trailing `_`).
- **Create flow fix:** while typing the description, arrows now drive the text cursor instead of scrolling the background diff.

Scope: applied to all four `/` filters (List local + gist, Pins, Gists) and both description contexts, per request.

## Test plan

- New unit tests: `TextInput` edit ops incl. multibyte boundaries; `input_line` reverse-cursor rendering; `handle_key` mid-string editing for both the gist-manager and create-flow description editors.
- `cargo fmt --check`, `cargo test` (299 pass), `cargo check`, `cargo clippy --all-targets -- -D warnings` — all clean.

## Docs

README keymap, the `?` help text, and `CHANGELOG.md` updated in lockstep.