### PR TITLE
feat: browse gist revisions and restore a single file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Gist revision history: press `h` on a gist file in the main list, gist manager, or gist detail view to browse revisions (newest first), show the incremental diff for a revision (`Enter`, parent → selected), diff against the current version (`D`), and restore a single file from an older revision (`r`, `y`/`n` confirm — creates a new revision, unlike `c` compact which deletes history). In revision history, `f` cycles the target file on multi-file gists. Revision diffs are read-only (no `d`/`u` download/upload).
+
 ## [0.11.0] — 2026-06-17
 
 - Built-in light/dark colour theme: set `theme = "light"` in `config.toml` for terminals with a light background, or press `T` at any time to toggle and save instantly.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "gistui"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gistui"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 license = "MIT"
 description = "A terminal UI for managing GitHub Gists"

--- a/README.md
+++ b/README.md
@@ -250,6 +250,8 @@ Press `?` in the app for the full keymap — it now opens the **current screen's
   remembered for the session). Known file types are **syntax-highlighted** by extension. Scroll
   with the arrow keys, or `PageUp`/`PageDown` to jump 10 lines at a time. Inside the preview, `y`
   copies the gist URL and `Y` copies the full file content to the clipboard.
+- `h` (on a gist file) — open **revision history** for that file (same screen as from the gist
+  manager/detail; `f` cycles files when the gist has more than one).
 - `r` — toggle **recursive** local file discovery; the pane title shows `[↓]` while active
   and scans in the background so the UI stays responsive.
 - `a` — flip the **anchor** (which pane drives match ranking); independent of focus, so you
@@ -283,11 +285,19 @@ the gist owning the currently selected file. From here you manage gists as a who
     including the 10th and beyond.
   - `1`–`9` still preview the content of the Nth file directly, full-screen (`↑↓←→` scroll,
     `R` refresh, `w` wrap, `q`/`Esc` back).
-  - `c` compact · `o` browser · `y` copy gist URL · `X` delete the entire gist (`y`/`n` confirm) ·
+  - `h` revision history (browse, incremental diff, diff vs current, restore the cursor file from an older revision) ·
+    `c` compact · `o` browser · `y` copy gist URL · `X` delete the entire gist (`y`/`n` confirm) ·
     `q`/`Esc` back to the gist manager.
 - `X` — delete the entire gist and all its files, after a `y`/`n` confirmation.
 - `o` — open the gist on gist.github.com in your browser.
 - `y` — copy the gist's URL to the system clipboard.
+- `h` — open **revision history** for the selected gist: browse revisions (newest first),
+  show the incremental diff for a revision (`Enter`, parent → selected; initial revision =
+  all additions), diff against the current version (`D`), and restore the target file from an
+  older revision (`r`, `y`/`n` confirm). From gist
+  detail, the target file is the one under the cursor; from the gist manager, it starts on
+  the gist's first file. Press `f` in revision history to cycle the target file when a gist
+  has more than one. Restore uploads old content as a **new** revision (history is kept).
 - `c` — compact revisions: after showing the revision count and a `y`/`n` confirmation, the
   gist is cloned to a temp dir over HTTPS (authenticating through your `gh` token, never SSH
   keys), its history squashed to a single commit, and force-pushed — collapsing all older
@@ -314,6 +324,9 @@ the gist owning the currently selected file. From here you manage gists as a who
   gist (`X` on the list), deleting a whole gist (`X` in the gist manager), and compacting a
   gist's revisions (`c` in the gist manager or detail view — a history-rewriting force-push;
   the confirmation prompt displays the gist's info so the target stays visible while you decide).
+- Restoring a file from an older revision (`r` in revision history) is also confirmed with a
+  full-screen diff, but it **adds** a new revision rather than rewriting history (the opposite
+  of `c` compact).
 - No GitHub token is stored by the app, and gist content is never written to the config
   file — only path↔gist pin mappings are persisted.
 - Clipboard copy (`y` URL, `Y` content) hands the text to the system clipboard via the OS

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -245,6 +245,31 @@ pub fn parse_revision_count(stdout: &str) -> Option<usize> {
     stdout.trim().parse().ok()
 }
 
+/// JSON body for restoring a single file from an old gist revision via `PATCH /gists/{id}`.
+pub fn restore_revision_json(filename: &str, content: &str) -> String {
+    serde_json::json!({
+        "files": {
+            filename: { "content": content }
+        }
+    })
+    .to_string()
+}
+
+/// `gh api --method PATCH` plan that uploads old file content as a new gist revision.
+pub fn restore_revision_command(gist_id: &str, input_path: &Path) -> CommandPlan {
+    CommandPlan {
+        program: "gh".into(),
+        args: vec![
+            "api".into(),
+            "--method".into(),
+            "PATCH".into(),
+            format!("/gists/{gist_id}"),
+            "--input".into(),
+            input_path.display().to_string(),
+        ],
+    }
+}
+
 /// Clones `gist_id` into `dir` as a git working copy (the gist's revisions are its commits).
 ///
 /// Cloned over HTTPS (not `gh gist clone`, which follows the user's `git_protocol` and may
@@ -629,6 +654,30 @@ mod tests {
         let plan = delete_command("abc123");
         assert_eq!(plan.program, "gh");
         assert_eq!(plan.args, vec!["gist", "delete", "--yes", "abc123"]);
+    }
+
+    #[test]
+    fn restore_revision_json_wraps_file_content() {
+        let body = restore_revision_json("config.toml", "old line\n");
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(parsed["files"]["config.toml"]["content"], "old line\n");
+    }
+
+    #[test]
+    fn restore_revision_command_patches_via_input_file() {
+        let plan = restore_revision_command("abc123", Path::new("/tmp/restore.json"));
+        assert_eq!(plan.program, "gh");
+        assert_eq!(
+            plan.args,
+            vec![
+                "api",
+                "--method",
+                "PATCH",
+                "/gists/abc123",
+                "--input",
+                "/tmp/restore.json"
+            ]
+        );
     }
 
     #[test]

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -86,6 +86,31 @@ pub struct GistGroup {
     pub file_count: usize,
 }
 
+/// One entry from `gh api /gists/{id}/commits` — a gist revision (newest-first in the API).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GistRevision {
+    pub version: String,
+    pub committed_at: String,
+    pub user: String,
+    pub change_status: GistRevisionChangeStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GistRevisionChangeStatus {
+    pub total: u32,
+    pub additions: u32,
+    pub deletions: u32,
+}
+
+/// Short git-style prefix of a gist revision `version` SHA for display.
+pub fn short_sha(version: &str) -> &str {
+    if version.len() <= 7 {
+        version
+    } else {
+        &version[..7]
+    }
+}
+
 /// A single gist comment, mirroring one object from `gh api /gists/{id}/comments`.
 /// The body is kept as raw plain text; the TUI wraps it to width (no markdown rendering).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -1,5 +1,5 @@
 use crate::actions::{run_command, CommandPlan, CommandRunner, SystemRunner};
-use crate::domain::{GistComment, GistFile};
+use crate::domain::{GistComment, GistFile, GistRevision, GistRevisionChangeStatus};
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 use std::collections::{BTreeMap, HashMap};
@@ -192,6 +192,124 @@ pub fn fetch_gist_file_content_with(
     run_command(runner, &gist_view_plan(gist_id, filename))
 }
 
+/// Plan for listing every revision of a gist via the REST API.
+pub fn gist_commits_plan(gist_id: &str) -> CommandPlan {
+    CommandPlan {
+        program: "gh".into(),
+        args: vec![
+            "api".into(),
+            "--paginate".into(),
+            format!("/gists/{gist_id}/commits?per_page=100"),
+        ],
+    }
+}
+
+/// Plan for fetching a single gist revision snapshot (files + metadata at that SHA).
+pub fn gist_revision_plan(gist_id: &str, version: &str) -> CommandPlan {
+    CommandPlan {
+        program: "gh".into(),
+        args: vec!["api".into(), format!("/gists/{gist_id}/{version}")],
+    }
+}
+
+pub fn fetch_gist_commits_json(gist_id: &str) -> Result<String> {
+    fetch_gist_commits_json_with(&SystemRunner, gist_id)
+}
+
+pub fn fetch_gist_commits_json_with(runner: &dyn CommandRunner, gist_id: &str) -> Result<String> {
+    run_command(runner, &gist_commits_plan(gist_id))
+}
+
+pub fn fetch_gist_revision_json(gist_id: &str, version: &str) -> Result<String> {
+    fetch_gist_revision_json_with(&SystemRunner, gist_id, version)
+}
+
+pub fn fetch_gist_revision_json_with(
+    runner: &dyn CommandRunner,
+    gist_id: &str,
+    version: &str,
+) -> Result<String> {
+    run_command(runner, &gist_revision_plan(gist_id, version))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RevisionFileContent {
+    Present(String),
+    Truncated,
+    Absent,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhGistCommit {
+    version: String,
+    #[serde(default)]
+    committed_at: String,
+    #[serde(default)]
+    user: Option<GhCommentUser>,
+    #[serde(default)]
+    change_status: GhGistChangeStatus,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct GhGistChangeStatus {
+    #[serde(default)]
+    total: u32,
+    #[serde(default)]
+    additions: u32,
+    #[serde(default)]
+    deletions: u32,
+}
+
+pub fn parse_gist_commits_json(raw: &str) -> Result<Vec<GistRevision>> {
+    let commits: Vec<GhGistCommit> =
+        serde_json::from_str(raw).context("parse gh gist commits JSON")?;
+    Ok(commits
+        .into_iter()
+        .map(|c| GistRevision {
+            version: c.version,
+            committed_at: c.committed_at,
+            user: c
+                .user
+                .map(|u| u.login)
+                .filter(|l| !l.is_empty())
+                .unwrap_or_else(|| "(unknown)".to_string()),
+            change_status: GistRevisionChangeStatus {
+                total: c.change_status.total,
+                additions: c.change_status.additions,
+                deletions: c.change_status.deletions,
+            },
+        })
+        .collect())
+}
+
+/// Extract one file's text from a revision snapshot (`GET /gists/{id}/{sha}`).
+pub fn revision_file_content(raw: &str, filename: &str) -> Result<RevisionFileContent> {
+    let root: serde_json::Value =
+        serde_json::from_str(raw).context("parse gh gist revision JSON")?;
+    let Some(files) = root.get("files").and_then(|f| f.as_object()) else {
+        return Ok(RevisionFileContent::Absent);
+    };
+    if let Some(entry) = files.get(filename) {
+        return classify_revision_file(entry);
+    }
+    for entry in files.values() {
+        if entry.get("filename").and_then(|f| f.as_str()) == Some(filename) {
+            return classify_revision_file(entry);
+        }
+    }
+    Ok(RevisionFileContent::Absent)
+}
+
+fn classify_revision_file(entry: &serde_json::Value) -> Result<RevisionFileContent> {
+    if entry.get("truncated").and_then(|t| t.as_bool()) == Some(true) {
+        return Ok(RevisionFileContent::Truncated);
+    }
+    match entry.get("content").and_then(|c| c.as_str()) {
+        Some(content) => Ok(RevisionFileContent::Present(content.to_string())),
+        None => Ok(RevisionFileContent::Absent),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -218,6 +336,38 @@ mod tests {
         let notes = files.iter().find(|f| f.filename == "notes.md").unwrap();
         assert_eq!(notes.description, "");
         assert!(notes.public);
+    }
+
+    #[test]
+    fn parses_gist_commits_into_revisions() {
+        let raw = include_str!("../tests/fixtures/gh/gist-commits.json");
+        let revisions = parse_gist_commits_json(raw).unwrap();
+        assert_eq!(revisions.len(), 2);
+        assert_eq!(revisions[0].version, "abc111def222333444");
+        assert_eq!(revisions[0].user, "akunzai");
+        assert_eq!(revisions[0].change_status.additions, 2);
+        assert_eq!(revisions[0].change_status.deletions, 1);
+        assert_eq!(revisions[1].committed_at, "2026-06-01T08:00:00Z");
+    }
+
+    #[test]
+    fn revision_file_content_reads_present_and_truncated() {
+        let raw = include_str!("../tests/fixtures/gh/gist-revision.json");
+        match revision_file_content(raw, "settings.json").unwrap() {
+            RevisionFileContent::Present(content) => {
+                assert!(content.contains("\"old\": true"));
+            }
+            other => panic!("expected Present, got {other:?}"),
+        }
+        let truncated = r#"{"files":{"a.txt":{"filename":"a.txt","truncated":true}}}"#;
+        assert_eq!(
+            revision_file_content(truncated, "a.txt").unwrap(),
+            RevisionFileContent::Truncated
+        );
+        assert_eq!(
+            revision_file_content(truncated, "missing.txt").unwrap(),
+            RevisionFileContent::Absent
+        );
     }
 
     #[test]

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -33,6 +33,7 @@ impl AppState {
             Screen::Pins => self.handle_key_pins(code),
             Screen::Gists => self.handle_key_gists(code),
             Screen::GistDetail => self.handle_key_detail(code),
+            Screen::Revisions => self.handle_key_revisions(code),
         }
     }
 
@@ -60,7 +61,7 @@ impl AppState {
                     self.help_index_open = false;
                     self.help_scroll = 0;
                 }
-                KeyCode::Char(c @ '1'..='8') => {
+                KeyCode::Char(c @ '1'..='9') if (c as u8 - b'1') < topics.len() as u8 => {
                     self.help_topic = topics[(c as u8 - b'1') as usize];
                     self.help_index_open = false;
                     self.help_scroll = 0;
@@ -83,7 +84,7 @@ impl AppState {
                         .unwrap_or(0);
                     self.help_index_open = true;
                 }
-                KeyCode::Char(c @ '1'..='8') => {
+                KeyCode::Char(c @ '1'..='9') if (c as u8 - b'1') < topics.len() as u8 => {
                     self.help_topic = topics[(c as u8 - b'1') as usize];
                     self.help_scroll = 0;
                 }
@@ -254,6 +255,11 @@ impl AppState {
             KeyCode::Char('y') if self.gists_index < groups.len() => {
                 return KeyOutcome::CopyGistUrl
             }
+            KeyCode::Char('h') if self.gists_index < groups.len() => {
+                if self.open_revisions(Screen::Gists) {
+                    return KeyOutcome::FetchRevisions;
+                }
+            }
             KeyCode::Char('c') if self.gists_index < groups.len() => {
                 // The revision count needs a network call, so analysis happens in run_loop;
                 // the confirm prompt is raised once the count is back.
@@ -299,6 +305,11 @@ impl AppState {
             KeyCode::PageUp => self.detail_nav(-10),
             KeyCode::Char('o') => return KeyOutcome::OpenBrowser,
             KeyCode::Char('y') => return KeyOutcome::CopyGistUrl,
+            KeyCode::Char('h') => {
+                if self.open_revisions(Screen::GistDetail) {
+                    return KeyOutcome::FetchRevisions;
+                }
+            }
             KeyCode::Char('c') => {
                 self.compact_return_screen = Screen::GistDetail;
                 return KeyOutcome::CompactGist;
@@ -355,6 +366,55 @@ impl AppState {
                         return KeyOutcome::PreviewContent;
                     }
                 }
+            }
+            KeyCode::Char('?') => self.open_help(),
+            _ => {}
+        }
+        KeyOutcome::None
+    }
+
+    fn handle_key_revisions(&mut self, code: KeyCode) -> KeyOutcome {
+        self.status = None;
+        let entries_len = self.revision_entries.as_ref().map(|e| e.len()).unwrap_or(0);
+        match code {
+            KeyCode::Char('q') | KeyCode::Esc => {
+                self.screen = self.revision_return_screen;
+            }
+            KeyCode::Down if entries_len > 0 => {
+                self.revision_index = (self.revision_index + 1).min(entries_len - 1);
+            }
+            KeyCode::Up if entries_len > 0 => {
+                self.revision_index = self.revision_index.saturating_sub(1);
+            }
+            KeyCode::PageDown if entries_len > 0 => {
+                self.revision_index =
+                    (self.revision_index + PAGE_SCROLL as usize).min(entries_len - 1);
+            }
+            KeyCode::PageUp if entries_len > 0 => {
+                self.revision_index = self.revision_index.saturating_sub(PAGE_SCROLL as usize);
+            }
+            KeyCode::Left => {
+                self.revision_hscroll = self.revision_hscroll.saturating_sub(1);
+            }
+            KeyCode::Right => self.revision_hscroll = self.revision_hscroll.saturating_add(1),
+            KeyCode::Enter if entries_len > 0 => return KeyOutcome::RevisionDiffIncremental,
+            KeyCode::Char('D') if entries_len > 0 && self.revision_index > 0 => {
+                return KeyOutcome::RevisionDiff;
+            }
+            KeyCode::Char('D') if entries_len > 0 => {
+                self.set_status("already at current revision");
+            }
+            KeyCode::Char('r') if entries_len > 1 && self.revision_index > 0 => {
+                return KeyOutcome::RestoreRevisionPreview;
+            }
+            KeyCode::Char('r') if entries_len <= 1 => {
+                self.set_status("only one revision — nothing to restore");
+            }
+            KeyCode::Char('r') if self.revision_index == 0 => {
+                self.set_status("already at current revision");
+            }
+            KeyCode::Char('f') if !self.cycle_revision_target_file() => {
+                self.set_status("only one file in this gist");
             }
             KeyCode::Char('?') => self.open_help(),
             _ => {}
@@ -584,6 +644,12 @@ impl AppState {
             }
             KeyCode::Char('S') => return KeyOutcome::SyncSelectedPair,
             KeyCode::Char('g') => self.open_gist_manager(),
+            KeyCode::Char('h') if self.gist_index < self.ranked_gists().len() => {
+                if self.open_revisions(Screen::List) {
+                    return KeyOutcome::FetchRevisions;
+                }
+                self.status = Some("select a gist file to view revision history".into());
+            }
             KeyCode::Char('e') => {
                 if self.selected_local().is_some() {
                     return KeyOutcome::EditLocal;
@@ -803,7 +869,8 @@ impl AppState {
             KeyCode::Right => self.scroll_diff_right(),
             KeyCode::Left => self.scroll_diff_left(),
             // Identical files have nothing to sync, so download/upload are not offered.
-            KeyCode::Char('d') if !self.diff_identical => {
+            // Revision-history diffs are read-only (no local file pairing).
+            KeyCode::Char('d') if self.diff_allows_sync() && !self.diff_identical => {
                 if self.download_target.exists() {
                     self.pending_action = Some(PendingAction::Download);
                     self.screen = Screen::Confirm;
@@ -811,7 +878,9 @@ impl AppState {
                     return KeyOutcome::Download;
                 }
             }
-            KeyCode::Char('u') if !self.diff_identical => return self.upload_intent(),
+            KeyCode::Char('u') if self.diff_allows_sync() && !self.diff_identical => {
+                return self.upload_intent();
+            }
             // Toggle between the configured context radius and the full file; the line
             // count changes, so reset the vertical scroll. The choice is persisted.
             KeyCode::Char('c') => {
@@ -925,6 +994,14 @@ impl AppState {
                     // Return to whichever screen launched the compaction (Gists or GistDetail).
                     self.pending_action = None;
                     self.screen = self.compact_return_screen;
+                }
+                _ => {}
+            },
+            Some(PendingAction::RestoreRevision { .. }) => match code {
+                KeyCode::Char('y') => return KeyOutcome::ExecuteRestoreRevision,
+                KeyCode::Char('n') | KeyCode::Char('q') | KeyCode::Esc => {
+                    self.pending_action = None;
+                    self.screen = Screen::Revisions;
                 }
                 _ => {}
             },

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,4 +1,6 @@
-use crate::domain::{group_gists, GistComment, GistFile, GistGroup, LocalCandidate, PinnedMapping};
+use crate::domain::{
+    group_gists, GistComment, GistFile, GistGroup, GistRevision, LocalCandidate, PinnedMapping,
+};
 use crate::ranking::{rank_gist_files, rank_local_files, MatchReason, RankedGistFile, RankedLocal};
 use anyhow::Result;
 use crossterm::{
@@ -26,6 +28,8 @@ pub enum Screen {
     Gists,
     /// Single-gist detail: basic info + file list + comments (entered from Gists with Enter).
     GistDetail,
+    /// Revision history for one gist (entered with `h` from Gist detail or Gist manager).
+    Revisions,
 }
 
 /// A help topic — one per key-dense area. Ordered for the index list and `1`-`8` quick-jump.
@@ -38,18 +42,20 @@ pub enum HelpTopic {
     Diff,
     Preview,
     Upload,
+    Revisions,
     General,
 }
 
 impl HelpTopic {
     /// All topics in index / quick-jump order.
-    pub fn all() -> [HelpTopic; 8] {
+    pub fn all() -> [HelpTopic; 9] {
         use HelpTopic::*;
         [
             List,
             Pins,
             GistManager,
             GistDetail,
+            Revisions,
             Diff,
             Preview,
             Upload,
@@ -64,6 +70,7 @@ impl HelpTopic {
             HelpTopic::Pins => "Pinned Mappings",
             HelpTopic::GistManager => "Gist manager",
             HelpTopic::GistDetail => "Gist detail",
+            HelpTopic::Revisions => "Revision history",
             HelpTopic::Diff => "Diff view",
             HelpTopic::Preview => "Preview",
             HelpTopic::Upload => "Upload confirmation",
@@ -78,6 +85,7 @@ impl HelpTopic {
             Screen::Pins => HelpTopic::Pins,
             Screen::Gists => HelpTopic::GistManager,
             Screen::GistDetail => HelpTopic::GistDetail,
+            Screen::Revisions => HelpTopic::Revisions,
             _ => HelpTopic::List,
         }
     }
@@ -116,6 +124,13 @@ pub enum PendingAction {
         gist_id: String,
         label: String,
         count: usize,
+    },
+    RestoreRevision {
+        gist_id: String,
+        filename: String,
+        version: String,
+        version_label: String,
+        content: String,
     },
 }
 
@@ -307,6 +322,16 @@ pub enum KeyOutcome {
     CopyPreviewContent,
     /// Toggle the colour theme between dark and light and persist to config (`T`, global).
     ThemeToggle,
+    /// Fetch the revision list for the gist opened on `Screen::Revisions`.
+    FetchRevisions,
+    /// Diff the target file: parent revision → selected revision (incremental).
+    RevisionDiffIncremental,
+    /// Diff the target file: selected revision vs current head.
+    RevisionDiff,
+    /// Fetch revision + head content and stage a restore confirm.
+    RestoreRevisionPreview,
+    /// Apply a confirmed single-file revision restore (`PATCH`).
+    ExecuteRestoreRevision,
 }
 
 #[derive(Debug, Clone)]
@@ -435,6 +460,19 @@ pub struct AppState {
     pub theme_choice: crate::config::ThemeChoice,
     /// Resolved colour palette for the current theme choice (from config).
     pub theme: Theme,
+    /// Gist whose revisions are shown on `Screen::Revisions`.
+    pub revision_gist_id: Option<String>,
+    /// Fetched revision rows (`None` while the initial list fetch is in flight).
+    pub revision_entries: Option<Vec<GistRevision>>,
+    /// Cursor into `revision_entries` (0 = current head).
+    pub revision_index: usize,
+    pub revision_hscroll: u16,
+    /// File within the gist that preview/diff/restore target.
+    pub revision_target_file: String,
+    /// Where `q`/`Esc` returns from `Screen::Revisions`.
+    pub revision_return_screen: Screen,
+    /// Error from the commits-list fetch, if any.
+    pub revision_fetch_error: Option<String>,
 }
 
 fn unranked_gists(gists: Vec<GistFile>) -> Vec<RankedGistFile> {
@@ -713,6 +751,91 @@ impl AppState {
     }
 
     /// Look up a gist group by id (unaffected by filtering); used by detail + confirm background.
+    /// Open `Screen::Revisions` for the gist on `return_screen`. Returns false when no gist
+    /// is selected or the gist has no files.
+    pub fn open_revisions(&mut self, return_screen: Screen) -> bool {
+        let gist_id = match return_screen {
+            Screen::List => self.selected_gist().map(|g| g.file.gist_id.clone()),
+            Screen::GistDetail => self.detail_gist_id.clone(),
+            Screen::Gists => self.selected_group().map(|g| g.id.clone()),
+            _ => None,
+        };
+        let Some(gist_id) = gist_id else {
+            return false;
+        };
+        let filenames = self.gist_filenames(&gist_id);
+        let target_file = match return_screen {
+            Screen::List => self
+                .selected_gist()
+                .map(|g| g.file.filename.clone())
+                .filter(|f| filenames.iter().any(|name| name == f)),
+            Screen::GistDetail => filenames
+                .into_iter()
+                .nth(self.detail_file_cursor)
+                .or_else(|| self.gist_filenames(&gist_id).first().cloned()),
+            Screen::Gists => filenames.first().cloned(),
+            _ => None,
+        };
+        let Some(target_file) = target_file else {
+            return false;
+        };
+        self.revision_gist_id = Some(gist_id);
+        self.revision_target_file = target_file;
+        self.revision_return_screen = return_screen;
+        self.revision_index = 0;
+        self.revision_hscroll = 0;
+        self.revision_entries = None;
+        self.revision_fetch_error = None;
+        self.screen = Screen::Revisions;
+        true
+    }
+
+    pub fn selected_revision(&self) -> Option<&GistRevision> {
+        let entries = self.revision_entries.as_ref()?;
+        entries.get(self.revision_index)
+    }
+
+    /// Advance `revision_target_file` to the next filename in this gist (wraps). Returns
+    /// false when the gist has at most one file.
+    pub fn cycle_revision_target_file(&mut self) -> bool {
+        let Some(gist_id) = self.revision_gist_id.clone() else {
+            return false;
+        };
+        let files = self.gist_filenames(&gist_id);
+        if files.len() <= 1 {
+            return false;
+        }
+        let current = files
+            .iter()
+            .position(|f| f == &self.revision_target_file)
+            .unwrap_or(0);
+        self.revision_target_file = files[(current + 1) % files.len()].clone();
+        true
+    }
+
+    /// True when the diff view supports local↔gist download/upload (`d`/`u`). Revision-history
+    /// diffs (returning to `Screen::Revisions`) are read-only comparisons.
+    pub fn diff_allows_sync(&self) -> bool {
+        self.diff_return != Screen::Revisions
+    }
+
+    /// Footer label for the revision-history target file, including `(n/total)` when multi-file.
+    pub fn revision_target_file_label(&self) -> String {
+        let Some(gist_id) = self.revision_gist_id.as_deref() else {
+            return self.revision_target_file.clone();
+        };
+        let files = self.gist_filenames(gist_id);
+        if files.len() <= 1 {
+            return self.revision_target_file.clone();
+        }
+        let pos = files
+            .iter()
+            .position(|f| f == &self.revision_target_file)
+            .map(|i| i + 1)
+            .unwrap_or(1);
+        format!("{} ({pos}/{})", self.revision_target_file, files.len())
+    }
+
     pub fn group_by_id(&self, gist_id: &str) -> Option<GistGroup> {
         self.gist_groups().into_iter().find(|g| g.id == gist_id)
     }
@@ -1031,6 +1154,13 @@ pub fn initial_state() -> AppState {
         gist_comment_counts: std::collections::HashMap::new(),
         theme_choice: crate::config::ThemeChoice::Dark,
         theme: Theme::DARK,
+        revision_gist_id: None,
+        revision_entries: None,
+        revision_index: 0,
+        revision_hscroll: 0,
+        revision_target_file: String::new(),
+        revision_return_screen: Screen::GistDetail,
+        revision_fetch_error: None,
     }
 }
 

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -27,6 +27,7 @@ pub(super) fn render(frame: &mut Frame, state: &AppState) {
         Screen::Pins => render_pins(frame, state),
         Screen::Gists => render_gists(frame, state),
         Screen::GistDetail => render_gist_detail(frame, state),
+        Screen::Revisions => render_revisions(frame, state),
     }
     if let Some(ref msg) = state.bg_task_msg {
         render_loading_overlay(frame, msg, state.spinner_frame, &state.theme);
@@ -72,6 +73,7 @@ Actions (on the selected local file + gist)
              pane — Gist pane = download view, Local pane = upload view
              (--- old / +++ new; local label = yellow, gist label = blue)
   Space      preview the gist file's content (R in preview to force-refresh)
+  h          open revision history for the selected gist file
   d          download the gist into the cwd
   u          upload the local file into the gist
   n          create a new gist from the local file (type a description, then s/p)
@@ -110,6 +112,7 @@ Actions (on the selected local file + gist)
   Enter      open the gist detail view (info, file list, comments)
   o          open the gist in your web browser
   y          copy the gist's URL to the system clipboard
+  h          open revision history (browse, diff, restore)
   c          compact revisions: squash history to one commit (force-push, y/n confirm)
   X          delete the entire gist and all its files (y/n confirm)
   q / Esc    back to the list"
@@ -121,11 +124,23 @@ Actions (on the selected local file + gist)
   PageUp/Dn  page comments / file cursor by 10
   Enter      preview the cursor-selected file (file list focused)
   1-9        preview the content of the Nth file (full-screen; R refresh, q back)
+  h          open revision history for this gist (target = cursor file)
   c          compact revisions (y/n confirm; gist info shown as context)
   o          open the gist in your web browser
   y          copy the gist's URL to the system clipboard
   X          delete the entire gist and all its files (y/n confirm)
   q / Esc    back to the gist manager"
+        }
+        HelpTopic::Revisions => {
+            "\
+  Up/Down    move between revisions (newest first; row 0 = current)
+  PageUp/Dn  page by 10
+  Left/Right scroll a long row horizontally
+  Enter      diff this revision vs its parent (incremental; initial = all additions)
+  f          cycle the target file (multi-file gists; wraps)
+  D          diff the target file: selected revision vs current (read-only; no download/upload)
+  r          restore the target file from the selected revision (y/n confirm)
+  q / Esc    back"
         }
         HelpTopic::Diff => {
             "\
@@ -464,7 +479,7 @@ pub(super) fn render_gists(frame: &mut Frame, state: &AppState) {
     } else {
         (
             String::new(),
-            "↑↓ move · ←→ scroll · Enter detail · / filter · s sort · v type · e desc · o browser · c compact · X delete · ? help · q back"
+            "↑↓ move · ←→ scroll · Enter detail · / filter · s sort · v type · e desc · h history · o browser · c compact · X delete · ? help · q back"
                 .to_string(),
             true,
         )
@@ -575,6 +590,131 @@ pub(super) fn gist_info_line(group: &GistGroup, now: u64) -> String {
         "{vis} · created {created} · updated {updated} · {}",
         group.id
     )
+}
+
+pub(super) fn revision_row_label(
+    rev: &crate::domain::GistRevision,
+    index: usize,
+    now: u64,
+) -> String {
+    let age = crate::domain::parse_rfc3339_to_unix(&rev.committed_at)
+        .map(|t| crate::domain::humanize_age(now as i64 - t as i64))
+        .unwrap_or_else(|| "?".into());
+    let delta = format!(
+        "+{}/-{}",
+        rev.change_status.additions, rev.change_status.deletions
+    );
+    let sha = crate::domain::short_sha(&rev.version);
+    let current = if index == 0 { " (current)" } else { "" };
+    format!(
+        "#{}  {} ago  {}  {}  {}{}",
+        index + 1,
+        age,
+        delta,
+        rev.user,
+        sha,
+        current
+    )
+}
+
+pub(super) fn render_revisions(frame: &mut Frame, state: &AppState) {
+    let area = frame.area();
+    let (ftitle, footer, colored) = if let Some(message) = &state.status {
+        (String::new(), message.clone(), false)
+    } else if state.revision_entries.is_none() {
+        (String::new(), "Loading revisions…".to_string(), false)
+    } else if let Some(err) = &state.revision_fetch_error {
+        (String::new(), err.clone(), false)
+    } else {
+        (
+            String::new(),
+            {
+                let file = state.revision_target_file_label();
+                let file_key = if state
+                    .revision_gist_id
+                    .as_ref()
+                    .is_some_and(|id| state.gist_filenames(id).len() > 1)
+                {
+                    "f next file · "
+                } else {
+                    ""
+                };
+                format!(
+                    "file={file} · {file_key}Enter incremental diff · D vs current · r restore · ? help · q back"
+                )
+            },
+            true,
+        )
+    };
+    let footer_lines = wrap_line_count(&footer, area.width.saturating_sub(2)).max(1);
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(3), Constraint::Length(footer_lines + 1)])
+        .split(area);
+
+    let gist_id = state.revision_gist_id.as_deref().unwrap_or("");
+    let label = state
+        .group_by_id(gist_id)
+        .map(|g| {
+            if g.description.trim().is_empty() {
+                g.id.clone()
+            } else {
+                g.description.clone()
+            }
+        })
+        .unwrap_or_else(|| gist_id.to_string());
+    let count = state
+        .revision_entries
+        .as_ref()
+        .map(|e| e.len())
+        .unwrap_or(0);
+    let now = unix_now();
+
+    let items: Vec<ListItem> =
+        match &state.revision_entries {
+            None => vec![ListItem::new("  ⏳ Loading revisions…")
+                .style(Style::default().fg(state.theme.dim))],
+            Some(entries) if entries.is_empty() => {
+                vec![ListItem::new("  📭 No revisions found")
+                    .style(Style::default().fg(state.theme.dim))]
+            }
+            Some(entries) => entries
+                .iter()
+                .enumerate()
+                .map(|(i, rev)| {
+                    ListItem::new(hscroll_str(
+                        &revision_row_label(rev, i, now),
+                        state.revision_hscroll,
+                    ))
+                })
+                .collect(),
+        };
+
+    let selected = (count > 0).then_some(state.revision_index);
+    let title = format!("Revisions: {label} {}", count_label(count, count));
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .title(title)
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(Style::default().fg(state.theme.accent))
+                .style(state.theme.base_style())
+                .padding(Padding::horizontal(1)),
+        )
+        .style(state.theme.base_style())
+        .highlight_style(
+            Style::default()
+                .bg(state.theme.accent)
+                .fg(state.theme.fg_on_accent)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▶ ");
+
+    let mut list_state = ListState::default();
+    list_state.select(selected);
+    frame.render_stateful_widget(list, chunks[0], &mut list_state);
+    render_footer(frame, chunks[1], &ftitle, &footer, colored, &state.theme);
 }
 
 /// Current Unix time in seconds (saturating to 0 before the epoch); used for relative-age labels.
@@ -810,10 +950,10 @@ pub(super) fn footer_with_status(status: Option<&str>, hints: &str) -> (String, 
 pub(super) fn detail_footer(status: Option<&str>, focus: DetailFocus) -> (String, bool) {
     let hints = match focus {
         DetailFocus::Comments => {
-            "Tab files · ↑↓ scroll · 1-9 preview · c compact · o browser · X delete · ? help · q back"
+            "Tab files · ↑↓ scroll · 1-9 preview · h history · c compact · o browser · X delete · ? help · q back"
         }
         DetailFocus::Files => {
-            "Tab comments · ↑↓ select · ⏎ preview · 1-9 preview · c compact · o browser · X delete · ? help · q back"
+            "Tab comments · ↑↓ select · ⏎ preview · 1-9 preview · h history · c compact · o browser · X delete · ? help · q back"
         }
     };
     footer_with_status(status, hints)
@@ -960,6 +1100,7 @@ pub(super) fn commands_hint(focus: FocusPane) -> String {
         FocusPane::Local => items.extend(["r recursive", "e edit", "n create", "P pins"]),
         FocusPane::Gist => items.extend([
             "Space preview",
+            "h history",
             "d download",
             "u upload",
             "X remove file",
@@ -1697,6 +1838,15 @@ pub(super) fn confirm_prompt(state: &AppState) -> String {
                 "Compact {count} revisions of \"{label}\" into one? This force-pushes and cannot be undone. (y/n)"
             )
         }
+        Some(PendingAction::RestoreRevision {
+            filename,
+            version_label,
+            ..
+        }) => {
+            format!(
+                "Restore {filename} to revision {version_label}? This uploads old content as a new revision. (y/n)"
+            )
+        }
         _ => format!(
             "Overwrite {}? (y/n)",
             crate::config::display_path(&state.download_target)
@@ -1718,6 +1868,7 @@ pub(super) fn confirm_modal_style(state: &AppState) -> (&'static str, Color) {
         Some(PendingAction::Delete { .. }) => ("Delete", theme.del_color),
         Some(PendingAction::RemoveFile { .. }) => ("Remove file", theme.del_color),
         Some(PendingAction::CompactGist { .. }) => ("Compact revisions", theme.del_color),
+        Some(PendingAction::RestoreRevision { .. }) => ("Restore revision", theme.notice_color),
         _ => ("Overwrite", theme.del_color),
     }
 }
@@ -1780,19 +1931,30 @@ pub(super) fn render_diff_pane(frame: &mut Frame, area: Rect, state: &AppState) 
 /// #72 audit: this footer intentionally does not surface `state.status`. Diff actions (`d`/`u`)
 /// transition to `Screen::Confirm` or to the IO that lands back on `List`; their results surface
 /// on those destination screens (which read `state.status`), so no status is set while on Diff.
-pub(super) fn render_diff(frame: &mut Frame, state: &AppState) {
+/// Footer hints for `Screen::Diff` (pure for tests).
+pub(super) fn diff_footer(state: &AppState) -> String {
     let context = if state.diff_show_full {
         "c context [full]".to_string()
     } else {
         format!("c context [{}]", state.diff_context)
     };
-    let footer = if state.diff_identical {
-        format!(
-            "Files are identical — nothing to sync  ·  ↑↓←→ PgUp/Dn scroll  ·  {context}  ·  Esc/q back"
-        )
+    let scroll = "↑↓←→ PgUp/Dn scroll";
+    let back = "Esc/q back";
+    if !state.diff_allows_sync() {
+        if state.diff_identical {
+            format!("Files are identical  ·  {scroll}  ·  {context}  ·  {back}")
+        } else {
+            format!("{scroll}  ·  {context}  ·  {back}")
+        }
+    } else if state.diff_identical {
+        format!("Files are identical — nothing to sync  ·  {scroll}  ·  {context}  ·  {back}")
     } else {
-        format!("↑↓←→ PgUp/Dn scroll  ·  d download  ·  u upload  ·  {context}  ·  Esc/q back")
-    };
+        format!("{scroll}  ·  d download  ·  u upload  ·  {context}  ·  {back}")
+    }
+}
+
+pub(super) fn render_diff(frame: &mut Frame, state: &AppState) {
+    let footer = diff_footer(state);
 
     let area = frame.area();
     let footer_lines = wrap_line_count(&footer, area.width.saturating_sub(2)).max(1);

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -322,6 +322,125 @@ pub(super) fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) ->
                     BgTaskOutcome::CommentsFetched { gist_id, result } => {
                         state.apply_fetched_comments(&gist_id, result);
                     }
+                    BgTaskOutcome::RevisionsFetched { gist_id, result } => {
+                        if state.revision_gist_id.as_deref() != Some(gist_id.as_str()) {
+                            continue;
+                        }
+                        match result {
+                            Ok(entries) => {
+                                state.revision_fetch_error = None;
+                                state.revision_entries = Some(entries);
+                                if state
+                                    .revision_entries
+                                    .as_ref()
+                                    .is_some_and(|e| e.len() <= 1)
+                                {
+                                    state.set_status("only one revision — nothing to restore");
+                                }
+                            }
+                            Err(error) => {
+                                state.revision_entries = Some(Vec::new());
+                                state.revision_fetch_error = Some(error);
+                            }
+                        }
+                    }
+                    BgTaskOutcome::RevisionDiff {
+                        result,
+                        old_label,
+                        new_label,
+                    } => match result {
+                        Ok((old_content, new_content)) => {
+                            let diff = crate::diff::unified_diff(
+                                &old_label,
+                                &old_content,
+                                &new_label,
+                                &new_content,
+                            );
+                            state.diff_text = diff;
+                            state.diff_scroll = 0;
+                            state.diff_hscroll = 0;
+                            state.diff_identical = old_content == new_content;
+                            state.diff_return = Screen::Revisions;
+                            state.pending_action = None;
+                            state.screen = Screen::Diff;
+                        }
+                        Err(error) => state.set_status(error),
+                    },
+                    BgTaskOutcome::RestoreRevisionReady {
+                        result,
+                        gist_id,
+                        filename,
+                        version,
+                        version_label,
+                    } => match result {
+                        Ok((revision_content, current_content)) => {
+                            if revision_content == current_content {
+                                state.set_status("revision matches current — nothing to restore");
+                                continue;
+                            }
+                            let old_label = format!("revision {version_label}");
+                            let new_label = format!("current {filename}");
+                            let diff = crate::diff::unified_diff(
+                                &old_label,
+                                &revision_content,
+                                &new_label,
+                                &current_content,
+                            );
+                            state.diff_text = diff;
+                            state.diff_scroll = 0;
+                            state.diff_hscroll = 0;
+                            state.diff_identical = false;
+                            state.pending_action = Some(PendingAction::RestoreRevision {
+                                gist_id,
+                                filename,
+                                version,
+                                version_label,
+                                content: revision_content,
+                            });
+                            state.screen = Screen::Confirm;
+                        }
+                        Err(error) => state.set_status(error),
+                    },
+                    BgTaskOutcome::RestoreRevisionDone {
+                        result,
+                        gist_id,
+                        filename,
+                    } => match result {
+                        Ok(_) => {
+                            state
+                                .gist_content_cache
+                                .remove(&(gist_id.clone(), filename.clone()));
+                            state.set_status(format!(
+                                "Restored {filename} from old revision (new revision created)"
+                            ));
+                            state.pending_action = None;
+                            state.screen = Screen::Revisions;
+                            state.revision_index = 0;
+                            state.revision_entries = None;
+                            state.loading = true;
+                            gist_rx = Some(spawn_gist_fetch());
+                            if let Some(gist_id) = state.revision_gist_id.clone() {
+                                spawn_bg(
+                                    &mut state,
+                                    &mut bg_rx,
+                                    "Loading revisions…",
+                                    move || {
+                                        let result = crate::gh::fetch_gist_commits_json(&gist_id)
+                                            .map_err(|e| e.to_string())
+                                            .and_then(|raw| {
+                                                crate::gh::parse_gist_commits_json(&raw)
+                                                    .map_err(|e| e.to_string())
+                                            });
+                                        BgTaskOutcome::RevisionsFetched { gist_id, result }
+                                    },
+                                );
+                            }
+                        }
+                        Err(error) => {
+                            state.set_status(format!("restore failed: {error}"));
+                            state.screen = Screen::Confirm;
+                        }
+                    },
                 }
             }
         }
@@ -866,6 +985,138 @@ pub(super) fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) ->
                 }
                 KeyOutcome::PersistDiffContext => persist_diff_context(&mut state),
                 KeyOutcome::ThemeToggle => persist_theme(&mut state),
+                KeyOutcome::FetchRevisions => {
+                    let Some(gist_id) = state.revision_gist_id.clone() else {
+                        continue;
+                    };
+                    spawn_bg(&mut state, &mut bg_rx, "Loading revisions…", move || {
+                        let result = crate::gh::fetch_gist_commits_json(&gist_id)
+                            .map_err(|e| e.to_string())
+                            .and_then(|raw| {
+                                crate::gh::parse_gist_commits_json(&raw).map_err(|e| e.to_string())
+                            });
+                        BgTaskOutcome::RevisionsFetched { gist_id, result }
+                    });
+                }
+                KeyOutcome::RevisionDiffIncremental => {
+                    let Some(gist_id) = state.revision_gist_id.clone() else {
+                        continue;
+                    };
+                    let Some(child) = state.selected_revision().cloned() else {
+                        continue;
+                    };
+                    let filename = state.revision_target_file.clone();
+                    let child_version = child.version.clone();
+                    let child_label = revision_version_label(&child);
+                    let parent = state
+                        .revision_entries
+                        .as_ref()
+                        .and_then(|entries| entries.get(state.revision_index + 1).cloned());
+                    let (parent_version, old_label) = match parent {
+                        Some(parent) => {
+                            let label = revision_version_label(&parent);
+                            (Some(parent.version), format!("revision {label}"))
+                        }
+                        None => (None, "(initial)".into()),
+                    };
+                    let new_label = format!("revision {child_label}");
+                    spawn_bg(&mut state, &mut bg_rx, "Loading diff…", move || {
+                        let result = fetch_revision_incremental_pair(
+                            &gist_id,
+                            &child_version,
+                            parent_version.as_deref(),
+                            &filename,
+                        );
+                        BgTaskOutcome::RevisionDiff {
+                            result,
+                            old_label,
+                            new_label,
+                        }
+                    });
+                }
+                KeyOutcome::RevisionDiff => {
+                    let Some(gist_id) = state.revision_gist_id.clone() else {
+                        continue;
+                    };
+                    let Some(revision) = state.selected_revision().cloned() else {
+                        continue;
+                    };
+                    let filename = state.revision_target_file.clone();
+                    let version = revision.version.clone();
+                    let version_label = revision_version_label(&revision);
+                    let old_label = format!("revision {version_label}");
+                    let new_label = format!("current {filename}");
+                    spawn_bg(&mut state, &mut bg_rx, "Loading diff…", move || {
+                        let result = fetch_revision_pair(
+                            &gist_id, &version, &filename, &old_label, &new_label,
+                        );
+                        BgTaskOutcome::RevisionDiff {
+                            result,
+                            old_label,
+                            new_label,
+                        }
+                    });
+                }
+                KeyOutcome::RestoreRevisionPreview => {
+                    let Some(gist_id) = state.revision_gist_id.clone() else {
+                        continue;
+                    };
+                    let Some(revision) = state.selected_revision().cloned() else {
+                        continue;
+                    };
+                    let filename = state.revision_target_file.clone();
+                    let version = revision.version.clone();
+                    let version_label = revision_version_label(&revision);
+                    spawn_bg(&mut state, &mut bg_rx, "Loading revision…", move || {
+                        let result = fetch_revision_pair_for_restore(&gist_id, &version, &filename);
+                        BgTaskOutcome::RestoreRevisionReady {
+                            result,
+                            gist_id,
+                            filename,
+                            version,
+                            version_label,
+                        }
+                    });
+                }
+                KeyOutcome::ExecuteRestoreRevision => {
+                    let Some(PendingAction::RestoreRevision {
+                        gist_id,
+                        filename,
+                        content,
+                        ..
+                    }) = state.pending_action.clone()
+                    else {
+                        continue;
+                    };
+                    let timestamp = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_nanos())
+                        .unwrap_or(0);
+                    let temp_dir = state.cwd.join(format!(".gistui_restore_{timestamp}"));
+                    if let Err(e) = std::fs::create_dir_all(&temp_dir) {
+                        state.set_status(format!("failed to create temp dir: {e}"));
+                        continue;
+                    }
+                    let json_path = temp_dir.join("restore.json");
+                    let body = crate::actions::restore_revision_json(&filename, &content);
+                    if let Err(e) = std::fs::write(&json_path, &body) {
+                        state.set_status(format!("failed to write restore payload: {e}"));
+                        let _ = std::fs::remove_dir_all(&temp_dir);
+                        continue;
+                    }
+                    let plan = crate::actions::restore_revision_command(&gist_id, &json_path);
+                    spawn_bg(&mut state, &mut bg_rx, "Restoring revision…", move || {
+                        let result = crate::actions::execute_command(&plan)
+                            .map(|_| ())
+                            .map_err(|e| e.to_string());
+                        let _ = std::fs::remove_dir_all(&temp_dir);
+                        BgTaskOutcome::RestoreRevisionDone {
+                            result,
+                            gist_id,
+                            filename,
+                        }
+                    });
+                }
                 KeyOutcome::None => {}
             }
         }
@@ -943,6 +1194,108 @@ enum BgTaskOutcome {
         gist_id: String,
         result: Result<Vec<GistComment>, String>,
     },
+    RevisionsFetched {
+        gist_id: String,
+        result: std::result::Result<Vec<crate::domain::GistRevision>, String>,
+    },
+    RevisionDiff {
+        result: std::result::Result<(String, String), String>,
+        old_label: String,
+        new_label: String,
+    },
+    RestoreRevisionReady {
+        result: std::result::Result<(String, String), String>,
+        gist_id: String,
+        filename: String,
+        version: String,
+        version_label: String,
+    },
+    RestoreRevisionDone {
+        result: std::result::Result<(), String>,
+        gist_id: String,
+        filename: String,
+    },
+}
+
+fn revision_version_label(revision: &crate::domain::GistRevision) -> String {
+    let sha = crate::domain::short_sha(&revision.version);
+    let age = crate::domain::parse_rfc3339_to_unix(&revision.committed_at)
+        .map(|t| {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+            crate::domain::humanize_age(now as i64 - t as i64)
+        })
+        .unwrap_or_else(|| "?".into());
+    format!("{sha} ({age} ago)")
+}
+
+fn fetch_revision_file_content(
+    gist_id: &str,
+    version: &str,
+    filename: &str,
+) -> std::result::Result<String, String> {
+    let raw = crate::gh::fetch_gist_revision_json(gist_id, version).map_err(|e| e.to_string())?;
+    match crate::gh::revision_file_content(&raw, filename).map_err(|e| e.to_string())? {
+        crate::gh::RevisionFileContent::Present(content) => Ok(content),
+        crate::gh::RevisionFileContent::Truncated => {
+            Err("file too large for API preview (>1 MB)".into())
+        }
+        crate::gh::RevisionFileContent::Absent => {
+            Err(format!("{filename} not present in this revision"))
+        }
+    }
+}
+
+fn fetch_revision_file_content_optional(
+    gist_id: &str,
+    version: &str,
+    filename: &str,
+) -> std::result::Result<String, String> {
+    let raw = crate::gh::fetch_gist_revision_json(gist_id, version).map_err(|e| e.to_string())?;
+    match crate::gh::revision_file_content(&raw, filename).map_err(|e| e.to_string())? {
+        crate::gh::RevisionFileContent::Present(content) => Ok(content),
+        crate::gh::RevisionFileContent::Truncated => {
+            Err("file too large for API preview (>1 MB)".into())
+        }
+        crate::gh::RevisionFileContent::Absent => Ok(String::new()),
+    }
+}
+
+fn fetch_revision_incremental_pair(
+    gist_id: &str,
+    child_version: &str,
+    parent_version: Option<&str>,
+    filename: &str,
+) -> std::result::Result<(String, String), String> {
+    let new_content = fetch_revision_file_content_optional(gist_id, child_version, filename)?;
+    let old_content = match parent_version {
+        Some(parent) => fetch_revision_file_content_optional(gist_id, parent, filename)?,
+        None => String::new(),
+    };
+    Ok((old_content, new_content))
+}
+
+fn fetch_revision_pair(
+    gist_id: &str,
+    version: &str,
+    filename: &str,
+    _old_label: &str,
+    _new_label: &str,
+) -> std::result::Result<(String, String), String> {
+    let old_content = fetch_revision_file_content(gist_id, version, filename)?;
+    let new_content =
+        crate::gh::fetch_gist_file_content(gist_id, filename).map_err(|e| e.to_string())?;
+    Ok((old_content, new_content))
+}
+
+fn fetch_revision_pair_for_restore(
+    gist_id: &str,
+    version: &str,
+    filename: &str,
+) -> std::result::Result<(String, String), String> {
+    fetch_revision_pair(gist_id, version, filename, "", "")
 }
 
 fn cache_gists(gists: &[GistFile]) {

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1147,6 +1147,7 @@ fn commands_hint_is_focus_aware() {
     assert!(!local.contains("d download"));
 
     let gist = commands_hint(FocusPane::Gist);
+    assert!(gist.contains("h history"));
     assert!(gist.contains("d download"));
     assert!(gist.contains("g gists"));
     assert!(!gist.contains("e edit"));
@@ -2982,9 +2983,10 @@ fn pins_filter_input_behaviors() {
 #[test]
 fn help_topic_all_is_ordered_and_titled() {
     let all = HelpTopic::all();
-    assert_eq!(all.len(), 8);
+    assert_eq!(all.len(), 9);
     assert_eq!(all[0], HelpTopic::List);
-    assert_eq!(all[7], HelpTopic::General);
+    assert_eq!(all[4], HelpTopic::Revisions);
+    assert_eq!(all[8], HelpTopic::General);
     assert_eq!(HelpTopic::Pins.title(), "Pinned Mappings");
 }
 
@@ -2997,7 +2999,202 @@ fn help_topic_for_screen_maps_key_dense_screens() {
         HelpTopic::for_screen(Screen::GistDetail),
         HelpTopic::GistDetail
     );
+    assert_eq!(
+        HelpTopic::for_screen(Screen::Revisions),
+        HelpTopic::Revisions
+    );
     assert_eq!(HelpTopic::for_screen(Screen::Diff), HelpTopic::List);
+}
+
+#[test]
+fn h_from_list_opens_revisions_for_selected_gist_file() {
+    let mut state = list_state_with_matches();
+    state.focus = FocusPane::Gist;
+    state.gist_index = 0;
+    let outcome = state.handle_key(KeyCode::Char('h'));
+    assert_eq!(outcome, KeyOutcome::FetchRevisions);
+    assert_eq!(state.screen, Screen::Revisions);
+    assert_eq!(state.revision_gist_id.as_deref(), Some("a"));
+    assert_eq!(state.revision_target_file, "settings.json");
+    assert_eq!(state.revision_return_screen, Screen::List);
+}
+
+#[test]
+fn h_from_gist_detail_opens_revisions_and_fetches() {
+    let mut state = state_with_gists();
+    state.screen = Screen::GistDetail;
+    state.detail_gist_id = Some("g1".into());
+    state.detail_file_cursor = 1;
+    let outcome = state.handle_key(KeyCode::Char('h'));
+    assert_eq!(outcome, KeyOutcome::FetchRevisions);
+    assert_eq!(state.screen, Screen::Revisions);
+    assert_eq!(state.revision_gist_id.as_deref(), Some("g1"));
+    assert_eq!(state.revision_target_file, "b.txt");
+    assert_eq!(state.revision_return_screen, Screen::GistDetail);
+    assert!(state.revision_entries.is_none());
+}
+
+#[test]
+fn revisions_r_on_head_is_blocked() {
+    let mut state = state_with_gists();
+    state.screen = Screen::Revisions;
+    state.revision_entries = Some(vec![crate::domain::GistRevision {
+        version: "abc".into(),
+        committed_at: "2026-06-10T00:00:00Z".into(),
+        user: "u".into(),
+        change_status: crate::domain::GistRevisionChangeStatus {
+            total: 1,
+            additions: 1,
+            deletions: 0,
+        },
+    }]);
+    state.handle_key(KeyCode::Char('r'));
+    assert_eq!(
+        state.status.as_deref(),
+        Some("only one revision — nothing to restore")
+    );
+}
+
+#[test]
+fn revisions_capital_d_on_current_shows_status() {
+    let mut state = state_with_gists();
+    state.screen = Screen::Revisions;
+    state.revision_index = 0;
+    state.revision_entries = Some(vec![
+        crate::domain::GistRevision {
+            version: "v2".into(),
+            committed_at: "2026-06-10T00:00:00Z".into(),
+            user: "u".into(),
+            change_status: crate::domain::GistRevisionChangeStatus {
+                total: 1,
+                additions: 1,
+                deletions: 0,
+            },
+        },
+        crate::domain::GistRevision {
+            version: "v1".into(),
+            committed_at: "2026-06-01T00:00:00Z".into(),
+            user: "u".into(),
+            change_status: crate::domain::GistRevisionChangeStatus {
+                total: 2,
+                additions: 2,
+                deletions: 0,
+            },
+        },
+    ]);
+    assert_eq!(state.handle_key(KeyCode::Char('D')), KeyOutcome::None);
+    assert_eq!(state.status.as_deref(), Some("already at current revision"));
+    state.revision_index = 1;
+    assert_eq!(
+        state.handle_key(KeyCode::Char('D')),
+        KeyOutcome::RevisionDiff
+    );
+}
+
+#[test]
+fn revisions_enter_triggers_incremental_diff() {
+    let mut state = state_with_gists();
+    state.screen = Screen::Revisions;
+    state.revision_index = 0;
+    state.revision_entries = Some(vec![
+        crate::domain::GistRevision {
+            version: "v2".into(),
+            committed_at: "2026-06-10T00:00:00Z".into(),
+            user: "u".into(),
+            change_status: crate::domain::GistRevisionChangeStatus {
+                total: 1,
+                additions: 1,
+                deletions: 0,
+            },
+        },
+        crate::domain::GistRevision {
+            version: "v1".into(),
+            committed_at: "2026-06-01T00:00:00Z".into(),
+            user: "u".into(),
+            change_status: crate::domain::GistRevisionChangeStatus {
+                total: 2,
+                additions: 2,
+                deletions: 0,
+            },
+        },
+    ]);
+    assert_eq!(
+        state.handle_key(KeyCode::Enter),
+        KeyOutcome::RevisionDiffIncremental
+    );
+    state.revision_index = 1;
+    assert_eq!(
+        state.handle_key(KeyCode::Enter),
+        KeyOutcome::RevisionDiffIncremental
+    );
+}
+
+#[test]
+fn revision_diff_omits_download_upload() {
+    let mut state = initial_state();
+    state.screen = Screen::Diff;
+    state.diff_return = Screen::Revisions;
+    state.diff_identical = false;
+    let footer = diff_footer(&state);
+    assert!(!footer.contains("download"));
+    assert!(!footer.contains("upload"));
+    assert_eq!(state.handle_key(KeyCode::Char('d')), KeyOutcome::None);
+    assert_eq!(state.handle_key(KeyCode::Char('u')), KeyOutcome::None);
+}
+
+#[test]
+fn revisions_f_cycles_target_file() {
+    let mut state = state_with_gists();
+    state.screen = Screen::Revisions;
+    state.revision_gist_id = Some("g1".into());
+    state.revision_target_file = "a.txt".into();
+    state.revision_entries = Some(vec![]);
+    state.handle_key(KeyCode::Char('f'));
+    assert_eq!(state.revision_target_file, "b.txt");
+    state.handle_key(KeyCode::Char('f'));
+    assert_eq!(state.revision_target_file, "a.txt");
+    assert_eq!(state.revision_target_file_label(), "a.txt (1/2)");
+}
+
+#[test]
+fn revisions_f_on_single_file_gist_shows_status() {
+    let mut state = initial_state();
+    state.gists = vec![GistFile {
+        gist_id: "g1".into(),
+        description: "solo".into(),
+        filename: "only.txt".into(),
+        public: false,
+        updated_at: "x".into(),
+        created_at: "x".into(),
+    }];
+    state.screen = Screen::Revisions;
+    state.revision_gist_id = Some("g1".into());
+    state.revision_target_file = "only.txt".into();
+    state.revision_entries = Some(vec![]);
+    state.handle_key(KeyCode::Char('f'));
+    assert_eq!(state.status.as_deref(), Some("only one file in this gist"));
+}
+
+#[test]
+fn restore_revision_confirm_prompt_and_y_intent() {
+    let mut state = state_with_gists();
+    state.screen = Screen::Confirm;
+    state.pending_action = Some(PendingAction::RestoreRevision {
+        gist_id: "g1".into(),
+        filename: "a.txt".into(),
+        version: "oldsha".into(),
+        version_label: "oldsha (3d ago)".into(),
+        content: "old\n".into(),
+    });
+    assert_eq!(
+        confirm_modal_style(&state),
+        ("Restore revision", Color::Yellow)
+    );
+    assert!(confirm_prompt(&state).contains("Restore a.txt to revision oldsha (3d ago)"));
+    assert_eq!(
+        state.handle_key(KeyCode::Char('y')),
+        KeyOutcome::ExecuteRestoreRevision
+    );
 }
 
 #[test]

--- a/tests/fixtures/gh/gist-commits.json
+++ b/tests/fixtures/gh/gist-commits.json
@@ -1,0 +1,16 @@
+[
+  {
+    "url": "https://api.github.com/gists/abc123/abc111def222",
+    "version": "abc111def222333444",
+    "user": { "login": "akunzai" },
+    "change_status": { "total": 3, "additions": 2, "deletions": 1 },
+    "committed_at": "2026-06-14T10:00:00Z"
+  },
+  {
+    "url": "https://api.github.com/gists/abc123/xyz999aaa888",
+    "version": "xyz999aaa888777666",
+    "user": { "login": "akunzai" },
+    "change_status": { "total": 10, "additions": 10, "deletions": 0 },
+    "committed_at": "2026-06-01T08:00:00Z"
+  }
+]

--- a/tests/fixtures/gh/gist-revision.json
+++ b/tests/fixtures/gh/gist-revision.json
@@ -1,0 +1,18 @@
+{
+  "url": "https://api.github.com/gists/abc123/xyz999aaa888",
+  "id": "abc123",
+  "files": {
+    "settings.json": {
+      "filename": "settings.json",
+      "type": "application/json",
+      "language": "JSON",
+      "raw_url": "https://gist.githubusercontent.com/abc123/raw/xyz999/settings.json",
+      "size": 24,
+      "truncated": false,
+      "content": "{\n  \"old\": true\n}\n"
+    }
+  },
+  "public": false,
+  "created_at": "2026-06-01T00:00:00Z",
+  "updated_at": "2026-06-01T08:00:00Z"
+}


### PR DESCRIPTION
## Summary

Implements #133 — gist revision history with single-file restore.

### Entry
- **`h`** from main list (gist file), Gist manager, or Gist detail

### Revision list
- Newest first; **only revisions that changed the target file** (snapshot compare after commit list fetch)
- **`f`** cycles target file on multi-file gists and re-filters

### Keymap
| Key | Action |
|-----|--------|
| `Enter` | Incremental diff (parent → selected) |
| `D` | Diff vs current head (read-only) |
| `r` | Restore target file (`PATCH`, new revision) + `y/n` confirm |

### Version
- `0.12.0` in `Cargo.toml`; CHANGELOG under `[Unreleased]` until release tag.

## Verification

- [x] `cargo fmt --check`
- [x] `cargo test` (332 tests)
- [x] `cargo check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] CI green

Closes #133