### PR TITLE
feat: Pins sort, stay-on-Pins after pull, short paths in confirm (0.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pins screen: `o` cycles sort order (default / local path / gist filename); active sort shown in the title bar.
 - Pins screen: after a `d` pull completes, the view stays on Pins instead of returning to the main list.
 - Confirm overwrite prompt now shows `~`-shortened paths instead of full absolute paths.
+- Fixed: pressing `u` or `d` in the diff screen opened from Pins (Enter or `d`-pull) now correctly targets the pin pair's local file instead of the Files-view selection; `record_pin_sync` also fires correctly after a confirmed pull.
 
 ## [0.10.0] — 2026-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Pins screen: `o` cycles sort order (default / local path / gist filename); active sort shown in the title bar.
+- Pins screen: after a `d` pull completes, the view stays on Pins instead of returning to the main list.
+- Confirm overwrite prompt now shows `~`-shortened paths instead of full absolute paths.
+
 ## [0.10.0] — 2026-06-16
 
 - `?` help is now contextual: it opens the current screen's keys (and is reachable from the Pins, Gist manager, and Gist detail screens, not just the list), with `Tab` to browse an index of all topics instead of scrolling one long page.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,7 +646,7 @@ dependencies = [
 
 [[package]]
 name = "gistui"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gistui"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 description = "A terminal UI for managing GitHub Gists"

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -138,6 +138,11 @@ impl AppState {
             KeyCode::Char('s') if !self.pinned.is_empty() => return KeyOutcome::SyncPinAuto,
             KeyCode::Char('u') if !self.pinned.is_empty() => return KeyOutcome::SyncPinPush,
             KeyCode::Char('d') if !self.pinned.is_empty() => return KeyOutcome::SyncPinPull,
+            KeyCode::Char('o') => {
+                self.pins_sort = self.pins_sort.next();
+                self.pins_index = 0;
+                self.pins_hscroll = 0;
+            }
             KeyCode::Char('?') => self.open_help(),
             _ => {}
         }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -725,7 +725,38 @@ impl AppState {
     /// Upload intent shared by the list and the diff screen: requires a selected local file
     /// and gist, then branches on whether the gist already holds a file of the local name
     /// (case C: preview + confirm overwrite) or not (case B: add directly).
+    /// True when we're in the diff screen launched from a Pins context (pin diff or pin pull).
+    /// In this state `preview_local` holds the pin's local file and `download_gist_id/filename`
+    /// hold the pin's gist identity, so upload/download should use those instead of the
+    /// Files-view selection which may point to a completely different pair.
+    pub fn is_pin_diff_context(&self) -> bool {
+        self.screen == Screen::Diff
+            && !self.preview_local.as_os_str().is_empty()
+            && self.download_gist_id.is_some()
+    }
+
     fn upload_intent(&mut self) -> KeyOutcome {
+        if self.is_pin_diff_context() {
+            let Some(local_filename) = self
+                .preview_local
+                .file_name()
+                .and_then(|n| n.to_str())
+                .map(String::from)
+            else {
+                self.status = Some("local file has no name".into());
+                return KeyOutcome::None;
+            };
+            let gist_id = self.download_gist_id.as_deref().unwrap_or_default();
+            let has_same_name = self
+                .gists
+                .iter()
+                .any(|g| g.gist_id == gist_id && g.filename == local_filename);
+            return if has_same_name {
+                KeyOutcome::UploadPreview
+            } else {
+                KeyOutcome::UploadAdd
+            };
+        }
         let (Some(local), Some(gist)) = (self.selected_local(), self.selected_gist()) else {
             self.status = Some("select a local file and a gist to upload".into());
             return KeyOutcome::None;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -195,6 +195,16 @@ cycling_enum! {
     }
 }
 
+cycling_enum! {
+    /// Sort order for the Pins screen. `Default` keeps config/insertion order; the
+    /// others sort the visible rows by the named field.
+    pub enum PinSort {
+        Default => "default",
+        Local => "local",
+        Gist => "gist",
+    }
+}
+
 impl GistSort {
     /// Re-orders ranked gists. `Match` keeps the incoming order; the others override it.
     fn apply(self, gists: &mut [RankedGistFile]) {
@@ -363,6 +373,7 @@ pub struct AppState {
     pub pins_hscroll: u16,
     pub pins_filtering: bool,
     pub pins_filter_query: TextInput,
+    pub pins_sort: PinSort,
     pub gists_index: usize,
     pub gists_hscroll: u16,
     pub gists_sort: GistGroupSort,
@@ -636,12 +647,13 @@ impl AppState {
             .min(u16::MAX as usize) as u16
     }
 
-    /// Indices into `self.pinned` that match the Pins-screen text filter, in original
-    /// order. Empty query → every index. Matched against the cwd/home-shortened local
-    /// path plus the gist filename (the meaningful, visible parts of the row).
+    /// Indices into `self.pinned` that match the Pins-screen text filter, in sort order.
+    /// Empty query → every index. Matched against the cwd/home-shortened local path plus
+    /// the gist filename (the meaningful, visible parts of the row).
     pub fn visible_pin_indices(&self) -> Vec<usize> {
         let query = self.pins_filter_query.to_lowercase();
-        self.pinned
+        let mut indices: Vec<usize> = self
+            .pinned
             .iter()
             .enumerate()
             .filter(|(_, m)| {
@@ -657,7 +669,20 @@ impl AppState {
                 hay.contains(&query)
             })
             .map(|(i, _)| i)
-            .collect()
+            .collect();
+        match self.pins_sort {
+            PinSort::Default => {}
+            PinSort::Local => indices.sort_by(|&a, &b| {
+                crate::config::display_path(&self.pinned[a].local_path)
+                    .cmp(&crate::config::display_path(&self.pinned[b].local_path))
+            }),
+            PinSort::Gist => indices.sort_by(|&a, &b| {
+                self.pinned[a]
+                    .gist_filename
+                    .cmp(&self.pinned[b].gist_filename)
+            }),
+        }
+        indices
     }
 
     /// The true `self.pinned` index of the currently selected Pins row (selection is a
@@ -932,6 +957,7 @@ pub fn initial_state() -> AppState {
         pins_hscroll: 0,
         pins_filtering: false,
         pins_filter_query: TextInput::default(),
+        pins_sort: PinSort::Default,
         gists_index: 0,
         gists_hscroll: 0,
         gists_sort: GistGroupSort::Updated,

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -82,6 +82,7 @@ Actions (on the selected local file + gist)
   Left/Right scroll a long local path horizontally (~ = home)
   /          filter pins by path or filename (↑↓ move · Enter apply · Esc clear)
              ←/→/Home/End move the text cursor · Del deletes ahead
+  o          cycle sort: default / local path / gist filename
   Enter      diff the selected pair (then d pull / u push from the diff)
   s          smart-sync (newer side wins; skips if already identical)
   u          force push  (upload local → gist)
@@ -294,7 +295,7 @@ pub(super) fn render_pins(frame: &mut Frame, state: &AppState) {
     let hints = if state.pinned.is_empty() {
         "Esc/q back"
     } else {
-        "↑↓ move · ←→ scroll · / filter · Enter diff · s sync · u push · d pull · x unpin · ? help  ·  ✓ synced ↑ local-newer ↓ remote-newer ? n/a  ·  Esc/q back"
+        "↑↓ move · ←→ scroll · / filter · o sort · Enter diff · s sync · u push · d pull · x unpin · ? help  ·  ✓ synced ↑ local-newer ↓ remote-newer ? n/a  ·  Esc/q back"
     };
     let (ftitle, footer, colored) = if state.pins_filtering {
         (
@@ -357,6 +358,9 @@ pub(super) fn render_pins(frame: &mut Frame, state: &AppState) {
     );
     if !state.pins_filter_query.is_empty() {
         title.push_str(&format!(" · /{}", state.pins_filter_query));
+    }
+    if state.pins_sort != crate::tui::PinSort::Default {
+        title.push_str(&format!(" · sort:{}", state.pins_sort.label()));
     }
     let list = List::new(items)
         .block(
@@ -1622,7 +1626,10 @@ pub(super) fn confirm_prompt(state: &AppState) -> String {
                 "Compact {count} revisions of \"{label}\" into one? This force-pushes and cannot be undone. (y/n)"
             )
         }
-        _ => format!("Overwrite {}? (y/n)", state.download_target.display()),
+        _ => format!(
+            "Overwrite {}? (y/n)",
+            crate::config::display_path(&state.download_target)
+        ),
     }
 }
 

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -1032,6 +1032,7 @@ fn spawn_pin_push(state: &mut AppState, bg_rx: &mut BgRx, m: &crate::domain::Pin
 /// Spawn the pull (download gist → local) flow for a pin: lands in the existing
 /// download `Screen::Confirm` diff when the local file exists.
 fn spawn_pin_pull(state: &mut AppState, bg_rx: &mut BgRx, m: &crate::domain::PinnedMapping) {
+    state.diff_return = Screen::Pins;
     let target = pin_local_abs(state, m);
     let gist_id = m.gist_id.clone();
     let filename = m.gist_filename.clone();
@@ -1284,6 +1285,7 @@ fn edit_upload_buffer(
 fn download(state: &mut AppState) {
     let target = state.download_target.clone();
     let content = state.preview_remote.clone();
+    let return_screen = state.diff_return;
     match crate::actions::execute_download(&target, &content, true) {
         Ok(()) => {
             state.set_status(format!(
@@ -1307,6 +1309,7 @@ fn download(state: &mut AppState) {
                 );
             }
             state.back_to_list();
+            state.screen = return_screen;
             refresh_locals(state);
         }
         Err(error) => {

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -459,12 +459,19 @@ pub(super) fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) ->
                 KeyOutcome::Pin => pin_selected(&mut state),
                 KeyOutcome::Unpin => unpin_selected(&mut state),
                 KeyOutcome::UploadAdd => {
-                    let (Some(local), Some(gist)) = (state.selected_local(), state.selected_gist())
-                    else {
-                        continue;
+                    let (local_path, gist_id) = if state.is_pin_diff_context() {
+                        (
+                            state.preview_local.clone(),
+                            state.download_gist_id.clone().unwrap(),
+                        )
+                    } else {
+                        let (Some(local), Some(gist)) =
+                            (state.selected_local(), state.selected_gist())
+                        else {
+                            continue;
+                        };
+                        (local.path.clone(), gist.file.gist_id.clone())
                     };
-                    let local_path = local.path.clone();
-                    let gist_id = gist.file.gist_id.clone();
                     let Some(filename) = upload_local_filename(&local_path) else {
                         state.set_status("local file has no name");
                         continue;
@@ -488,17 +495,40 @@ pub(super) fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) ->
                     state.screen = Screen::Confirm;
                 }
                 KeyOutcome::UploadPreview => {
-                    let (Some(local), Some(gist)) = (state.selected_local(), state.selected_gist())
-                    else {
-                        continue;
+                    let (local_path, gist_id, gist_file) = if state.is_pin_diff_context() {
+                        let local_path = state.preview_local.clone();
+                        let gist_id = state.download_gist_id.clone().unwrap();
+                        let filename = state.download_gist_filename.clone().unwrap_or_default();
+                        let gist_file = state
+                            .gists
+                            .iter()
+                            .find(|g| g.gist_id == gist_id && g.filename == filename)
+                            .cloned()
+                            .unwrap_or_else(|| GistFile {
+                                gist_id: gist_id.clone(),
+                                description: String::new(),
+                                filename: filename.clone(),
+                                public: false,
+                                updated_at: String::new(),
+                                created_at: String::new(),
+                            });
+                        (local_path, gist_id, gist_file)
+                    } else {
+                        let (Some(local), Some(gist)) =
+                            (state.selected_local(), state.selected_gist())
+                        else {
+                            continue;
+                        };
+                        (
+                            local.path.clone(),
+                            gist.file.gist_id.clone(),
+                            gist.file.clone(),
+                        )
                     };
-                    let Some(filename) = upload_local_filename(&local.path) else {
+                    let Some(filename) = upload_local_filename(&local_path) else {
                         state.set_status("local file has no name");
                         continue;
                     };
-                    let gist_id = gist.file.gist_id.clone();
-                    let gist_file = gist.file.clone();
-                    let local_path = local.path.clone();
                     let (local_label, gist_label) = diff_labels(Some(&local_path), &gist_file);
 
                     spawn_bg(&mut state, &mut bg_rx, "Loading diff…", move || {
@@ -1064,6 +1094,11 @@ fn spawn_pin_diff(state: &mut AppState, bg_rx: &mut BgRx, m: &crate::domain::Pin
     let local_abs = pin_local_abs(state, m);
     let gist_id = m.gist_id.clone();
     let filename = m.gist_filename.clone();
+    // Record the pin's identity so that `d`/`u` in the diff screen can attribute
+    // the action to this pin (record_pin_sync) and use the correct local file
+    // instead of the Files-view selection (is_pin_diff_context check).
+    state.download_gist_id = Some(gist_id.clone());
+    state.download_gist_filename = Some(filename.clone());
     // Pull the real `updated_at` from the loaded gists so the diff header shows the
     // gist mtime (matching the Pins list) instead of "unknown".
     let updated_at = state


### PR DESCRIPTION
## Summary

- **Pins sort (`o` key)**: cycles through `default` (insertion order) → `local` (by `~`-path) → `gist` (by gist filename); active sort label shown in the title bar when non-default.
- **Stay on Pins after pull**: `d` (force pull) from the Pins screen now keeps you on the Pins view after the download completes — direct write and diff+confirm both respect this.
- **Short paths in confirm**: the "Overwrite …? (y/n)" prompt now uses `display_path` (home → `~`) instead of the raw absolute path.
- **Fix: pin diff upload/download uses the correct local file**: when entering the diff via Pins (Enter or `d`-pull), pressing `u` was uploading the Files-view selection instead of the pin pair's local file, and `record_pin_sync` was not firing after a confirmed pull. Fixed by recording `download_gist_id/filename` in `spawn_pin_diff` and routing `UploadPreview`/`UploadAdd`/`upload_intent` through a pin-context branch.
- **Version bump** to 0.11.0 (not yet released).

## Test plan

- [x] All 299 tests pass (`cargo test`)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Manual: Pins screen → `o` twice → title shows `· sort:local` then `· sort:gist`; third press removes label
- [x] Manual: Pins `d` pull (file exists) → confirm `y` → stays on Pins screen
- [x] Manual: Pins `d` pull (new file) → stays on Pins screen
- [x] Manual: Pins Enter → diff → `u` → upload preview shows the **pin's** local file, not the Files-view selection
- [x] Manual: Pins Enter → diff → `d` → confirm `y` → pin sync status updates correctly
- [x] Manual: overwrite confirm from main list shows `~/…` paths