### PR TITLE
build: exclude contributor/release docs from published crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,10 @@ repository = "https://github.com/akunzai/gistui"
 homepage = "https://akunzai.github.io/gistui/"
 keywords = ["tui", "gist", "github", "cli", "terminal"]
 categories = ["command-line-utilities"]
-# Keep the published crate lean: ship the source, docs and license but not the
-# demo harness, site assets, CI config or install script. The README's demo GIF is
-# referenced by absolute URL, so it still renders on crates.io without shipping it.
+# Keep the published crate lean: ship the source, user docs and license but not
+# the demo harness, site assets, CI config, install scripts or contributor/release
+# process docs. The README's demo GIF is referenced by absolute URL, so it still
+# renders on crates.io without shipping it.
 exclude = [
     "/.github",
     "/docs",
@@ -19,6 +20,8 @@ exclude = [
     "/install.ps1",
     "/AGENTS.md",
     "/CLAUDE.md",
+    "/CONTRIBUTING.md",
+    "/RELEASING.md",
     "/.gitignore",
 ]
 


### PR DESCRIPTION
## What

Follow-up to #131. `CONTRIBUTING.md` and `RELEASING.md` are repo-contributor / maintainer process docs with no value to crate consumers (`cargo install` / docs.rs), so exclude them from the published crate.

Verified with `cargo package --list` — neither is now packaged.

## Notes

No changelog entry — packaging metadata only.