### PR TITLE
fix: exclude AGENTS.md from crate + fix crates.io badge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /target/
 .superpowers/
+# JetBrains IDE project files
+/.idea/
 # Python bytecode + screenshot venv from the demo harness (scripts/demo/)
 __pycache__/
 *.pyc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ exclude = [
     "/scripts",
     "/install.sh",
     "/install.ps1",
+    "/AGENTS.md",
     "/CLAUDE.md",
     "/.gitignore",
 ]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gistui
 
 [![CI](https://github.com/akunzai/gistui/actions/workflows/ci.yml/badge.svg)](https://github.com/akunzai/gistui/actions/workflows/ci.yml)
-[![crates.io](https://img.shields.io/crates/v/gistui.svg)](https://crates.io/crates/gistui)
+[![crates.io](https://badgen.net/crates/v/gistui)](https://crates.io/crates/gistui)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 A terminal UI for managing GitHub Gists. Browse, diff, download, upload, create, edit, and


### PR DESCRIPTION
## What

Packaging/docs hygiene fixes surfaced while fixing the broken crates.io badge:

- **build:** add `/AGENTS.md` to `Cargo.toml` `exclude`. `CLAUDE.md` is a symlink to `AGENTS.md`, so excluding only `/CLAUDE.md` still shipped the real agent-memory file in the published crate.
- **build:** gitignore `/.idea/`. The untracked JetBrains project dir was not ignored, so `cargo package` swept its four files into the published crate.
- **docs:** switch the README crates.io version badge from `img.shields.io` to `badgen.net`. shields.io renders `invalid` because its upstream fetch to the crates.io API is rejected under crates.io's new [data-access policy](https://crates.io/data-access). `badgen.net/crates/v/gistui` resolves the version correctly (currently `v0.11.0`).

Verified with `cargo package --list` — neither `AGENTS.md` nor `.idea/` is now packaged. The static License badge (shields `/badge/` endpoint, not the crates.io API) still renders fine and is left unchanged.

## Notes

No changelog entry — all changes are internal/docs-only (badge URL + packaging metadata).