### PR TITLE
feat: self-upgrade for pre-built binary installs (#127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Pre-built binary installs can self-upgrade from GitHub Releases: `gistui --upgrade` (latest), `gistui --upgrade --check` (compare only), and `gistui --upgrade --upgrade-version <tag>` (pin a release). Homebrew, Scoop (including the `scoop/shims/gistui.exe` PATH shim), and cargo installs are detected and pointed at their own upgrade commands instead.
 - Pins screen: `o` cycles sort order (default / local path / gist filename); active sort shown in the title bar.
 - Pins screen: after a `d` pull completes, the view stays on Pins instead of returning to the main list.
 - Confirm overwrite prompt now shows `~`-shortened paths instead of full absolute paths.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,23 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,7 +70,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -64,7 +81,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -80,6 +97,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
 ]
 
 [[package]]
@@ -177,12 +203,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -202,6 +265,16 @@ name = "char_index"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b4b5c964e3265da460e34f037984985900ce56b7aba4bbf7d38473d7aec3d2"
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
+]
 
 [[package]]
 name = "clap"
@@ -270,6 +343,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,10 +376,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -393,6 +502,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate64"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,6 +520,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -437,6 +563,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -468,7 +595,18 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -499,7 +637,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -545,6 +683,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "finl_unicode"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +709,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -573,6 +737,15 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures-core"
@@ -626,9 +799,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -652,14 +827,18 @@ dependencies = [
  "clap",
  "crossterm",
  "dirs",
+ "flate2",
  "ratatui",
  "serde",
  "serde_json",
  "sha2 0.11.0",
  "similar",
  "synoptic",
+ "tar",
  "tempfile",
  "toml",
+ "ureq",
+ "zip",
 ]
 
 [[package]]
@@ -706,12 +885,103 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
 ]
 
 [[package]]
@@ -725,6 +995,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "if_chain"
@@ -751,6 +1042,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -786,6 +1086,16 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -864,6 +1174,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -891,6 +1207,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
  "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -931,6 +1268,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,7 +1286,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1081,6 +1428,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pest"
 version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1182,10 +1545,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "powerfmt"
@@ -1388,6 +1766,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,7 +1798,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1487,6 +1914,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,6 +1945,12 @@ dependencies = [
  "cpufeatures 0.3.0",
  "digest 0.11.3",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -1540,6 +1984,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "similar"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1565,6 +2015,12 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -1598,6 +2054,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1635,6 +2097,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1644,7 +2128,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1772,6 +2256,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1856,6 +2350,46 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1994,6 +2528,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "wezterm-bidi"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2095,12 +2647,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -2203,7 +2828,199 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "getrandom 0.3.4",
+ "hmac",
+ "indexmap",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "sha1",
+ "thiserror 2.0.18",
+ "time",
+ "xz2",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,13 +34,17 @@ anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 crossterm = "0.29"
 dirs = "6"
+flate2 = "1"
 ratatui = "0.30"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 sha2 = "0.11"
 similar = "3"
 synoptic = "2.2.9"
+tar = "0.4"
 toml = "1.1"
+ureq = { version = "2", default-features = true }
+zip = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -150,7 +150,28 @@ ln -sf "$PWD/target/release/gistui" ~/.local/bin/gistui
 gistui            # launch the TUI in the current directory (needs a TTY)
 gistui ~/dotfiles # launch against a specific working directory
 gistui --check    # print gh readiness, then exit (no TUI)
+gistui --upgrade  # upgrade a pre-built release binary in place (see below)
 ```
+
+### Upgrading pre-built binaries
+
+If you installed via `install.sh`, `install.ps1`, or a manual GitHub Release download,
+`gistui` can upgrade itself without re-running the installer:
+
+```bash
+gistui --upgrade                         # upgrade to the latest release
+gistui --upgrade --check                 # print current vs latest; exit 0 if up to date
+gistui --upgrade --upgrade-version v0.12.0  # pin to a specific release (0.12.0 also works)
+```
+
+The upgrader downloads the same checksummed release assets as the install scripts,
+verifies SHA-256, and replaces the **currently running** binary. On Windows the
+running `.exe` cannot be overwritten immediately — gistui stages the new binary and
+finishes the swap after you exit the process.
+
+Package-manager and toolchain installs are **not** self-upgraded; gistui detects them
+and prints the right command instead (`brew upgrade gistui`, `scoop update gistui`,
+`cargo install gistui --force`, or `cargo binstall gistui --force`).
 
 Run `gistui` from the directory whose files you want to pair with your gists, or pass that
 directory as an argument. The path defaults to the current directory; if you pass one that

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,4 @@ pub mod local;
 pub mod lru;
 pub mod ranking;
 pub mod tui;
+pub mod upgrade;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,17 @@ struct Cli {
     #[arg(long, help = "Print startup checks without launching the TUI")]
     check: bool,
     #[arg(
+        long,
+        help = "Upgrade the running pre-built binary from GitHub Releases (combine with --check or --upgrade-version)"
+    )]
+    upgrade: bool,
+    #[arg(
+        long = "upgrade-version",
+        value_name = "TAG",
+        help = "With --upgrade: install a specific release (v0.12.0 or 0.12.0)"
+    )]
+    upgrade_version: Option<String>,
+    #[arg(
         value_name = "PATH",
         help = "Working directory to pair files against (defaults to the current directory)"
     )]
@@ -20,6 +31,13 @@ struct Cli {
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
+
+    if cli.upgrade {
+        return gistui::upgrade::run(gistui::upgrade::Options {
+            check_only: cli.check,
+            version: cli.upgrade_version,
+        });
+    }
 
     // Validate the working directory before touching the terminal, so a bad path fails
     // cleanly with a non-zero exit instead of half-entering the TUI.

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -1,0 +1,885 @@
+//! Self-upgrade for pre-built release binaries (issue #127).
+//!
+//! Pure planning/parsing lives here; network and filesystem replacement are thin IO
+//! boundaries injectable in tests via [`ReleaseClient`].
+
+use crate::domain::sha256_hex;
+use anyhow::{bail, Context, Result};
+use std::cmp::Ordering;
+use std::fs;
+use std::io::{Cursor, Read};
+use std::path::{Path, PathBuf};
+
+pub const REPO: &str = "akunzai/gistui";
+
+/// How the running binary appears to have been installed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InstallMethod {
+    /// `install.sh` / `install.ps1`, manual release extract, or other standalone copy.
+    Standalone,
+    Homebrew,
+    Scoop,
+    CargoInstall,
+    CargoBinstall,
+    /// Managed/unknown layout — refuse self-upgrade.
+    Refuse {
+        hint: String,
+    },
+}
+
+/// Platform asset naming shared with `install.sh`, `install.ps1`, and binstall metadata.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Platform {
+    pub target: String,
+    pub archive_ext: &'static str,
+    pub bin_name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReleaseAsset {
+    pub version: String,
+    pub pkg_name: String,
+    pub archive_name: String,
+    pub download_base: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpgradePlan {
+    pub exe_path: PathBuf,
+    pub method: InstallMethod,
+    pub current_version: String,
+    pub target_version: String,
+    pub asset: ReleaseAsset,
+    pub check_only: bool,
+}
+
+pub struct Options {
+    pub check_only: bool,
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExecuteOutcome {
+    UpToDate,
+    UpdateAvailable,
+    Upgraded,
+}
+
+pub trait ReleaseClient {
+    fn fetch_latest_tag(&self) -> Result<String>;
+    fn download(&self, url: &str) -> Result<Vec<u8>>;
+}
+
+pub struct UreqClient;
+
+impl ReleaseClient for UreqClient {
+    fn fetch_latest_tag(&self) -> Result<String> {
+        let url = format!("https://api.github.com/repos/{REPO}/releases/latest");
+        let response = ureq::get(&url)
+            .set("User-Agent", "gistui-upgrader")
+            .set("Accept", "application/vnd.github+json")
+            .call()
+            .with_context(|| format!("could not query latest release at {url}"))?;
+        let body = response
+            .into_string()
+            .context("failed to read latest-release response")?;
+        parse_latest_release_tag(body.as_bytes())
+    }
+
+    fn download(&self, url: &str) -> Result<Vec<u8>> {
+        let response = ureq::get(url)
+            .set("User-Agent", "gistui-upgrader")
+            .call()
+            .with_context(|| format!("download failed: {url}"))?;
+        let mut reader = response.into_reader();
+        let mut body = Vec::new();
+        reader
+            .read_to_end(&mut body)
+            .with_context(|| format!("failed to read download body: {url}"))?;
+        Ok(body)
+    }
+}
+
+/// Entry point for `gistui --upgrade`.
+pub fn run(opts: Options) -> Result<()> {
+    run_with_client(opts, &UreqClient)
+}
+
+pub fn run_with_client(opts: Options, client: &impl ReleaseClient) -> Result<()> {
+    let exe_path = std::env::current_exe().context("could not resolve the running executable")?;
+    let method = detect_install_method(&exe_path);
+    match &method {
+        InstallMethod::Homebrew
+        | InstallMethod::Scoop
+        | InstallMethod::CargoInstall
+        | InstallMethod::CargoBinstall => {
+            let hint = upgrade_hint(&method).expect("managed install should have a hint");
+            bail!("self-upgrade is not supported for this install — use: {hint}");
+        }
+        InstallMethod::Refuse { hint } => {
+            bail!("self-upgrade is not supported for this install ({hint})");
+        }
+        InstallMethod::Standalone => {}
+    }
+
+    let plan = UpgradePlan {
+        exe_path,
+        method,
+        current_version: env!("CARGO_PKG_VERSION").to_string(),
+        target_version: opts
+            .version
+            .as_deref()
+            .map(normalize_tag)
+            .unwrap_or_default(),
+        asset: ReleaseAsset {
+            version: String::new(),
+            pkg_name: String::new(),
+            archive_name: String::new(),
+            download_base: String::new(),
+        },
+        check_only: opts.check_only,
+    };
+
+    match execute_plan(&plan, client)? {
+        ExecuteOutcome::UpToDate | ExecuteOutcome::Upgraded => Ok(()),
+        ExecuteOutcome::UpdateAvailable => std::process::exit(1),
+    }
+}
+
+pub fn execute_plan(plan: &UpgradePlan, client: &impl ReleaseClient) -> Result<ExecuteOutcome> {
+    let platform = detect_platform()?;
+    let target_version = if plan.target_version.is_empty() {
+        let tag = client.fetch_latest_tag()?;
+        normalize_tag(&tag)
+    } else {
+        plan.target_version.clone()
+    };
+
+    let asset = release_asset(&target_version, &platform);
+
+    if version_cmp(&target_version, &plan.current_version) == Ordering::Equal {
+        println!(
+            "gistui {} is up to date ({})",
+            plan.current_version,
+            plan.exe_path.display()
+        );
+        return Ok(ExecuteOutcome::UpToDate);
+    }
+
+    if version_cmp(&target_version, &plan.current_version) == Ordering::Less {
+        bail!(
+            "requested release {target_version} is older than the running version {}",
+            plan.current_version
+        );
+    }
+
+    if plan.check_only {
+        println!(
+            "gistui {} → {} available ({})",
+            plan.current_version,
+            target_version,
+            plan.exe_path.display()
+        );
+        return Ok(ExecuteOutcome::UpdateAvailable);
+    }
+
+    let archive_url = format!(
+        "{}/{}/{}",
+        asset.download_base, asset.version, asset.archive_name
+    );
+    let checksum_url = format!("{archive_url}.sha256");
+
+    let archive_bytes = client
+        .download(&archive_url)
+        .with_context(|| format!("could not download release asset for {}", platform.target))?;
+    let checksum_bytes = client.download(&checksum_url)?;
+    let expected_hash = parse_sha256_file(&String::from_utf8_lossy(&checksum_bytes))?;
+    verify_sha256(&archive_bytes, &expected_hash)
+        .with_context(|| format!("checksum mismatch for {}", asset.archive_name))?;
+
+    let new_binary = extract_binary(&archive_bytes, &asset, &platform)?;
+    replace_binary(&plan.exe_path, &new_binary)?;
+
+    println!(
+        "upgraded gistui {} → {} ({})",
+        plan.current_version,
+        target_version,
+        plan.exe_path.display()
+    );
+    Ok(ExecuteOutcome::Upgraded)
+}
+
+pub fn detect_platform() -> Result<Platform> {
+    let os = std::env::consts::OS;
+    let arch = std::env::consts::ARCH;
+    let (plat, ext) = match os {
+        "linux" => ("unknown-linux-gnu", "tar.gz"),
+        "macos" => ("apple-darwin", "tar.gz"),
+        "windows" => ("pc-windows-msvc", "zip"),
+        other => bail!("unsupported operating system: {other}"),
+    };
+    let cpu = match arch {
+        "x86_64" => "x86_64",
+        "aarch64" => "aarch64",
+        other => bail!("unsupported architecture: {other}"),
+    };
+    if os == "windows" && cpu != "x86_64" {
+        bail!("no prebuilt Windows binary for {cpu} (only x86_64 is published)");
+    }
+    let bin_name = if os == "windows" {
+        "gistui.exe".to_string()
+    } else {
+        "gistui".to_string()
+    };
+    Ok(Platform {
+        target: format!("{cpu}-{plat}"),
+        archive_ext: ext,
+        bin_name,
+    })
+}
+
+pub fn release_tag(version: &str) -> String {
+    let bare = normalize_tag(version);
+    format!("v{bare}")
+}
+
+pub fn release_asset(version: &str, platform: &Platform) -> ReleaseAsset {
+    let tag = release_tag(version);
+    let pkg_name = format!("gistui-{tag}-{}", platform.target);
+    let archive_name = format!("{pkg_name}.{}", platform.archive_ext);
+    let download_base = format!("https://github.com/{REPO}/releases/download");
+    ReleaseAsset {
+        version: tag,
+        pkg_name,
+        archive_name,
+        download_base,
+    }
+}
+
+/// Normalize a user- or API-supplied release tag to a bare `X.Y.Z` version.
+///
+/// Accepts optional `v`/`V` prefix and surrounding whitespace, so `v0.10.0` and
+/// `0.10.0` resolve to the same release.
+pub fn normalize_tag(tag: &str) -> String {
+    let trimmed = tag.trim();
+    trimmed
+        .strip_prefix('v')
+        .or_else(|| trimmed.strip_prefix('V'))
+        .unwrap_or(trimmed)
+        .to_string()
+}
+
+pub fn version_cmp(left: &str, right: &str) -> Ordering {
+    let parse = |s: &str| -> Vec<u64> {
+        normalize_tag(s)
+            .split('.')
+            .map(|p| p.parse().unwrap_or(0))
+            .collect()
+    };
+    let a = parse(left);
+    let b = parse(right);
+    let len = a.len().max(b.len());
+    for i in 0..len {
+        let av = *a.get(i).unwrap_or(&0);
+        let bv = *b.get(i).unwrap_or(&0);
+        match av.cmp(&bv) {
+            Ordering::Equal => {}
+            other => return other,
+        }
+    }
+    Ordering::Equal
+}
+
+pub fn parse_latest_release_tag(body: &[u8]) -> Result<String> {
+    let value: serde_json::Value =
+        serde_json::from_slice(body).context("invalid latest-release JSON")?;
+    value
+        .get("tag_name")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .context("latest-release JSON missing tag_name")
+}
+
+pub fn parse_sha256_file(content: &str) -> Result<String> {
+    let line = content
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .context("checksum file is empty")?;
+    let hash = line
+        .split_whitespace()
+        .next()
+        .context("checksum line missing hash")?;
+    Ok(hash.to_ascii_lowercase())
+}
+
+pub fn verify_sha256(data: &[u8], expected_hex: &str) -> Result<()> {
+    let actual = sha256_hex(data);
+    if actual != expected_hex.to_ascii_lowercase() {
+        bail!("expected {expected_hex}, got {actual}");
+    }
+    Ok(())
+}
+
+pub fn detect_install_method(exe: &Path) -> InstallMethod {
+    let path = exe.to_string_lossy();
+    let canonical = fs::canonicalize(exe).unwrap_or_else(|_| exe.to_path_buf());
+    let canon = canonical.to_string_lossy();
+
+    if cellar_path(&canon) {
+        return InstallMethod::Homebrew;
+    }
+
+    if (path.contains("/homebrew/bin/")
+        || path.contains("/usr/local/bin/")
+        || path.contains("\\homebrew\\bin\\"))
+        && symlink_points_to_cellar(exe)
+    {
+        return InstallMethod::Homebrew;
+    }
+
+    if scoop_install_path(&canon) {
+        return InstallMethod::Scoop;
+    }
+
+    if is_cargo_bin_path(&canon) {
+        return match cargo_install_kind() {
+            CargoInstallKind::Binstall => InstallMethod::CargoBinstall,
+            CargoInstallKind::Install => InstallMethod::CargoInstall,
+            CargoInstallKind::Unknown => InstallMethod::Refuse {
+                hint: "cargo toolchain install detected — use \
+                       `cargo install gistui --force` or `cargo binstall gistui --force`"
+                    .to_string(),
+            },
+        };
+    }
+
+    if looks_managed_system_path(&canon) {
+        return InstallMethod::Refuse {
+            hint: "system-managed path — re-run install.sh or install.ps1".to_string(),
+        };
+    }
+
+    InstallMethod::Standalone
+}
+
+pub fn upgrade_hint(method: &InstallMethod) -> Option<&'static str> {
+    match method {
+        InstallMethod::Homebrew => Some("brew upgrade gistui"),
+        InstallMethod::Scoop => Some("scoop update gistui"),
+        InstallMethod::CargoInstall => Some("cargo install gistui --force"),
+        InstallMethod::CargoBinstall => Some("cargo binstall gistui --force"),
+        InstallMethod::Standalone | InstallMethod::Refuse { .. } => None,
+    }
+}
+
+fn cellar_path(path: &str) -> bool {
+    path.contains("/Cellar/gistui/") || path.contains("\\Cellar\\gistui\\")
+}
+
+/// Scoop installs resolve to `scoop/apps/gistui/...`; the shim on PATH is
+/// `scoop/shims/gistui.exe` — treat both as managed.
+fn scoop_install_path(path: &str) -> bool {
+    const MARKERS: &[&str] = &[
+        "scoop/apps/gistui",
+        "scoop\\apps\\gistui",
+        "scoop/shims/gistui",
+        "scoop\\shims\\gistui",
+    ];
+    MARKERS.iter().any(|marker| path.contains(marker))
+}
+
+fn symlink_points_to_cellar(exe: &Path) -> bool {
+    let meta = match fs::symlink_metadata(exe) {
+        Ok(m) => m,
+        Err(_) => return false,
+    };
+    if !meta.file_type().is_symlink() {
+        return false;
+    }
+    let target = match fs::read_link(exe) {
+        Ok(t) => t,
+        Err(_) => return false,
+    };
+    cellar_path(&target.to_string_lossy())
+}
+
+fn is_cargo_bin_path(path: &str) -> bool {
+    path.contains("/.cargo/bin/gistui")
+        || path.ends_with("\\.cargo\\bin\\gistui.exe")
+        || path.ends_with("/.cargo/bin/gistui.exe")
+}
+
+enum CargoInstallKind {
+    Binstall,
+    Install,
+    Unknown,
+}
+
+fn cargo_install_kind() -> CargoInstallKind {
+    let Some(home) = dirs::home_dir() else {
+        return CargoInstallKind::Unknown;
+    };
+    let crates2 = home.join(".cargo/.crates2.json");
+    if let Ok(raw) = fs::read_to_string(&crates2) {
+        if raw.contains("\"gistui\"") && raw.contains("bin") {
+            return CargoInstallKind::Binstall;
+        }
+    }
+    let crates = home.join(".cargo/.crates.toml");
+    if let Ok(raw) = fs::read_to_string(&crates) {
+        if raw.contains("gistui") {
+            return CargoInstallKind::Install;
+        }
+    }
+    CargoInstallKind::Unknown
+}
+
+fn looks_managed_system_path(path: &str) -> bool {
+    path.starts_with("/usr/bin/")
+        || path.starts_with("/bin/")
+        || path.contains("\\Program Files\\")
+        || path.contains("\\Program Files (x86)\\")
+}
+
+pub fn extract_binary(
+    archive: &[u8],
+    asset: &ReleaseAsset,
+    platform: &Platform,
+) -> Result<Vec<u8>> {
+    match platform.archive_ext {
+        "tar.gz" => extract_from_tar_gz(archive, &asset.pkg_name, &platform.bin_name),
+        "zip" => extract_from_zip(archive, &asset.pkg_name, &platform.bin_name),
+        other => bail!("unsupported archive format: {other}"),
+    }
+}
+
+fn extract_from_tar_gz(archive: &[u8], pkg_name: &str, bin_name: &str) -> Result<Vec<u8>> {
+    let decoder = flate2::read::GzDecoder::new(Cursor::new(archive));
+    let mut archive = tar::Archive::new(decoder);
+    let wanted = format!("{pkg_name}/{bin_name}");
+    for entry in archive.entries().context("invalid tar archive")? {
+        let mut entry = entry.context("invalid tar entry")?;
+        let path = entry.path().context("tar entry missing path")?;
+        if path.to_string_lossy() == wanted {
+            let mut buf = Vec::new();
+            entry
+                .read_to_end(&mut buf)
+                .context("failed to read binary from tar archive")?;
+            return Ok(buf);
+        }
+    }
+    bail!("binary not found in archive at {wanted}");
+}
+
+fn extract_from_zip(archive: &[u8], pkg_name: &str, bin_name: &str) -> Result<Vec<u8>> {
+    let cursor = Cursor::new(archive);
+    let mut zip = zip::ZipArchive::new(cursor).context("invalid zip archive")?;
+    let wanted = format!("{pkg_name}/{bin_name}");
+    let mut file = zip
+        .by_name(&wanted)
+        .with_context(|| format!("binary not found in archive at {wanted}"))?;
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf)
+        .context("failed to read binary from zip archive")?;
+    Ok(buf)
+}
+
+pub fn replace_binary(target: &Path, bytes: &[u8]) -> Result<()> {
+    let parent = target
+        .parent()
+        .context("executable has no parent directory")?;
+    if !is_writable_dir(parent) {
+        bail!("cannot write to {} (permission denied)", parent.display());
+    }
+
+    #[cfg(unix)]
+    {
+        let tmp_name = format!(".gistui-upgrade-{}", std::process::id());
+        let tmp_path = parent.join(tmp_name);
+        fs::write(&tmp_path, bytes).context("failed to write staged binary")?;
+        fs::set_permissions(&tmp_path, fs::Permissions::from_mode(0o755))
+            .context("failed to set executable permissions")?;
+        fs::rename(&tmp_path, target).context("failed to replace running binary")?;
+        Ok(())
+    }
+
+    #[cfg(windows)]
+    {
+        replace_binary_windows(target, bytes)
+    }
+}
+
+#[cfg(windows)]
+fn replace_binary_windows(target: &Path, bytes: &[u8]) -> Result<()> {
+    let parent = target
+        .parent()
+        .context("executable has no parent directory")?;
+    let stem = target
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .context("executable has no file stem")?;
+    let staging = parent.join(format!("{stem}.exe.new"));
+    fs::write(&staging, bytes).context("failed to write staged binary")?;
+
+    // A running .exe cannot be overwritten on Windows. Spawn a detached helper that waits for
+    // this process to exit, then swaps the staged file into place.
+    let script = parent.join(format!("{stem}.upgrade.ps1"));
+    let script_body = format!(
+        "$ErrorActionPreference = 'Stop'\n\
+         $target = '{}'\n\
+         $staging = '{}'\n\
+         $pid = {}\n\
+         while (Get-Process -Id $pid -ErrorAction SilentlyContinue) {{ Start-Sleep -Milliseconds 200 }}\n\
+         Move-Item -Force $staging $target\n\
+         Remove-Item -Force '{}'\n",
+        target.display(),
+        staging.display(),
+        std::process::id(),
+        script.display()
+    );
+    fs::write(&script, script_body).context("failed to write upgrade helper script")?;
+
+    std::process::Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-WindowStyle",
+            "Hidden",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            &script.to_string_lossy(),
+        ])
+        .spawn()
+        .context("failed to spawn Windows upgrade helper")?;
+
+    println!(
+        "upgrade staged; exit this process to finish replacing {}",
+        target.display()
+    );
+    std::process::exit(0);
+}
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+fn is_writable_dir(dir: &Path) -> bool {
+    fs::metadata(dir)
+        .map(|m| !m.permissions().readonly())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    struct FakeClient {
+        latest: String,
+        files: std::collections::HashMap<String, Vec<u8>>,
+    }
+
+    impl ReleaseClient for FakeClient {
+        fn fetch_latest_tag(&self) -> Result<String> {
+            Ok(self.latest.clone())
+        }
+
+        fn download(&self, url: &str) -> Result<Vec<u8>> {
+            self.files
+                .get(url)
+                .cloned()
+                .with_context(|| format!("missing fixture for {url}"))
+        }
+    }
+
+    #[test]
+    fn normalize_tag_accepts_v_prefix_whitespace_and_bare_versions() {
+        assert_eq!(normalize_tag("v0.12.0"), "0.12.0");
+        assert_eq!(normalize_tag("V0.12.0"), "0.12.0");
+        assert_eq!(normalize_tag("0.12.0"), "0.12.0");
+        assert_eq!(normalize_tag("  v0.10.0  "), "0.10.0");
+        assert_eq!(normalize_tag(" 0.10.0 "), "0.10.0");
+    }
+
+    #[test]
+    fn release_asset_treats_v_prefixed_and_bare_versions_equally() {
+        let platform = Platform {
+            target: "aarch64-apple-darwin".to_string(),
+            archive_ext: "tar.gz",
+            bin_name: "gistui".to_string(),
+        };
+        let with_v = release_asset("v0.10.0", &platform);
+        let bare = release_asset("0.10.0", &platform);
+        assert_eq!(with_v, bare);
+        assert_eq!(with_v.version, "v0.10.0");
+        assert_eq!(
+            with_v.archive_name,
+            "gistui-v0.10.0-aarch64-apple-darwin.tar.gz"
+        );
+    }
+
+    #[test]
+    fn version_cmp_orders_semver_like_tags() {
+        assert_eq!(version_cmp("0.11.0", "0.11.0"), Ordering::Equal);
+        assert_eq!(version_cmp("v0.12.0", "0.11.0"), Ordering::Greater);
+        assert_eq!(version_cmp("0.10.9", "0.11.0"), Ordering::Less);
+    }
+
+    #[test]
+    fn release_asset_matches_install_script_naming() {
+        let platform = Platform {
+            target: "aarch64-apple-darwin".to_string(),
+            archive_ext: "tar.gz",
+            bin_name: "gistui".to_string(),
+        };
+        let asset = release_asset("v0.11.0", &platform);
+        assert_eq!(asset.version, "v0.11.0");
+        assert_eq!(asset.pkg_name, "gistui-v0.11.0-aarch64-apple-darwin");
+        assert_eq!(
+            asset.archive_name,
+            "gistui-v0.11.0-aarch64-apple-darwin.tar.gz"
+        );
+    }
+
+    #[test]
+    fn parse_latest_release_tag_reads_tag_name() {
+        let body = br#"{"tag_name":"v0.12.0"}"#;
+        assert_eq!(parse_latest_release_tag(body).unwrap(), "v0.12.0");
+    }
+
+    #[test]
+    fn parse_sha256_file_tolerates_crlf_and_two_field_format() {
+        let hash = "a".repeat(64);
+        let content = format!("{hash}  gistui-v0.11.0-x86_64-apple-darwin.tar.gz\r\n");
+        assert_eq!(parse_sha256_file(&content).unwrap(), hash);
+    }
+
+    #[test]
+    fn verify_sha256_checks_digest() {
+        let data = b"hello";
+        let expected = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
+        verify_sha256(data, expected).unwrap();
+        assert!(verify_sha256(data, "00").is_err());
+    }
+
+    #[test]
+    fn detect_install_method_recognizes_homebrew_cellar() {
+        let method =
+            detect_install_method(Path::new("/opt/homebrew/Cellar/gistui/0.11.0/bin/gistui"));
+        assert_eq!(method, InstallMethod::Homebrew);
+        assert_eq!(upgrade_hint(&method), Some("brew upgrade gistui"));
+    }
+
+    #[test]
+    fn detect_install_method_recognizes_scoop_layout() {
+        let method = detect_install_method(Path::new(
+            "C:/Users/me/scoop/apps/gistui/current/gistui.exe",
+        ));
+        assert_eq!(method, InstallMethod::Scoop);
+    }
+
+    #[test]
+    fn detect_install_method_recognizes_scoop_shim_on_path() {
+        for path in [
+            "C:\\Users\\me\\scoop\\shims\\gistui.exe",
+            "C:/Users/me/scoop/shims/gistui.exe",
+        ] {
+            let method = detect_install_method(Path::new(path));
+            assert_eq!(method, InstallMethod::Scoop, "path: {path}");
+            assert_eq!(upgrade_hint(&method), Some("scoop update gistui"));
+        }
+    }
+
+    #[test]
+    fn scoop_install_path_matches_apps_and_shims() {
+        assert!(scoop_install_path(
+            "C:\\Users\\me\\scoop\\apps\\gistui\\2.0.0\\gistui.exe"
+        ));
+        assert!(scoop_install_path("C:/Users/me/scoop/shims/gistui.exe"));
+        assert!(!scoop_install_path("C:/Users/me/.local/bin/gistui.exe"));
+    }
+
+    #[test]
+    fn looks_managed_system_path_flags_common_locations() {
+        assert!(looks_managed_system_path("/usr/bin/gistui"));
+        assert!(looks_managed_system_path(
+            "C:\\Program Files\\gistui\\gistui.exe"
+        ));
+        assert!(!looks_managed_system_path("/Users/me/.local/bin/gistui"));
+    }
+
+    #[test]
+    fn detect_install_method_treats_local_bin_as_standalone() {
+        let method = detect_install_method(Path::new("/Users/me/.local/bin/gistui"));
+        assert_eq!(method, InstallMethod::Standalone);
+    }
+
+    #[test]
+    fn extract_binary_reads_tar_gz_layout() {
+        let dir = tempdir().unwrap();
+        let archive_path = dir.path().join("asset.tar.gz");
+        {
+            let file = fs::File::create(&archive_path).unwrap();
+            let enc = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+            let mut builder = tar::Builder::new(enc);
+            let mut header = tar::Header::new_gnu();
+            header
+                .set_path("gistui-v0.11.0-x86_64-apple-darwin/gistui")
+                .unwrap();
+            header.set_size(6);
+            header.set_cksum();
+            builder.append(&header, b"BINARY".as_slice()).unwrap();
+            builder.into_inner().unwrap().finish().unwrap();
+        }
+        let bytes = fs::read(&archive_path).unwrap();
+        let asset = release_asset(
+            "0.11.0",
+            &Platform {
+                target: "x86_64-apple-darwin".to_string(),
+                archive_ext: "tar.gz",
+                bin_name: "gistui".to_string(),
+            },
+        );
+        assert_eq!(
+            extract_binary(&bytes, &asset, &detect_platform().unwrap()).unwrap(),
+            b"BINARY"
+        );
+    }
+
+    #[test]
+    fn execute_plan_check_only_exits_when_update_available() {
+        let dir = tempdir().unwrap();
+        let exe = dir.path().join("gistui");
+        fs::write(&exe, b"old").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&exe, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        let platform = Platform {
+            target: "x86_64-apple-darwin".to_string(),
+            archive_ext: "tar.gz",
+            bin_name: "gistui".to_string(),
+        };
+        let asset = release_asset("99.0.0", &platform);
+        let archive_url = format!(
+            "{}/{}/{}",
+            asset.download_base, asset.version, asset.archive_name
+        );
+        let checksum_url = format!("{archive_url}.sha256");
+
+        let mut tar_bytes = Vec::new();
+        {
+            let enc = flate2::write::GzEncoder::new(&mut tar_bytes, flate2::Compression::default());
+            let mut builder = tar::Builder::new(enc);
+            let payload = b"NEW".to_vec();
+            let mut header = tar::Header::new_gnu();
+            header
+                .set_path(format!("{}/gistui", asset.pkg_name))
+                .unwrap();
+            header.set_size(3);
+            header.set_cksum();
+            builder.append(&header, &payload[..]).unwrap();
+            builder.into_inner().unwrap().finish().unwrap();
+        }
+        let hash = sha256_hex(&tar_bytes);
+
+        let client = FakeClient {
+            latest: "v99.0.0".to_string(),
+            files: std::collections::HashMap::from([
+                (archive_url.clone(), tar_bytes),
+                (
+                    checksum_url,
+                    format!("{hash}  {}\n", asset.archive_name).into_bytes(),
+                ),
+            ]),
+        };
+
+        let plan = UpgradePlan {
+            exe_path: exe.clone(),
+            method: InstallMethod::Standalone,
+            current_version: env!("CARGO_PKG_VERSION").to_string(),
+            target_version: String::new(),
+            asset: ReleaseAsset {
+                version: String::new(),
+                pkg_name: String::new(),
+                archive_name: String::new(),
+                download_base: String::new(),
+            },
+            check_only: true,
+        };
+
+        assert_eq!(
+            execute_plan(&plan, &client).unwrap(),
+            ExecuteOutcome::UpdateAvailable
+        );
+    }
+
+    #[test]
+    fn execute_plan_replaces_standalone_binary_on_unix() {
+        if std::env::consts::OS == "windows" {
+            return;
+        }
+        let dir = tempdir().unwrap();
+        let exe = dir.path().join("gistui");
+        fs::write(&exe, b"old").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&exe, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        let platform = detect_platform().unwrap();
+        let asset = release_asset("99.0.0", &platform);
+        let archive_url = format!(
+            "{}/{}/{}",
+            asset.download_base, asset.version, asset.archive_name
+        );
+        let checksum_url = format!("{archive_url}.sha256");
+
+        let mut tar_bytes = Vec::new();
+        {
+            let enc = flate2::write::GzEncoder::new(&mut tar_bytes, flate2::Compression::default());
+            let mut builder = tar::Builder::new(enc);
+            let payload = b"NEW";
+            let mut header = tar::Header::new_gnu();
+            header
+                .set_path(format!("{}/{}", asset.pkg_name, platform.bin_name))
+                .unwrap();
+            header.set_size(3);
+            header.set_cksum();
+            builder.append(&header, &payload[..]).unwrap();
+            builder.into_inner().unwrap().finish().unwrap();
+        }
+        let hash = sha256_hex(&tar_bytes);
+
+        let client = FakeClient {
+            latest: "v99.0.0".to_string(),
+            files: std::collections::HashMap::from([
+                (archive_url, tar_bytes),
+                (
+                    checksum_url,
+                    format!("{hash}  {}\n", asset.archive_name).into_bytes(),
+                ),
+            ]),
+        };
+
+        let plan = UpgradePlan {
+            exe_path: exe.clone(),
+            method: InstallMethod::Standalone,
+            current_version: "0.0.1".to_string(),
+            target_version: String::new(),
+            asset: ReleaseAsset {
+                version: String::new(),
+                pkg_name: String::new(),
+                archive_name: String::new(),
+                download_base: String::new(),
+            },
+            check_only: false,
+        };
+
+        execute_plan(&plan, &client).unwrap();
+        assert_eq!(fs::read(&exe).unwrap(), b"NEW");
+    }
+}


### PR DESCRIPTION
Closes #127

## Summary

Adds a CLI self-upgrade path for pre-built release installs (`install.sh`, `install.ps1`, manual GitHub Release downloads):

- `gistui --upgrade` — upgrade to the latest release
- `gistui --upgrade --check` — compare current vs latest (exit 0 if up to date)
- `gistui --upgrade --upgrade-version <tag>` — pin a release (`v0.10.0` and `0.10.0` both accepted)

The upgrader downloads the same checksummed GitHub Release assets as the install scripts, verifies SHA-256, and replaces the running binary in place (Unix) or via a staged Windows helper script.

## Managed installs

Homebrew, Scoop (including `scoop/shims/gistui.exe`), and cargo/binstall layouts are detected and refused with the appropriate upgrade command instead of overwriting managed files.

## Testing

- 16 unit tests in `src/upgrade.rs` (mocked HTTP/filesystem; no network)
- Manual e2e on macOS aarch64: seeded `0.9.0` binary → `--upgrade --check` → `--upgrade --upgrade-version 0.10.0` / `v0.10.0` / `--upgrade` → verified `gistui 0.10.0` from published release assets

## Docs

- `README.md` — Usage + Upgrading section
- `CHANGELOG.md` — `[Unreleased]` entry