### PR TITLE
feat: mouse support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Mouse support: wheel scroll, click to focus/select, double-click to open, and a clickable close button on pop-up screens (on by default; disable with `mouse = false` or `--no-mouse`).
+
 ## [0.12.0] — 2026-06-19
 
 - Vim-style navigation: `h`/`j`/`k`/`l` move and scroll alongside arrow keys; `Ctrl+b` / `Ctrl+f` page up/down by 10 (same as PageUp/PageDown) on every scrollable screen, including the main list (Files/Gists panes), Pins, and Gist manager. Revision history is now `H` (was `h`); cycling the revision target file is `F` (was `f`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "gistui"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gistui"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 license = "MIT"
 description = "A terminal UI for managing GitHub Gists"

--- a/README.md
+++ b/README.md
@@ -78,13 +78,24 @@ Press **`?`** anytime for the **full, contextual keymap** — it opens the curre
 topic; `Tab` browses all topics (List, Pins, Gist manager, Gist detail, Diff, Preview, …).
 The footer also shows keys for the focused pane.
 
+**Mouse** (on by default; disable with `mouse = false` in config or `--no-mouse`):
+
+| Action | Effect |
+|--------|--------|
+| Wheel up/down | scroll the focused list or content pane |
+| Click a row | select it (List panes also switch focus) |
+| Double-click a row | open it — List diff, gist detail, pin diff, revision diff, or file preview (same as `Enter`) |
+| Click a tab (Gist details) | switch between Files / Comments |
+| Click `[✕]` button (pop-up screens) | close / go back |
+
 ## Safety
 
 gistui is conservative about writes: downloads land only in `./<gist-filename>`; an existing
 file is never overwritten without a diff and `y/n` confirmation; destructive remote actions
 each get their own confirm. Others' gists (e.g. starred) are read-only for pin/upload/delete
 — fork with `F` in gist detail. No GitHub token is stored; gist content is never written to
-config.
+config. Mouse is on by default and can be disabled with `mouse = false` in the config file or
+the `--no-mouse` flag.
 
 Full rules: **[reference/SAFETY.md](reference/SAFETY.md)**.
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -18,6 +18,11 @@ diff_show_full = false
 # Use "light" for terminals with a light background colour.
 # theme = "dark"
 
+# Enable mouse support: wheel scroll, click to focus/select, double-click to open,
+# and a clickable [Esc]/[n] close button on pop-up screens. Default: true.
+# (The `--no-mouse` CLI flag also forces it off for a single session.)
+mouse = true
+
 # Directories skipped when recursive local file discovery is active (r key).
 # Hidden directories (names starting with ".") are always skipped regardless
 # of this list. Add project-specific build output dirs here as needed.

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,10 @@ fn default_diff_context() -> u32 {
     3
 }
 
+fn default_mouse() -> bool {
+    true
+}
+
 fn default_skip_dirs() -> Vec<String> {
     [
         "node_modules",
@@ -64,6 +68,10 @@ pub struct AppConfig {
     /// Built-in colour theme: `"dark"` (default) or `"light"`.
     #[serde(default)]
     pub theme: ThemeChoice,
+    /// Enable mouse support (wheel scroll, click-to-focus/select). Default `true`;
+    /// set `false` to opt out (the `--no-mouse` CLI flag also forces it off).
+    #[serde(default = "default_mouse")]
+    pub mouse: bool,
 }
 
 impl Default for AppConfig {
@@ -75,6 +83,7 @@ impl Default for AppConfig {
             diff_context: default_diff_context(),
             diff_show_full: false,
             theme: ThemeChoice::Dark,
+            mouse: true,
         }
     }
 }
@@ -168,6 +177,12 @@ pub fn save_config(path: &Path, config: &AppConfig) -> Result<()> {
     fs::write(path, raw).with_context(|| format!("write {}", path.display()))
 }
 
+/// Effective mouse-enabled state: the config value, with the `--no-mouse` CLI flag able
+/// to force it off. There is intentionally no `--mouse` flag — edit the config to force on.
+pub fn resolve_mouse_enabled(config_mouse: bool, no_mouse: bool) -> bool {
+    config_mouse && !no_mouse
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -225,6 +240,7 @@ mod tests {
             diff_context: default_diff_context(),
             diff_show_full: false,
             theme: ThemeChoice::Dark,
+            mouse: true,
         };
 
         save_config(&path, &config).unwrap();
@@ -393,5 +409,32 @@ mod tests {
             assert_eq!(display_path(&p), display_path_with_home(&p, Some(&home)));
             assert_eq!(display_path(&p), "~/code/gistui");
         }
+    }
+
+    #[test]
+    fn mouse_defaults_to_true_when_absent() {
+        // A config file with no `mouse` key must load as enabled.
+        let toml = "scan_depth = 4\n";
+        let config: AppConfig = toml::from_str(toml).unwrap();
+        assert!(config.mouse);
+    }
+
+    #[test]
+    fn mouse_round_trips() {
+        let config = AppConfig {
+            mouse: false,
+            ..Default::default()
+        };
+        let text = toml::to_string(&config).unwrap();
+        let parsed: AppConfig = toml::from_str(&text).unwrap();
+        assert!(!parsed.mouse);
+    }
+
+    #[test]
+    fn resolve_mouse_enabled_truth_table() {
+        assert!(resolve_mouse_enabled(true, false)); // default on, no flag
+        assert!(!resolve_mouse_enabled(true, true)); // flag forces off
+        assert!(!resolve_mouse_enabled(false, false)); // config off
+        assert!(!resolve_mouse_enabled(false, true)); // both off
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,11 @@ struct Cli {
         help = "Working directory to pair files against (defaults to the current directory)"
     )]
     path: Option<PathBuf>,
+    #[arg(
+        long = "no-mouse",
+        help = "Disable mouse capture (scroll/click) for this session"
+    )]
+    no_mouse: bool,
 }
 
 fn main() -> Result<()> {
@@ -51,5 +56,5 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    gistui::tui::run()
+    gistui::tui::run(cli.no_mouse)
 }

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -550,17 +550,7 @@ impl AppState {
             KeyCode::Char('F') => return self.fork_intent(),
             // 1–9 preview the content of the Nth file in the gist (full-screen preview).
             KeyCode::Char(c @ '1'..='9') => {
-                if let Some(gist_id) = self.detail_gist_id.clone() {
-                    let index = (c as u8 - b'1') as usize;
-                    if let Some(filename) = self.gist_filenames(&gist_id).into_iter().nth(index) {
-                        if self.block_if_non_previewable_gist_file(&gist_id, &filename) {
-                            return KeyOutcome::None;
-                        }
-                        self.preview_request = Some((gist_id, filename));
-                        self.preview_return = Screen::GistDetail;
-                        return KeyOutcome::PreviewContent;
-                    }
-                }
+                return self.preview_detail_file((c as u8 - b'1') as usize);
             }
             KeyCode::Tab => {
                 self.detail_focus = match self.detail_focus {
@@ -722,6 +712,215 @@ impl AppState {
             Err(error) => {
                 self.detail_comments = Some(Vec::new());
                 self.detail_comments_error = Some(error);
+            }
+        }
+    }
+
+    /// Number of navigation steps per mouse wheel tick. List/index screens move one row;
+    /// content panes (Diff, Preview, Confirm, GistDetail) scroll three lines for faster
+    /// panning. Help body also scrolls three; the Help topic index is a list (one row).
+    fn wheel_step(&self) -> usize {
+        match self.screen {
+            Screen::Diff | Screen::Preview | Screen::Confirm => 3,
+            // GistDetail: the comments body scrolls like content (3 lines); the file list
+            // steps one file at a time.
+            Screen::GistDetail if self.detail_focus == DetailFocus::Comments => 3,
+            Screen::Help if !self.help_index_open => 3, // help body scrolls; topic index is a list
+            _ => 1, // List/Pins/Gists/Revisions/Help index/GistDetail Files
+        }
+    }
+
+    /// Select the clicked list row on the current screen, focusing its pane/list. Returns
+    /// `true` when a row was hit (so a double-click should "open" it). A click in a pane's
+    /// blank area or border focuses it but selects nothing (returns `false`); a click off
+    /// every list returns `false`.
+    fn click_select(&mut self, col: u16, row: u16, layout: &MouseLayout) -> bool {
+        match self.screen {
+            Screen::List => {
+                if let Some(hit) = layout.local {
+                    if point_in(hit.rect, col, row) {
+                        // A click anywhere in the pane (incl. blank/border) focuses it; a
+                        // click on a row also selects it.
+                        self.focus = FocusPane::Local;
+                        if let Some(idx) = hit.index_at(row, self.visible_locals().len()) {
+                            self.local_index = idx;
+                            self.local_hscroll = 0;
+                            if self.anchor == FocusPane::Local {
+                                self.reset_ranked_pane();
+                            }
+                            return true;
+                        }
+                        return false;
+                    }
+                }
+                if let Some(hit) = layout.gist {
+                    if point_in(hit.rect, col, row) {
+                        self.focus = FocusPane::Gist;
+                        if let Some(idx) = hit.index_at(row, self.ranked_gists().len()) {
+                            self.gist_index = idx;
+                            self.gist_hscroll = 0;
+                            if self.anchor == FocusPane::Gist {
+                                self.reset_ranked_pane();
+                            }
+                            return true;
+                        }
+                        return false;
+                    }
+                }
+                false
+            }
+            Screen::Gists => {
+                if let Some(hit) = layout.list {
+                    if point_in(hit.rect, col, row) {
+                        if let Some(idx) = hit.index_at(row, self.visible_gist_groups().len()) {
+                            self.gists_index = idx;
+                            self.gists_hscroll = 0;
+                            return true;
+                        }
+                    }
+                }
+                false
+            }
+            Screen::Pins => {
+                if let Some(hit) = layout.list {
+                    if point_in(hit.rect, col, row) {
+                        if let Some(idx) = hit.index_at(row, self.visible_pin_indices().len()) {
+                            self.pins_index = idx;
+                            self.pins_hscroll = 0;
+                            return true;
+                        }
+                    }
+                }
+                false
+            }
+            Screen::Revisions => {
+                if let Some(hit) = layout.list {
+                    if point_in(hit.rect, col, row) {
+                        let count = self.revision_entries.as_ref().map_or(0, |e| e.len());
+                        if let Some(idx) = hit.index_at(row, count) {
+                            self.revision_index = idx;
+                            self.revision_hscroll = 0;
+                            return true;
+                        }
+                    }
+                }
+                false
+            }
+            Screen::GistDetail => {
+                if let Some(hit) = layout.detail_files {
+                    if point_in(hit.rect, col, row) {
+                        // Clicking the file list focuses the Files tab; a row also moves the cursor.
+                        self.detail_focus = DetailFocus::Files;
+                        let count = self
+                            .detail_gist_id
+                            .as_deref()
+                            .map_or(0, |id| self.gist_filenames(id).len());
+                        if let Some(idx) = hit.index_at(row, count) {
+                            self.detail_file_cursor = idx;
+                            return true;
+                        }
+                    }
+                }
+                false
+            }
+            _ => false,
+        }
+    }
+
+    /// Open/activate the currently selected row on the current screen (the double-click
+    /// action), reusing each screen's `Enter` behaviour where one exists.
+    fn activate_selected(&mut self) -> KeyOutcome {
+        match self.screen {
+            // GistDetail files have no `Enter`; they preview via number keys, so a
+            // double-click previews the file under the cursor.
+            Screen::GistDetail => self.preview_detail_file(self.detail_file_cursor),
+            _ => self.handle_key_with(KeyCode::Enter, KeyModifiers::NONE),
+        }
+    }
+
+    /// Preview the `index`-th file of the gist shown on `Screen::GistDetail` (full-screen),
+    /// the action behind the `1`–`9` keys and a file double-click.
+    fn preview_detail_file(&mut self, index: usize) -> KeyOutcome {
+        if let Some(gist_id) = self.detail_gist_id.clone() {
+            if let Some(filename) = self.gist_filenames(&gist_id).into_iter().nth(index) {
+                if self.block_if_non_previewable_gist_file(&gist_id, &filename) {
+                    return KeyOutcome::None;
+                }
+                self.preview_request = Some((gist_id, filename));
+                self.preview_return = Screen::GistDetail;
+                return KeyOutcome::PreviewContent;
+            }
+        }
+        KeyOutcome::None
+    }
+
+    /// Switch the GistDetail tab if `col`/`row` lands on a tab header. Returns the outcome
+    /// (possibly `FetchComments`) when a tab was clicked, else `None` to fall through.
+    fn click_detail_tab(&mut self, col: u16, row: u16, layout: &MouseLayout) -> Option<KeyOutcome> {
+        if self.screen != Screen::GistDetail {
+            return None;
+        }
+        if let Some(rect) = layout.detail_tab_files {
+            if point_in(rect, col, row) {
+                self.detail_focus = DetailFocus::Files;
+                return Some(KeyOutcome::None);
+            }
+        }
+        if let Some(rect) = layout.detail_tab_comments {
+            if point_in(rect, col, row) {
+                self.detail_focus = DetailFocus::Comments;
+                if self.detail_comments.is_none() && !self.detail_comments_loading {
+                    return Some(KeyOutcome::FetchComments);
+                }
+                return Some(KeyOutcome::None);
+            }
+        }
+        None
+    }
+
+    /// Translate a classified mouse intent into a state change, reusing existing keyboard
+    /// logic. Pure (no IO, no clock); returns a `KeyOutcome` so `run_loop` can perform any
+    /// follow-up IO (e.g. `PreviewDiff` on double-click).
+    pub fn handle_mouse(&mut self, input: MouseInput, layout: &MouseLayout) -> KeyOutcome {
+        match input {
+            MouseInput::ScrollUp | MouseInput::ScrollDown => {
+                let action = if matches!(input, MouseInput::ScrollUp) {
+                    NavAction::Up
+                } else {
+                    NavAction::Down
+                };
+                for _ in 0..self.wheel_step() {
+                    self.apply_navigation(action);
+                }
+                KeyOutcome::None
+            }
+            MouseInput::Click { col, row } => {
+                // Close button takes priority on non-List screens.
+                if let Some(rect) = layout.close_button {
+                    if point_in(rect, col, row) {
+                        // Esc is the universal cancel across all screens and all
+                        // pending-action variants (including the create-description
+                        // editing sub-state where 'n' would type into the field).
+                        return self.handle_key_with(KeyCode::Esc, KeyModifiers::NONE);
+                    }
+                }
+                // A GistDetail tab header click switches focus (single-click action).
+                if let Some(outcome) = self.click_detail_tab(col, row, layout) {
+                    return outcome;
+                }
+                self.click_select(col, row, layout);
+                KeyOutcome::None
+            }
+            MouseInput::DoubleClick { col, row } => {
+                // A tab double-click is just a tab switch (no "open").
+                if let Some(outcome) = self.click_detail_tab(col, row, layout) {
+                    return outcome;
+                }
+                if self.click_select(col, row, layout) {
+                    // Selection landed on a row — open/activate it.
+                    return self.activate_selected();
+                }
+                KeyOutcome::None
             }
         }
     }
@@ -1304,4 +1503,9 @@ impl AppState {
         }
         KeyOutcome::None
     }
+}
+
+/// Whether a column/row position lands inside a `Rect`.
+fn point_in(rect: ratatui::layout::Rect, col: u16, row: u16) -> bool {
+    col >= rect.x && col < rect.right() && row >= rect.y && row < rect.bottom()
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -4,10 +4,11 @@ use crate::domain::{
 use crate::ranking::{rank_gist_files, rank_local_files, MatchReason, RankedGistFile, RankedLocal};
 use anyhow::Result;
 use crossterm::{
+    event::{DisableMouseCapture, EnableMouseCapture},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ratatui::{backend::CrosstermBackend, widgets::Clear, Terminal};
+use ratatui::{backend::CrosstermBackend, layout::Rect, widgets::Clear, Terminal};
 use std::io;
 use std::path::PathBuf;
 
@@ -360,6 +361,72 @@ pub enum KeyOutcome {
     ForkGist,
 }
 
+/// A clickable list pane recorded by `render` for the current frame.
+/// `offset` is ratatui's first-visible-item index, captured after the list renders.
+#[derive(Debug, Clone, Copy)]
+pub struct PaneHit {
+    pub rect: Rect,
+    pub offset: usize,
+}
+
+impl PaneHit {
+    /// Map an absolute terminal `row` to a list index, or `None` for border rows,
+    /// rows past the last item, or an empty list. `visible_len` is the count of
+    /// currently visible rows (e.g. `visible_locals().len()` / `ranked_gists().len()`).
+    pub fn index_at(&self, row: u16, visible_len: usize) -> Option<usize> {
+        let top = self.rect.y + 1; // skip the top border
+        let bottom = self.rect.bottom().saturating_sub(1); // exclusive of bottom border
+        if row < top || row >= bottom {
+            return None;
+        }
+        let idx = self.offset + (row - top) as usize;
+        (idx < visible_len).then_some(idx)
+    }
+}
+
+/// Per-frame mouse hit regions, owned by `run_loop`, filled by `render`.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct MouseLayout {
+    pub local: Option<PaneHit>,
+    pub gist: Option<PaneHit>,
+    /// Single-list screens (Gists / Pins / Revisions).
+    pub list: Option<PaneHit>,
+    /// GistDetail file list (Files tab).
+    pub detail_files: Option<PaneHit>,
+    /// GistDetail "Files" / "Comments" tab headers (clickable to switch focus).
+    pub detail_tab_files: Option<Rect>,
+    pub detail_tab_comments: Option<Rect>,
+    pub close_button: Option<Rect>,
+}
+
+/// A classified mouse intent handed to the pure `handle_mouse`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MouseInput {
+    ScrollUp,
+    ScrollDown,
+    Click { col: u16, row: u16 },
+    DoubleClick { col: u16, row: u16 },
+}
+
+/// Max gap between two left-clicks on the same cell to count as a double-click.
+pub const DOUBLE_CLICK_MS: u128 = 400;
+
+/// Classify a left-button press as a single or double click. `prev` is the (col,row) of
+/// the previous left press; `elapsed_ms` is the time since it. Pure: the caller (run_loop)
+/// owns the clock and supplies the elapsed milliseconds.
+pub fn classify_click(
+    prev: Option<(u16, u16)>,
+    elapsed_ms: u128,
+    col: u16,
+    row: u16,
+) -> MouseInput {
+    if prev == Some((col, row)) && elapsed_ms <= DOUBLE_CLICK_MS {
+        MouseInput::DoubleClick { col, row }
+    } else {
+        MouseInput::Click { col, row }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct AppState {
     pub locals: Vec<LocalCandidate>,
@@ -413,6 +480,9 @@ pub struct AppState {
     /// Syntax-highlight file content in the preview and diff-context lines (issue #69).
     /// Defaults on; `load_startup_state` turns it off when `NO_COLOR` is set in the environment.
     pub syntax_highlight: bool,
+    /// Whether mouse capture is active this session (config `mouse` AND-NOT `--no-mouse`).
+    /// Gates the `Event::Mouse` branch and the close-button rendering.
+    pub mouse_enabled: bool,
     pub preview_gist_key: Option<(String, String)>,
     /// Screen to return to when leaving the full-screen preview (default: List; set to
     /// GistDetail when a detail-view file preview is launched).
@@ -1317,6 +1387,7 @@ pub fn initial_state() -> AppState {
         preview_title: String::new(),
         preview_wrap: false,
         syntax_highlight: true,
+        mouse_enabled: true,
         preview_gist_key: None,
         preview_return: Screen::List,
         preview_request: None,
@@ -1381,7 +1452,7 @@ pub fn initial_state() -> AppState {
     }
 }
 
-pub fn load_startup_state() -> Result<AppState> {
+pub fn load_startup_state(no_mouse: bool) -> Result<AppState> {
     let mut state = initial_state();
     let config_path = crate::config::config_path()?;
     let config = crate::config::load_config(&config_path)?;
@@ -1396,6 +1467,7 @@ pub fn load_startup_state() -> Result<AppState> {
     state.theme = Theme::for_choice(config.theme);
     // Honour NO_COLOR for the syntax-highlight feature only (existing semantic colours stay).
     state.syntax_highlight = std::env::var_os("NO_COLOR").is_none();
+    state.mouse_enabled = crate::config::resolve_mouse_enabled(config.mouse, no_mouse);
     state.locals = crate::local::discover_local_candidates(
         &cwd,
         &state.pinned,
@@ -1425,17 +1497,22 @@ pub fn load_startup_state() -> Result<AppState> {
     Ok(state)
 }
 
-pub fn run() -> Result<()> {
+pub fn run(no_mouse: bool) -> Result<()> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen)?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let result = run_loop(&mut terminal);
+    let result = run_loop(&mut terminal, no_mouse);
 
     let _ = disable_raw_mode();
     let _ = execute!(terminal.backend_mut(), LeaveAlternateScreen);
+    // Always emitted (harmless if capture was never enabled), so it runs even on error.
+    let _ = execute!(
+        terminal.backend_mut(),
+        crossterm::event::DisableMouseCapture
+    );
 
     result
 }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -11,7 +11,8 @@ use ratatui::{
 };
 use similar::{ChangeTag, TextDiff};
 
-pub(super) fn render(frame: &mut Frame, state: &AppState) {
+pub(super) fn render(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout) {
+    *layout = MouseLayout::default();
     // Paint the full canvas so every unfilled cell uses the theme background (no-op for dark
     // theme where bg=Reset, effective for light theme which sets a grey canvas).
     frame.render_widget(
@@ -19,19 +20,34 @@ pub(super) fn render(frame: &mut Frame, state: &AppState) {
         frame.area(),
     );
     match state.screen {
-        Screen::List => render_list(frame, state),
-        Screen::Diff => render_diff(frame, state),
-        Screen::Confirm => render_confirm(frame, state),
-        Screen::Preview => render_preview(frame, state),
-        Screen::Help => render_help(frame, state),
-        Screen::Pins => render_pins(frame, state),
-        Screen::Gists => render_gists(frame, state),
-        Screen::GistDetail => render_gist_detail(frame, state),
-        Screen::Revisions => render_revisions(frame, state),
+        Screen::List => render_list(frame, state, layout),
+        Screen::Diff => render_diff(frame, state, layout),
+        Screen::Confirm => render_confirm(frame, state, layout),
+        Screen::Preview => render_preview(frame, state, layout),
+        Screen::Help => render_help(frame, state, layout),
+        Screen::Pins => render_pins(frame, state, layout),
+        Screen::Gists => render_gists(frame, state, layout),
+        Screen::GistDetail => render_gist_detail(frame, state, layout),
+        Screen::Revisions => render_revisions(frame, state, layout),
     }
     if let Some(ref msg) = state.bg_task_msg {
         render_loading_overlay(frame, msg, state.spinner_frame, &state.theme);
     }
+}
+
+fn render_close_button(frame: &mut Frame, outer: Rect, theme: &Theme) -> Rect {
+    let text = "[✕]";
+    let width = text.chars().count() as u16;
+    if outer.width < width + 2 || outer.height == 0 {
+        return Rect::new(outer.x, outer.y, 0, 0);
+    }
+    let x = outer.right().saturating_sub(width + 1);
+    let rect = Rect::new(x, outer.y, width, 1);
+    frame.render_widget(
+        Paragraph::new(Span::styled(text, Style::default().fg(theme.accent))),
+        rect,
+    );
+    rect
 }
 
 /// A count suffix for a list title: `(N)` normally, or `(shown/total)` when a filter has
@@ -88,7 +104,14 @@ Actions (on the selected local file + gist)
   X          remove the selected file from its gist (y/n confirm)
   g          open the gist manager (edit description, delete gist)
   e          edit the local file in $EDITOR
-  y          copy the selected gist's URL to the system clipboard"
+  y          copy the selected gist's URL to the system clipboard
+
+Mouse (on by default; disable with mouse = false in config or --no-mouse)
+  Wheel      scroll the focused list or content pane
+  Click      select the clicked row (List panes also switch focus)
+  Dbl-click  open the clicked row (diff / detail / pin diff / preview)
+  Tab click  switch Files / Comments on the Gist details screen
+  [✕] btn    close / go back on any pop-up screen"
         }
         HelpTopic::Pins => {
             "\
@@ -195,7 +218,7 @@ Actions (on the selected local file + gist)
     }
 }
 
-pub(super) fn render_help(frame: &mut Frame, state: &AppState) {
+pub(super) fn render_help(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout) {
     if state.help_index_open {
         let items: Vec<ListItem> = HelpTopic::all()
             .iter()
@@ -242,6 +265,9 @@ pub(super) fn render_help(frame: &mut Frame, state: &AppState) {
             frame.area(),
         );
     }
+    if state.mouse_enabled {
+        layout.close_button = Some(render_close_button(frame, frame.area(), &state.theme));
+    }
 }
 
 /// Lowercase file extension of a filename or path string, if any.
@@ -280,7 +306,7 @@ fn preview_line_spans(state: &AppState) -> Vec<Vec<Span<'static>>> {
     }
 }
 
-pub(super) fn render_preview(frame: &mut Frame, state: &AppState) {
+pub(super) fn render_preview(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout) {
     let area = frame.area();
     // A `R`-refresh fetch error (set via state.status) must surface here, not be swallowed.
     let hints = if state.preview_wrap {
@@ -332,9 +358,12 @@ pub(super) fn render_preview(frame: &mut Frame, state: &AppState) {
         render_text_scrollbar(frame, chunks[0], total_lines, state.diff_scroll as usize);
     }
     render_footer(frame, chunks[1], "", &footer, colored, &state.theme);
+    if state.mouse_enabled {
+        layout.close_button = Some(render_close_button(frame, area, &state.theme));
+    }
 }
 
-pub(super) fn render_pins(frame: &mut Frame, state: &AppState) {
+pub(super) fn render_pins(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout) {
     let area = frame.area();
     // Sync feedback (e.g. "already in sync", "can't tell which side is newer") is set via
     // state.status while staying on this screen, so the footer must surface it (see #72).
@@ -430,6 +459,12 @@ pub(super) fn render_pins(frame: &mut Frame, state: &AppState) {
     let mut list_state = ListState::default();
     list_state.select(selected);
     frame.render_stateful_widget(list, chunks[0], &mut list_state);
+    if state.mouse_enabled {
+        layout.list = Some(PaneHit {
+            rect: chunks[0],
+            offset: list_state.offset(),
+        });
+    }
 
     if state.pins_filtering {
         render_footer_line(
@@ -441,6 +476,9 @@ pub(super) fn render_pins(frame: &mut Frame, state: &AppState) {
         );
     } else {
         render_footer(frame, chunks[1], &ftitle, &footer, colored, &state.theme);
+    }
+    if state.mouse_enabled {
+        layout.close_button = Some(render_close_button(frame, area, &state.theme));
     }
 }
 
@@ -522,7 +560,7 @@ pub(super) fn gist_group_row_label(
     )
 }
 
-pub(super) fn render_gists(frame: &mut Frame, state: &AppState) {
+pub(super) fn render_gists(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout) {
     let area = frame.area();
     // Footer: filter input while filtering, else a one-shot status message (e.g. the compaction
     // result) when present, else the command hints. Only the hints get key colouring.
@@ -615,6 +653,12 @@ pub(super) fn render_gists(frame: &mut Frame, state: &AppState) {
     let mut list_state = ListState::default();
     list_state.select(selected);
     frame.render_stateful_widget(list, chunks[0], &mut list_state);
+    if state.mouse_enabled {
+        layout.list = Some(PaneHit {
+            rect: chunks[0],
+            offset: list_state.offset(),
+        });
+    }
 
     if state.gists_filtering {
         render_footer_line(
@@ -626,6 +670,9 @@ pub(super) fn render_gists(frame: &mut Frame, state: &AppState) {
         );
     } else {
         render_footer(frame, chunks[1], &ftitle, &footer, colored, &state.theme);
+    }
+    if state.mouse_enabled {
+        layout.close_button = Some(render_close_button(frame, area, &state.theme));
     }
 }
 
@@ -704,7 +751,7 @@ pub(super) fn revision_row_label(
     )
 }
 
-pub(super) fn render_revisions(frame: &mut Frame, state: &AppState) {
+pub(super) fn render_revisions(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout) {
     let area = frame.area();
     let (ftitle, footer, colored) = if let Some(message) = &state.status {
         (String::new(), message.clone(), false)
@@ -801,7 +848,16 @@ pub(super) fn render_revisions(frame: &mut Frame, state: &AppState) {
     let mut list_state = ListState::default();
     list_state.select(selected);
     frame.render_stateful_widget(list, chunks[0], &mut list_state);
+    if state.mouse_enabled {
+        layout.list = Some(PaneHit {
+            rect: chunks[0],
+            offset: list_state.offset(),
+        });
+    }
     render_footer(frame, chunks[1], &ftitle, &footer, colored, &state.theme);
+    if state.mouse_enabled {
+        layout.close_button = Some(render_close_button(frame, area, &state.theme));
+    }
 }
 
 /// Current Unix time in seconds (saturating to 0 before the epoch); used for relative-age labels.
@@ -925,7 +981,13 @@ pub(super) fn render_gist_info_and_files(
 
 /// The gist detail header: a block holding the basic-info line and the `Files │ Comments`
 /// focus tabs. The active tab's content is rendered below it.
-fn render_detail_header(frame: &mut Frame, area: Rect, state: &AppState, gist_id: &str) {
+fn render_detail_header(
+    frame: &mut Frame,
+    area: Rect,
+    state: &AppState,
+    gist_id: &str,
+    layout: &mut MouseLayout,
+) {
     let Some(group) = state.group_by_id(gist_id) else {
         return;
     };
@@ -951,15 +1013,33 @@ fn render_detail_header(frame: &mut Frame, area: Rect, state: &AppState, gist_id
         ),
         area,
     );
+    if state.mouse_enabled {
+        // Tab line is the 2nd content row (border + gist-info line above it); content starts
+        // after the left border (1) + horizontal padding (1). Labels: " Files " (7), " │ " (3),
+        // " Comments " (10) — see detail_focus_tabs_line.
+        let content_x = area.x + 2;
+        let tabs_y = area.y + 2;
+        layout.detail_tab_files = Some(Rect::new(content_x, tabs_y, 7, 1));
+        layout.detail_tab_comments = Some(Rect::new(content_x + 10, tabs_y, 10, 1));
+    }
 }
 
 /// The gist detail's Files tab: the numbered, cursor-highlighted, scrollable file list,
 /// titled with the file count.
-fn render_gist_file_list(frame: &mut Frame, area: Rect, state: &AppState, gist_id: &str) {
+fn render_gist_file_list(
+    frame: &mut Frame,
+    area: Rect,
+    state: &AppState,
+    gist_id: &str,
+    layout: &mut MouseLayout,
+) {
     let files = state.gist_file_display_names(gist_id);
     let cursor = state.detail_file_cursor.min(files.len().saturating_sub(1));
     let visible_rows = (area.height as usize).saturating_sub(2);
     let offset = file_list_scroll(cursor, visible_rows, files.len());
+    if state.mouse_enabled {
+        layout.detail_files = Some(PaneHit { rect: area, offset });
+    }
     let lines = file_rows(&files, cursor, offset, visible_rows, true, &state.theme);
     frame.render_widget(
         Paragraph::new(lines).style(state.theme.base_style()).block(
@@ -1110,7 +1190,7 @@ pub(super) fn detail_focus_tabs_line(focus: DetailFocus, theme: &Theme) -> Line<
     Line::from(spans)
 }
 
-pub(super) fn render_gist_detail(frame: &mut Frame, state: &AppState) {
+pub(super) fn render_gist_detail(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout) {
     let area = frame.area();
     let owned = state
         .detail_gist_id
@@ -1129,16 +1209,21 @@ pub(super) fn render_gist_detail(frame: &mut Frame, state: &AppState) {
         ])
         .split(area);
     if let Some(id) = state.detail_gist_id.as_deref() {
-        render_detail_header(frame, chunks[0], state, id);
+        render_detail_header(frame, chunks[0], state, id, layout);
         match state.detail_focus {
-            DetailFocus::Files => render_gist_file_list(frame, chunks[1], state, id),
+            DetailFocus::Files => render_gist_file_list(frame, chunks[1], state, id, layout),
             DetailFocus::Comments => render_gist_comments(frame, chunks[1], state),
         }
     }
     render_footer(frame, chunks[2], "", &footer, colored, &state.theme);
 
-    if state.editing_description {
-        render_centered_modal_input(
+    let edit_modal = if state.editing_description {
+        // The modal covers the file list and tabs; drop their hit regions so a click
+        // behind the modal doesn't move the cursor or switch tabs.
+        layout.detail_files = None;
+        layout.detail_tab_files = None;
+        layout.detail_tab_comments = None;
+        Some(render_centered_modal_input(
             frame,
             "Edit description (Enter apply · Esc cancel)",
             "",
@@ -1146,7 +1231,18 @@ pub(super) fn render_gist_detail(frame: &mut Frame, state: &AppState) {
             "",
             state.theme.accent,
             &state.theme,
-        );
+        ))
+    } else {
+        None
+    };
+    if state.mouse_enabled {
+        // When the edit-description modal is open, the close button belongs on it;
+        // otherwise it sits on the full-screen detail view's top-right corner.
+        layout.close_button = Some(render_close_button(
+            frame,
+            edit_modal.unwrap_or(area),
+            &state.theme,
+        ));
     }
 }
 
@@ -1435,7 +1531,7 @@ pub(super) fn input_line(prefix: &str, input: &TextInput, suffix: &str) -> Line<
     Line::from(spans)
 }
 
-pub(super) fn render_list(frame: &mut Frame, state: &AppState) {
+pub(super) fn render_list(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout) {
     let area = frame.area();
     let footer_body = if state.filtering {
         let (pane, query) = match state.focus {
@@ -1506,7 +1602,7 @@ pub(super) fn render_list(frame: &mut Frame, state: &AppState) {
     } else {
         local_title
     };
-    render_pane(
+    let local_offset = render_pane(
         frame,
         columns[0],
         &local_title,
@@ -1515,6 +1611,12 @@ pub(super) fn render_list(frame: &mut Frame, state: &AppState) {
         local_selected,
         &state.theme,
     );
+    if state.mouse_enabled {
+        layout.local = Some(PaneHit {
+            rect: columns[0],
+            offset: local_offset,
+        });
+    }
 
     let ranked = state.ranked_gists();
     let gist_items: Vec<ListItem> = if state.loading && ranked.is_empty() {
@@ -1556,7 +1658,7 @@ pub(super) fn render_list(frame: &mut Frame, state: &AppState) {
     } else {
         gist_title
     };
-    render_pane(
+    let gist_offset = render_pane(
         frame,
         columns[1],
         &gist_title,
@@ -1565,6 +1667,12 @@ pub(super) fn render_list(frame: &mut Frame, state: &AppState) {
         gist_selected,
         &state.theme,
     );
+    if state.mouse_enabled {
+        layout.gist = Some(PaneHit {
+            rect: columns[1],
+            offset: gist_offset,
+        });
+    }
 
     if state.filtering {
         let (pane, query) = match state.focus {
@@ -1597,7 +1705,7 @@ pub(super) fn render_pane(
     focused: bool,
     selected: Option<usize>,
     theme: &Theme,
-) {
+) -> usize {
     let item_count = items.len();
     let border_style = if focused {
         Style::default().fg(theme.accent)
@@ -1634,6 +1742,7 @@ pub(super) fn render_pane(
     let mut list_state = ListState::default();
     list_state.select(selected);
     frame.render_stateful_widget(list, area, &mut list_state);
+    let offset = list_state.offset();
 
     // Show a scrollbar when the list overflows its viewport.
     let viewport = area.height.saturating_sub(2) as usize;
@@ -1650,6 +1759,7 @@ pub(super) fn render_pane(
             &mut scrollbar_state,
         );
     }
+    offset
 }
 
 /// Builds the visible, coloured slice of a unified diff (additions green, deletions red,
@@ -2105,7 +2215,7 @@ pub(super) fn diff_footer(state: &AppState) -> String {
     }
 }
 
-pub(super) fn render_diff(frame: &mut Frame, state: &AppState) {
+pub(super) fn render_diff(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout) {
     let footer = diff_footer(state);
 
     let area = frame.area();
@@ -2118,6 +2228,9 @@ pub(super) fn render_diff(frame: &mut Frame, state: &AppState) {
     render_diff_pane(frame, chunks[0], state);
 
     render_footer(frame, chunks[1], "", &footer, true, &state.theme);
+    if state.mouse_enabled {
+        layout.close_button = Some(render_close_button(frame, area, &state.theme));
+    }
 }
 
 /// `Screen::Confirm`: the diff fills the screen as context behind a centered prompt modal,
@@ -2125,7 +2238,7 @@ pub(super) fn render_diff(frame: &mut Frame, state: &AppState) {
 /// #72 audit: this modal intentionally does not surface `state.status`. It is a transient y/n
 /// gate — confirming executes the action and transitions to `List`/`Gists`, where the result
 /// status is shown; cancelling returns to the launching screen without setting a status here.
-pub(super) fn render_confirm(frame: &mut Frame, state: &AppState) {
+pub(super) fn render_confirm(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout) {
     match &state.pending_action {
         Some(PendingAction::CompactGist { gist_id, .. }) => {
             render_gist_info_and_files(frame, frame.area(), state, gist_id);
@@ -2135,7 +2248,7 @@ pub(super) fn render_confirm(frame: &mut Frame, state: &AppState) {
     let (title, border) = confirm_modal_style(state);
     // The create flow's description step is an active text input, so it needs the
     // reverse-video cursor; every other confirm prompt is static text.
-    if matches!(state.pending_action, Some(PendingAction::Create { .. }))
+    let modal = if matches!(state.pending_action, Some(PendingAction::Create { .. }))
         && state.editing_description
     {
         render_centered_modal_input(
@@ -2146,9 +2259,13 @@ pub(super) fn render_confirm(frame: &mut Frame, state: &AppState) {
             CREATE_DESC_SUFFIX,
             border,
             &state.theme,
-        );
+        )
     } else {
-        render_centered_modal(frame, title, &confirm_prompt(state), border, &state.theme);
+        render_centered_modal(frame, title, &confirm_prompt(state), border, &state.theme)
+    };
+    if state.mouse_enabled {
+        // Put the close button on the modal box itself, not the full-screen corner.
+        layout.close_button = Some(render_close_button(frame, modal, &state.theme));
     }
 }
 
@@ -2192,7 +2309,7 @@ pub(super) fn render_centered_modal(
     body: &str,
     border: Color,
     theme: &Theme,
-) {
+) -> Rect {
     let rect = centered_modal_rect(frame.area(), body);
     frame.render_widget(Clear, rect);
     frame.render_widget(
@@ -2202,6 +2319,7 @@ pub(super) fn render_centered_modal(
             .block(modal_block(title, border, theme)),
         rect,
     );
+    rect
 }
 
 /// Centered modal whose body is an active text input (`prefix` + text-with-cursor +
@@ -2214,7 +2332,7 @@ pub(super) fn render_centered_modal_input(
     suffix: &str,
     border: Color,
     theme: &Theme,
-) {
+) -> Rect {
     // Size from the plain text plus one column for the (possibly trailing) cursor cell.
     let plain = format!("{prefix}{input} {suffix}");
     let rect = centered_modal_rect(frame.area(), &plain);
@@ -2226,6 +2344,7 @@ pub(super) fn render_centered_modal_input(
             .block(modal_block(title, border, theme)),
         rect,
     );
+    rect
 }
 
 /// Frames for the in-progress spinner, advanced by `AppState::spinner_frame` (one step per

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -1,10 +1,18 @@
 use super::*;
-use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use crossterm::event::{self, Event, KeyCode, KeyEventKind, MouseButton, MouseEventKind};
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io;
 
-pub(super) fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()> {
-    let mut state = load_startup_state()?;
+pub(super) fn run_loop(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    no_mouse: bool,
+) -> Result<()> {
+    let mut state = load_startup_state(no_mouse)?;
+    if state.mouse_enabled {
+        execute!(terminal.backend_mut(), EnableMouseCapture)?;
+    }
+    let mut mouse_layout = MouseLayout::default();
+    let mut last_click: Option<(u16, u16, std::time::Instant)> = None;
     let mut gist_rx = Some(spawn_gist_fetch());
     let mut fork_rx: Option<std::sync::mpsc::Receiver<std::collections::HashMap<String, u32>>> =
         None;
@@ -17,7 +25,7 @@ pub(super) fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) ->
     let mut bg_rx: Option<std::sync::mpsc::Receiver<BgTaskOutcome>> = None;
 
     loop {
-        terminal.draw(|frame| render(frame, &state))?;
+        terminal.draw(|frame| render(frame, &state, &mut mouse_layout))?;
         // Advance the spinner once per iteration; the poll below caps the loop at ~150ms, so
         // in-progress states (scanning/loading/working) animate even with no input.
         state.spinner_frame = state.spinner_frame.wrapping_add(1);
@@ -543,272 +551,210 @@ pub(super) fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) ->
         if !event::poll(std::time::Duration::from_millis(150))? {
             continue;
         }
-        if let Event::Key(key) = event::read()? {
-            // Windows reports both Press and Release (and Repeat) for each
-            // keystroke, while Unix terminals report only Press. Without this
-            // filter every key fires twice on Windows — Tab toggles focus back
-            // to where it started and Up/Down jump two rows. See ratatui#347.
-            if key.kind != KeyEventKind::Press {
-                continue;
-            }
-            if state.bg_task_msg.is_some() {
-                if key.code == KeyCode::Esc {
-                    state.bg_task_msg = None;
-                    bg_rx = None;
-                    state.set_status("Cancelled");
+        let outcome = match event::read()? {
+            Event::Key(key) => {
+                // Windows reports both Press and Release (and Repeat) for each
+                // keystroke, while Unix terminals report only Press. Without this
+                // filter every key fires twice on Windows — Tab toggles focus back
+                // to where it started and Up/Down jump two rows. See ratatui#347.
+                if key.kind != KeyEventKind::Press {
+                    continue;
                 }
-                continue;
-            }
-
-            match state.handle_key_with(key.code, key.modifiers) {
-                KeyOutcome::Quit => break,
-                KeyOutcome::PreviewDiff => {
-                    let Some(ranked) = state.selected_gist() else {
-                        continue;
-                    };
-                    // List-originated diff returns to the List on Esc (reset any
-                    // leftover Pins origin from an earlier pin diff).
-                    state.diff_return = Screen::List;
-                    let local_path = state.selected_local().map(|local| local.path.clone());
-                    let gist = ranked.file.clone();
-                    let gist_id = gist.gist_id.clone();
-                    let filename = gist.filename.clone();
-                    let raw_url = gist.raw_url.clone();
-                    let (local_label, gist_label) = diff_labels(local_path.as_deref(), &gist);
-                    let target = state.cwd.join(&filename);
-                    let upload_orientation = state.focus == FocusPane::Local;
-
-                    spawn_bg(&mut state, &mut bg_rx, "Loading diff…", move || {
-                        let result = fetch_gist_content(&gist_id, &filename, raw_url.as_deref());
-                        BgTaskOutcome::PreviewDiff {
-                            result,
-                            local_path,
-                            local_label,
-                            gist_label,
-                            target,
-                            upload_orientation,
-                        }
-                    });
-                }
-                KeyOutcome::Download => download(&mut state),
-                KeyOutcome::DownloadGist => {
-                    let Some(ranked) = state.selected_gist() else {
-                        continue;
-                    };
-                    let gist = ranked.file.clone();
-                    let gist_id = gist.gist_id.clone();
-                    let filename = gist.filename.clone();
-                    let raw_url = gist.raw_url.clone();
-                    let target = state.cwd.join(&filename);
-                    let (local_label, gist_label) = diff_labels(Some(&target), &gist);
-
-                    spawn_bg(&mut state, &mut bg_rx, "Downloading…", move || {
-                        let result = fetch_gist_content(&gist_id, &filename, raw_url.as_deref());
-                        BgTaskOutcome::DownloadSelected {
-                            result,
-                            target,
-                            local_label,
-                            gist_label,
-                            gist_id,
-                            filename,
-                        }
-                    });
-                }
-                KeyOutcome::OpenGistDetail => {
-                    let Some(group) = state.selected_group() else {
-                        continue;
-                    };
-                    let gist_id = group.id.clone();
-                    state.screen = Screen::GistDetail;
-                    state.detail_gist_id = Some(gist_id);
-                    state.detail_comments = None;
-                    state.detail_comments_loading = false;
-                    state.detail_comments_error = None;
-                    state.detail_scroll = 0;
-                    state.detail_focus = DetailFocus::Files;
-                    state.detail_file_cursor = 0;
-                }
-                KeyOutcome::FetchComments => {
-                    let Some(gist_id) = state.detail_gist_id.clone() else {
-                        continue;
-                    };
-                    if state.detail_comments.is_some() || state.detail_comments_loading {
-                        continue;
+                if state.bg_task_msg.is_some() {
+                    if key.code == KeyCode::Esc {
+                        state.bg_task_msg = None;
+                        bg_rx = None;
+                        state.set_status("Cancelled");
                     }
-                    state.detail_comments_loading = true;
-                    let fetch_id = gist_id.clone();
-                    spawn_bg(&mut state, &mut bg_rx, "Loading comments…", move || {
-                        let result = crate::gh::fetch_gist_comments_json(&fetch_id)
-                            .map_err(|e| e.to_string())
-                            .and_then(|raw| {
-                                crate::gh::parse_gist_comments_json(&raw).map_err(|e| e.to_string())
-                            });
-                        BgTaskOutcome::CommentsFetched {
-                            gist_id: fetch_id,
-                            result,
-                        }
-                    });
+                    continue;
                 }
-                KeyOutcome::CompactGist => {
-                    let Some(gist_id) = state.context_gist_id() else {
-                        continue;
-                    };
-                    let Some(group) = state.group_by_id(&gist_id) else {
-                        continue;
-                    };
-                    let label = if group.description.trim().is_empty() {
-                        group.id.clone()
-                    } else {
-                        group.description.clone()
-                    };
-
-                    spawn_bg(&mut state, &mut bg_rx, "Checking revisions…", move || {
-                        let result = crate::actions::execute_command(
-                            &crate::actions::gist_revision_count_command(&gist_id),
-                        )
-                        .map_err(|e| e.to_string())
-                        .and_then(|out| {
-                            crate::actions::parse_revision_count(&out)
-                                .ok_or_else(|| "could not parse revision count".to_string())
-                        });
-                        BgTaskOutcome::CompactAnalyze {
-                            result,
-                            gist_id,
-                            label,
-                        }
-                    });
+                state.handle_key_with(key.code, key.modifiers)
+            }
+            Event::Mouse(m) if state.mouse_enabled => {
+                if state.bg_task_msg.is_some() {
+                    continue; // ignore mouse while a background task overlay is up, mirroring keys
                 }
-                KeyOutcome::Pin => pin_selected(&mut state),
-                KeyOutcome::Unpin => unpin_selected(&mut state),
-                KeyOutcome::UploadAdd => {
-                    let (local_path, gist_id) = if state.is_pin_diff_context() {
-                        (
-                            state.preview_local.clone(),
-                            state.download_gist_id.clone().unwrap(),
-                        )
-                    } else {
-                        let (Some(local), Some(gist)) =
-                            (state.selected_local(), state.selected_gist())
-                        else {
-                            continue;
-                        };
-                        (local.path.clone(), gist.file.gist_id.clone())
-                    };
-                    let Some(filename) = upload_local_filename(&local_path) else {
-                        state.set_status("local file has no name");
-                        continue;
-                    };
+                let input = match m.kind {
+                    MouseEventKind::ScrollUp => Some(super::MouseInput::ScrollUp),
+                    MouseEventKind::ScrollDown => Some(super::MouseInput::ScrollDown),
+                    MouseEventKind::Down(MouseButton::Left) => {
+                        let prev = last_click.map(|(c, r, _)| (c, r));
+                        let elapsed = last_click
+                            .map(|(_, _, t)| t.elapsed().as_millis())
+                            .unwrap_or(u128::MAX);
+                        let classified = super::classify_click(prev, elapsed, m.column, m.row);
+                        last_click = Some((m.column, m.row, std::time::Instant::now()));
+                        Some(classified)
+                    }
+                    _ => None,
+                };
+                match input {
+                    Some(i) => state.handle_mouse(i, &mouse_layout),
+                    None => KeyOutcome::None,
+                }
+            }
+            _ => KeyOutcome::None,
+        };
+        match outcome {
+            KeyOutcome::Quit => break,
+            KeyOutcome::PreviewDiff => {
+                let Some(ranked) = state.selected_gist() else {
+                    continue;
+                };
+                // List-originated diff returns to the List on Esc (reset any
+                // leftover Pins origin from an earlier pin diff).
+                state.diff_return = Screen::List;
+                let local_path = state.selected_local().map(|local| local.path.clone());
+                let gist = ranked.file.clone();
+                let gist_id = gist.gist_id.clone();
+                let filename = gist.filename.clone();
+                let raw_url = gist.raw_url.clone();
+                let (local_label, gist_label) = diff_labels(local_path.as_deref(), &gist);
+                let target = state.cwd.join(&filename);
+                let upload_orientation = state.focus == FocusPane::Local;
 
-                    state.pending_action = Some(PendingAction::Upload {
-                        gist_id,
-                        filename: filename.clone(),
-                        local_path: local_path.clone(),
-                    });
-
-                    let local_label =
-                        format!("local: {}", crate::config::display_path(&local_path));
-                    let gist_label = "(new file)".to_string();
-                    state.init_upload_state(
-                        &local_path,
-                        Some(String::new()),
+                spawn_bg(&mut state, &mut bg_rx, "Loading diff…", move || {
+                    let result = fetch_gist_content(&gist_id, &filename, raw_url.as_deref());
+                    BgTaskOutcome::PreviewDiff {
+                        result,
+                        local_path,
                         local_label,
                         gist_label,
-                    );
-                    state.screen = Screen::Confirm;
-                }
-                KeyOutcome::UploadPreview => {
-                    let (local_path, gist_id, gist_file) = if state.is_pin_diff_context() {
-                        let local_path = state.preview_local.clone();
-                        let gist_id = state.download_gist_id.clone().unwrap();
-                        let filename = state.download_gist_filename.clone().unwrap_or_default();
-                        let gist_file = state
-                            .gists
-                            .iter()
-                            .find(|g| g.gist_id == gist_id && g.filename == filename)
-                            .cloned()
-                            .unwrap_or_else(|| GistFile {
-                                gist_id: gist_id.clone(),
-                                description: String::new(),
-                                filename: filename.clone(),
-                                public: false,
-                                updated_at: String::new(),
-                                created_at: String::new(),
-                                owner_login: String::new(),
-                                fork_of_id: None,
-                                raw_url: None,
-                                content_type: None,
-                                node_id: None,
-                            });
-                        (local_path, gist_id, gist_file)
-                    } else {
-                        let (Some(local), Some(gist)) =
-                            (state.selected_local(), state.selected_gist())
-                        else {
-                            continue;
-                        };
-                        (
-                            local.path.clone(),
-                            gist.file.gist_id.clone(),
-                            gist.file.clone(),
-                        )
-                    };
-                    let Some(filename) = upload_local_filename(&local_path) else {
-                        state.set_status("local file has no name");
-                        continue;
-                    };
-                    let raw_url = gist_file.raw_url.clone();
-                    let (local_label, gist_label) = diff_labels(Some(&local_path), &gist_file);
+                        target,
+                        upload_orientation,
+                    }
+                });
+            }
+            KeyOutcome::Download => download(&mut state),
+            KeyOutcome::DownloadGist => {
+                let Some(ranked) = state.selected_gist() else {
+                    continue;
+                };
+                let gist = ranked.file.clone();
+                let gist_id = gist.gist_id.clone();
+                let filename = gist.filename.clone();
+                let raw_url = gist.raw_url.clone();
+                let target = state.cwd.join(&filename);
+                let (local_label, gist_label) = diff_labels(Some(&target), &gist);
 
-                    spawn_bg(&mut state, &mut bg_rx, "Loading diff…", move || {
-                        let result = fetch_gist_content(&gist_id, &filename, raw_url.as_deref());
-                        BgTaskOutcome::UploadPreview {
-                            result,
-                            gist_id,
-                            filename,
-                            local_path,
-                            local_label,
-                            gist_label,
-                        }
-                    });
-                }
-                KeyOutcome::Upload => {
-                    let Some(PendingAction::Upload {
+                spawn_bg(&mut state, &mut bg_rx, "Downloading…", move || {
+                    let result = fetch_gist_content(&gist_id, &filename, raw_url.as_deref());
+                    BgTaskOutcome::DownloadSelected {
+                        result,
+                        target,
+                        local_label,
+                        gist_label,
                         gist_id,
                         filename,
-                        local_path: _,
-                    }) = state.pending_action.clone()
+                    }
+                });
+            }
+            KeyOutcome::OpenGistDetail => {
+                let Some(group) = state.selected_group() else {
+                    continue;
+                };
+                let gist_id = group.id.clone();
+                state.screen = Screen::GistDetail;
+                state.detail_gist_id = Some(gist_id);
+                state.detail_comments = None;
+                state.detail_comments_loading = false;
+                state.detail_comments_error = None;
+                state.detail_scroll = 0;
+                state.detail_focus = DetailFocus::Files;
+                state.detail_file_cursor = 0;
+            }
+            KeyOutcome::FetchComments => {
+                let Some(gist_id) = state.detail_gist_id.clone() else {
+                    continue;
+                };
+                if state.detail_comments.is_some() || state.detail_comments_loading {
+                    continue;
+                }
+                state.detail_comments_loading = true;
+                let fetch_id = gist_id.clone();
+                spawn_bg(&mut state, &mut bg_rx, "Loading comments…", move || {
+                    let result = crate::gh::fetch_gist_comments_json(&fetch_id)
+                        .map_err(|e| e.to_string())
+                        .and_then(|raw| {
+                            crate::gh::parse_gist_comments_json(&raw).map_err(|e| e.to_string())
+                        });
+                    BgTaskOutcome::CommentsFetched {
+                        gist_id: fetch_id,
+                        result,
+                    }
+                });
+            }
+            KeyOutcome::CompactGist => {
+                let Some(gist_id) = state.context_gist_id() else {
+                    continue;
+                };
+                let Some(group) = state.group_by_id(&gist_id) else {
+                    continue;
+                };
+                let label = if group.description.trim().is_empty() {
+                    group.id.clone()
+                } else {
+                    group.description.clone()
+                };
+
+                spawn_bg(&mut state, &mut bg_rx, "Checking revisions…", move || {
+                    let result = crate::actions::execute_command(
+                        &crate::actions::gist_revision_count_command(&gist_id),
+                    )
+                    .map_err(|e| e.to_string())
+                    .and_then(|out| {
+                        crate::actions::parse_revision_count(&out)
+                            .ok_or_else(|| "could not parse revision count".to_string())
+                    });
+                    BgTaskOutcome::CompactAnalyze {
+                        result,
+                        gist_id,
+                        label,
+                    }
+                });
+            }
+            KeyOutcome::Pin => pin_selected(&mut state),
+            KeyOutcome::Unpin => unpin_selected(&mut state),
+            KeyOutcome::UploadAdd => {
+                let (local_path, gist_id) = if state.is_pin_diff_context() {
+                    (
+                        state.preview_local.clone(),
+                        state.download_gist_id.clone().unwrap(),
+                    )
+                } else {
+                    let (Some(local), Some(gist)) = (state.selected_local(), state.selected_gist())
                     else {
                         continue;
                     };
+                    (local.path.clone(), gist.file.gist_id.clone())
+                };
+                let Some(filename) = upload_local_filename(&local_path) else {
+                    state.set_status("local file has no name");
+                    continue;
+                };
 
-                    let upload_content = state.content_to_upload();
+                state.pending_action = Some(PendingAction::Upload {
+                    gist_id,
+                    filename: filename.clone(),
+                    local_path: local_path.clone(),
+                });
 
-                    // Generate unique temp directory in workspace
-                    let timestamp = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .map(|d| d.as_nanos())
-                        .unwrap_or(0);
-                    let temp_dir = state.cwd.join(format!(".gistui_upload_{timestamp}"));
-
-                    if let Err(e) = std::fs::create_dir_all(&temp_dir) {
-                        state.set_status(format!("failed to create temp dir: {e}"));
-                        continue;
-                    }
-
-                    let temp_file_path = temp_dir.join(&filename);
-                    if let Err(e) = std::fs::write(&temp_file_path, &upload_content) {
-                        state.set_status(format!("failed to write temp file: {e}"));
-                        let _ = std::fs::remove_dir_all(&temp_dir);
-                        continue;
-                    }
-
-                    let has_same_name = state
+                let local_label = format!("local: {}", crate::config::display_path(&local_path));
+                let gist_label = "(new file)".to_string();
+                state.init_upload_state(&local_path, Some(String::new()), local_label, gist_label);
+                state.screen = Screen::Confirm;
+            }
+            KeyOutcome::UploadPreview => {
+                let (local_path, gist_id, gist_file) = if state.is_pin_diff_context() {
+                    let local_path = state.preview_local.clone();
+                    let gist_id = state.download_gist_id.clone().unwrap();
+                    let filename = state.download_gist_filename.clone().unwrap_or_default();
+                    let gist_file = state
                         .gists
                         .iter()
-                        .any(|g| g.gist_id == gist_id && g.filename == filename);
-
-                    let plan = if has_same_name {
-                        let target = GistFile {
+                        .find(|g| g.gist_id == gist_id && g.filename == filename)
+                        .cloned()
+                        .unwrap_or_else(|| GistFile {
                             gist_id: gist_id.clone(),
                             description: String::new(),
                             filename: filename.clone(),
@@ -820,485 +766,555 @@ pub(super) fn run_loop(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) ->
                             raw_url: None,
                             content_type: None,
                             node_id: None,
-                        };
-                        crate::actions::upload_command(&temp_file_path, &target)
-                    } else {
-                        crate::actions::upload_add_command(&temp_file_path, &gist_id)
-                    };
-
-                    state.back_to_list();
-                    spawn_bg(&mut state, &mut bg_rx, "Uploading…", move || {
-                        let result = crate::actions::execute_command(&plan)
-                            .map(|_| ())
-                            .map_err(|e| e.to_string());
-
-                        let _ = std::fs::remove_dir_all(&temp_dir);
-
-                        BgTaskOutcome::UploadReplace {
-                            result,
-                            gist_id,
-                            filename,
-                        }
-                    });
-                }
-                KeyOutcome::EditUpload => {
-                    edit_upload_buffer(terminal, &mut state)?;
-                }
-                KeyOutcome::Create(public) => {
-                    let Some(PendingAction::Create { local_path }) = state.pending_action.clone()
-                    else {
-                        continue;
-                    };
-                    let description = state.description_input.to_string();
-                    let plan = crate::actions::create_command(&local_path, public, &description);
-
-                    spawn_bg(&mut state, &mut bg_rx, "Creating gist…", move || {
-                        let result = crate::actions::execute_command(&plan)
-                            .map(|_| ())
-                            .map_err(|e| e.to_string());
-                        BgTaskOutcome::CreateGist {
-                            result,
-                            local_path,
-                            public,
-                        }
-                    });
-                }
-                KeyOutcome::PreviewContent => {
-                    // A detail-view number key records the exact file in `preview_request`;
-                    // otherwise fall back to the file selected on the list.
-                    let key = match state.preview_request.take() {
-                        Some(key) => key,
-                        None => match state.selected_gist() {
-                            Some(gist) => (gist.file.gist_id.clone(), gist.file.filename.clone()),
-                            None => continue,
-                        },
-                    };
-                    if let Some(cached) = state.gist_content_cache.get(&key) {
-                        state.preview_title = format!("Preview: {} / {}", key.0, key.1);
-                        state.preview_gist_key = Some(key);
-                        state.diff_text = cached.clone();
-                        state.diff_scroll = 0;
-                        state.diff_hscroll = 0;
-                        state.status = None;
-                        state.screen = Screen::Preview;
-                    } else {
-                        let gist_id = key.0.clone();
-                        let filename = key.1.clone();
-                        let raw_url = state.gist_file_raw_url(&gist_id, &filename);
-                        let preview_title = format!("Preview: {gist_id} / {filename}");
-                        spawn_bg(&mut state, &mut bg_rx, "Loading preview…", move || {
-                            let result =
-                                fetch_gist_content(&gist_id, &filename, raw_url.as_deref());
-                            BgTaskOutcome::PreviewContent {
-                                result,
-                                key,
-                                preview_title,
-                            }
                         });
-                    }
-                }
-                KeyOutcome::RefreshPreview => {
-                    if let Some(key) = state.preview_gist_key.clone() {
-                        state.gist_content_cache.remove(&key);
-                        let gist_id = key.0.clone();
-                        let filename = key.1.clone();
-                        let raw_url = state.gist_file_raw_url(&gist_id, &filename);
-                        let preview_title = format!("Preview: {gist_id} / {filename}");
-                        spawn_bg(&mut state, &mut bg_rx, "Loading preview…", move || {
-                            let result =
-                                fetch_gist_content(&gist_id, &filename, raw_url.as_deref());
-                            BgTaskOutcome::PreviewContent {
-                                result,
-                                key,
-                                preview_title,
-                            }
-                        });
-                    }
-                }
-                KeyOutcome::OpenBrowser => open_browser(&mut state),
-                KeyOutcome::CopyGistUrl => copy_gist_url(&mut state),
-                KeyOutcome::CopyPreviewContent => copy_preview_content(&mut state),
-                KeyOutcome::EditLocal => edit_local(terminal, &mut state)?,
-                KeyOutcome::ExecuteDelete => {
-                    let Some(PendingAction::Delete { gist_id, .. }) = state.pending_action.clone()
-                    else {
-                        continue;
-                    };
-                    let plan = crate::actions::delete_command(&gist_id);
-                    state.back_to_list();
-
-                    spawn_bg(&mut state, &mut bg_rx, "Deleting gist…", move || {
-                        let result = crate::actions::execute_command(&plan)
-                            .map(|_| ())
-                            .map_err(|e| e.to_string());
-                        BgTaskOutcome::DeleteGist { result, gist_id }
-                    });
-                }
-                KeyOutcome::ExecuteRemoveFile => {
-                    let Some(PendingAction::RemoveFile {
-                        gist_id, filename, ..
-                    }) = state.pending_action.clone()
-                    else {
-                        continue;
-                    };
-                    let plan = crate::actions::remove_file_command(&gist_id, &filename);
-                    state.back_to_list();
-
-                    spawn_bg(&mut state, &mut bg_rx, "Removing file…", move || {
-                        let result = crate::actions::execute_command(&plan)
-                            .map(|_| ())
-                            .map_err(|e| e.to_string());
-                        BgTaskOutcome::RemoveFile {
-                            result,
-                            gist_id,
-                            filename,
-                        }
-                    });
-                }
-                KeyOutcome::ExecuteCompactGist => {
-                    let Some(PendingAction::CompactGist {
-                        gist_id,
-                        label,
-                        count,
-                    }) = state.pending_action.clone()
-                    else {
-                        continue;
-                    };
-                    state.pending_action = None;
-                    state.screen = state.compact_return_screen;
-
-                    spawn_bg(
-                        &mut state,
-                        &mut bg_rx,
-                        "Compacting revisions…",
-                        move || {
-                            let result = crate::actions::execute_compact_gist(&gist_id)
-                                .map_err(|e| e.to_string());
-                            BgTaskOutcome::CompactGist {
-                                result,
-                                label,
-                                count,
-                            }
-                        },
-                    );
-                }
-                KeyOutcome::ApplyDescription => {
-                    let gist_id = state
-                        .detail_gist_id
-                        .clone()
-                        .or_else(|| state.selected_group().map(|g| g.id.clone()));
-                    let Some(gist_id) = gist_id else {
-                        state.editing_description = false;
-                        continue;
-                    };
-                    let description = state.description_input.to_string();
-                    let plan = crate::actions::edit_description_command(&gist_id, &description);
-                    state.editing_description = false;
-                    state.description_input.clear();
-
-                    spawn_bg(
-                        &mut state,
-                        &mut bg_rx,
-                        "Updating description…",
-                        move || {
-                            let result = crate::actions::execute_command(&plan)
-                                .map(|_| ())
-                                .map_err(|e| e.to_string());
-                            BgTaskOutcome::ApplyDescription { result, gist_id }
-                        },
-                    );
-                }
-                KeyOutcome::RefreshLocals => {
-                    state.set_status("Scanning files…");
-                    state.local_scanning = true;
-                    local_rx = Some(spawn_local_scan(
-                        state.cwd.clone(),
-                        state.pinned.clone(),
-                        state.local_recursive,
-                        state.skip_dirs.clone(),
-                        state.scan_depth,
-                    ));
-                }
-                KeyOutcome::UnpinAtPin => unpin_at_pin_index(&mut state),
-                KeyOutcome::SyncSelectedPair => {
+                    (local_path, gist_id, gist_file)
+                } else {
                     let (Some(local), Some(gist)) = (state.selected_local(), state.selected_gist())
                     else {
                         continue;
                     };
-                    let local_abs = state.cwd.join(&local.path);
-                    let gist_id = gist.file.gist_id.clone();
-                    let filename = gist.file.filename.clone();
-                    let idx = state.pinned.iter().position(|m| {
-                        pin_local_abs(&state, m) == local_abs
-                            && m.gist_id == gist_id
-                            && m.gist_filename == filename
-                    });
-                    let Some(idx) = idx else {
-                        state.set_status("pair is not pinned — press p to pin first");
-                        continue;
-                    };
-                    let m = state.pinned[idx].clone();
-                    match state.pin_sync_status(idx) {
-                        crate::domain::SyncStatus::Push => {
-                            spawn_pin_push(&mut state, &mut bg_rx, &m)
-                        }
-                        crate::domain::SyncStatus::Pull => {
-                            spawn_pin_pull(&mut state, &mut bg_rx, &m)
-                        }
-                        crate::domain::SyncStatus::InSync => state.set_status("already in sync"),
-                        crate::domain::SyncStatus::Unknown => state.set_status(
-                            "can't tell which side is newer — use u to push or d to pull",
-                        ),
-                    }
-                }
-                KeyOutcome::SyncPinPush => {
-                    if let Some(m) = selected_pin(&state) {
-                        spawn_pin_push(&mut state, &mut bg_rx, &m);
-                    }
-                }
-                KeyOutcome::SyncPinPull => {
-                    if let Some(m) = selected_pin(&state) {
-                        spawn_pin_pull(&mut state, &mut bg_rx, &m);
-                    }
-                }
-                KeyOutcome::SyncPinAuto => {
-                    let Some(pin_idx) = state.selected_pin_index() else {
-                        continue;
-                    };
-                    let m = state.pinned[pin_idx].clone();
-                    match state.pin_sync_status(pin_idx) {
-                        crate::domain::SyncStatus::InSync => state.set_status("already in sync"),
-                        crate::domain::SyncStatus::Pull => {
-                            spawn_pin_pull(&mut state, &mut bg_rx, &m)
-                        }
-                        crate::domain::SyncStatus::Push => {
-                            // Cheap, network-free no-op check: if the local file still
-                            // hashes to last_seen_hash, the newer mtime is a touch with
-                            // no content change. Note: only fires for plain pushes — a
-                            // push whose baseline was a JSON-transformed/redacted upload
-                            // won't match the raw file, so it harmlessly falls through to
-                            // a full push.
-                            let local_abs = pin_local_abs(&state, &m);
-                            let unchanged = m.last_seen_hash.as_deref().is_some_and(|baseline| {
-                                std::fs::read(&local_abs)
-                                    .map(|b| crate::domain::sha256_hex(&b) == baseline)
-                                    .unwrap_or(false)
-                            });
-                            if unchanged {
-                                state.set_status("already in sync");
-                            } else {
-                                spawn_pin_push(&mut state, &mut bg_rx, &m);
-                            }
-                        }
-                        crate::domain::SyncStatus::Unknown => state.set_status(
-                            "can't tell which side is newer — use u to push or d to pull",
-                        ),
-                    }
-                }
-                KeyOutcome::PreviewPinDiff => {
-                    if let Some(m) = selected_pin(&state) {
-                        state.diff_return = Screen::Pins;
-                        spawn_pin_diff(&mut state, &mut bg_rx, &m);
-                    }
-                }
-                KeyOutcome::PersistDiffContext => persist_diff_context(&mut state),
-                KeyOutcome::ThemeToggle => persist_theme(&mut state),
-                KeyOutcome::FetchRevisions => {
-                    let Some(gist_id) = state.revision_gist_id.clone() else {
-                        continue;
-                    };
-                    spawn_bg(&mut state, &mut bg_rx, "Loading revisions…", move || {
-                        let result = crate::gh::fetch_gist_commits_json(&gist_id)
-                            .map_err(|e| e.to_string())
-                            .and_then(|raw| {
-                                crate::gh::parse_gist_commits_json(&raw).map_err(|e| e.to_string())
-                            });
-                        BgTaskOutcome::RevisionsFetched { gist_id, result }
-                    });
-                }
-                KeyOutcome::RevisionDiffIncremental => {
-                    let Some(gist_id) = state.revision_gist_id.clone() else {
-                        continue;
-                    };
-                    let Some(child) = state.selected_revision().cloned() else {
-                        continue;
-                    };
-                    let filename = state.revision_target_file.clone();
-                    let child_version = child.version.clone();
-                    let child_label = revision_version_label(&child);
-                    let parent = state
-                        .revision_entries
-                        .as_ref()
-                        .and_then(|entries| entries.get(state.revision_index + 1).cloned());
-                    let (parent_version, old_label) = match parent {
-                        Some(parent) => {
-                            let label = revision_version_label(&parent);
-                            (Some(parent.version), format!("revision {label}"))
-                        }
-                        None => (None, "(initial)".into()),
-                    };
-                    let new_label = format!("revision {child_label}");
-                    let owner_login = state.gist_owner_login(&gist_id);
-                    spawn_bg(&mut state, &mut bg_rx, "Loading diff…", move || {
-                        let result = fetch_revision_incremental_pair(
-                            &gist_id,
-                            &child_version,
-                            parent_version.as_deref(),
-                            &filename,
-                            &owner_login,
-                        );
-                        BgTaskOutcome::RevisionDiff {
-                            result,
-                            old_label,
-                            new_label,
-                        }
-                    });
-                }
-                KeyOutcome::RevisionDiff => {
-                    let Some(gist_id) = state.revision_gist_id.clone() else {
-                        continue;
-                    };
-                    let Some(revision) = state.selected_revision().cloned() else {
-                        continue;
-                    };
-                    let filename = state.revision_target_file.clone();
-                    let version = revision.version.clone();
-                    let version_label = revision_version_label(&revision);
-                    let old_label = format!("revision {version_label}");
-                    let new_label = format!("current {filename}");
-                    let raw_url = state.gist_file_raw_url(&gist_id, &filename);
-                    let owner_login = state.gist_owner_login(&gist_id);
-                    spawn_bg(&mut state, &mut bg_rx, "Loading diff…", move || {
-                        let result = fetch_revision_pair(
-                            &gist_id,
-                            &version,
-                            &filename,
-                            raw_url.as_deref(),
-                            &owner_login,
-                            &old_label,
-                            &new_label,
-                        );
-                        BgTaskOutcome::RevisionDiff {
-                            result,
-                            old_label,
-                            new_label,
-                        }
-                    });
-                }
-                KeyOutcome::RestoreRevisionPreview => {
-                    let Some(gist_id) = state.revision_gist_id.clone() else {
-                        continue;
-                    };
-                    let Some(revision) = state.selected_revision().cloned() else {
-                        continue;
-                    };
-                    let filename = state.revision_target_file.clone();
-                    let version = revision.version.clone();
-                    let version_label = revision_version_label(&revision);
-                    let raw_url = state.gist_file_raw_url(&gist_id, &filename);
-                    let owner_login = state.gist_owner_login(&gist_id);
-                    spawn_bg(&mut state, &mut bg_rx, "Loading revision…", move || {
-                        let result = fetch_revision_pair_for_restore(
-                            &gist_id,
-                            &version,
-                            &filename,
-                            raw_url.as_deref(),
-                            &owner_login,
-                        );
-                        BgTaskOutcome::RestoreRevisionReady {
-                            result,
-                            gist_id,
-                            filename,
-                            version,
-                            version_label,
-                        }
-                    });
-                }
-                KeyOutcome::ExecuteRestoreRevision => {
-                    let Some(PendingAction::RestoreRevision {
+                    (
+                        local.path.clone(),
+                        gist.file.gist_id.clone(),
+                        gist.file.clone(),
+                    )
+                };
+                let Some(filename) = upload_local_filename(&local_path) else {
+                    state.set_status("local file has no name");
+                    continue;
+                };
+                let raw_url = gist_file.raw_url.clone();
+                let (local_label, gist_label) = diff_labels(Some(&local_path), &gist_file);
+
+                spawn_bg(&mut state, &mut bg_rx, "Loading diff…", move || {
+                    let result = fetch_gist_content(&gist_id, &filename, raw_url.as_deref());
+                    BgTaskOutcome::UploadPreview {
+                        result,
                         gist_id,
                         filename,
-                        content,
-                        ..
-                    }) = state.pending_action.clone()
-                    else {
-                        continue;
-                    };
-                    let timestamp = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .map(|d| d.as_nanos())
-                        .unwrap_or(0);
-                    let temp_dir = state.cwd.join(format!(".gistui_restore_{timestamp}"));
-                    if let Err(e) = std::fs::create_dir_all(&temp_dir) {
-                        state.set_status(format!("failed to create temp dir: {e}"));
-                        continue;
+                        local_path,
+                        local_label,
+                        gist_label,
                     }
-                    let json_path = temp_dir.join("restore.json");
-                    let body = crate::actions::restore_revision_json(&filename, &content);
-                    if let Err(e) = std::fs::write(&json_path, &body) {
-                        state.set_status(format!("failed to write restore payload: {e}"));
-                        let _ = std::fs::remove_dir_all(&temp_dir);
-                        continue;
-                    }
-                    let plan = crate::actions::restore_revision_command(&gist_id, &json_path);
-                    spawn_bg(&mut state, &mut bg_rx, "Restoring revision…", move || {
-                        let result = crate::actions::execute_command(&plan)
-                            .map(|_| ())
-                            .map_err(|e| e.to_string());
-                        let _ = std::fs::remove_dir_all(&temp_dir);
-                        BgTaskOutcome::RestoreRevisionDone {
-                            result,
-                            gist_id,
-                            filename,
-                        }
-                    });
-                }
-                KeyOutcome::ToggleGistStar => {
-                    let Some(gist_id) = state.context_gist_id() else {
-                        state.set_status("select a gist first");
-                        continue;
-                    };
-                    let starring = !state.gist_is_starred(&gist_id);
-                    let plan = if starring {
-                        crate::actions::star_gist_command(&gist_id)
-                    } else {
-                        crate::actions::unstar_gist_command(&gist_id)
-                    };
-                    let msg = if starring {
-                        "Starring…"
-                    } else {
-                        "Unstarring…"
-                    };
-                    spawn_bg(&mut state, &mut bg_rx, msg, move || {
-                        let result = crate::actions::execute_command(&plan)
-                            .map(|_| ())
-                            .map_err(|e| e.to_string());
-                        BgTaskOutcome::GistStarToggle {
-                            result,
-                            gist_id,
-                            starred: starring,
-                        }
-                    });
-                }
-                KeyOutcome::ForkGist => {
-                    let Some(gist_id) = state.context_gist_id() else {
-                        state.set_status("select a gist to fork");
-                        continue;
-                    };
-                    if state.gist_is_owned(&gist_id) {
-                        state.set_status("already yours — no fork needed");
-                        continue;
-                    }
-                    let plan = crate::actions::fork_gist_command(&gist_id);
-                    spawn_bg(&mut state, &mut bg_rx, "Forking…", move || {
-                        let result = crate::actions::execute_command(&plan)
-                            .map(|_| ())
-                            .map_err(|e| e.to_string());
-                        BgTaskOutcome::ForkGist { result, gist_id }
-                    });
-                }
-                KeyOutcome::None => {}
+                });
             }
+            KeyOutcome::Upload => {
+                let Some(PendingAction::Upload {
+                    gist_id,
+                    filename,
+                    local_path: _,
+                }) = state.pending_action.clone()
+                else {
+                    continue;
+                };
+
+                let upload_content = state.content_to_upload();
+
+                // Generate unique temp directory in workspace
+                let timestamp = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_nanos())
+                    .unwrap_or(0);
+                let temp_dir = state.cwd.join(format!(".gistui_upload_{timestamp}"));
+
+                if let Err(e) = std::fs::create_dir_all(&temp_dir) {
+                    state.set_status(format!("failed to create temp dir: {e}"));
+                    continue;
+                }
+
+                let temp_file_path = temp_dir.join(&filename);
+                if let Err(e) = std::fs::write(&temp_file_path, &upload_content) {
+                    state.set_status(format!("failed to write temp file: {e}"));
+                    let _ = std::fs::remove_dir_all(&temp_dir);
+                    continue;
+                }
+
+                let has_same_name = state
+                    .gists
+                    .iter()
+                    .any(|g| g.gist_id == gist_id && g.filename == filename);
+
+                let plan = if has_same_name {
+                    let target = GistFile {
+                        gist_id: gist_id.clone(),
+                        description: String::new(),
+                        filename: filename.clone(),
+                        public: false,
+                        updated_at: String::new(),
+                        created_at: String::new(),
+                        owner_login: String::new(),
+                        fork_of_id: None,
+                        raw_url: None,
+                        content_type: None,
+                        node_id: None,
+                    };
+                    crate::actions::upload_command(&temp_file_path, &target)
+                } else {
+                    crate::actions::upload_add_command(&temp_file_path, &gist_id)
+                };
+
+                state.back_to_list();
+                spawn_bg(&mut state, &mut bg_rx, "Uploading…", move || {
+                    let result = crate::actions::execute_command(&plan)
+                        .map(|_| ())
+                        .map_err(|e| e.to_string());
+
+                    let _ = std::fs::remove_dir_all(&temp_dir);
+
+                    BgTaskOutcome::UploadReplace {
+                        result,
+                        gist_id,
+                        filename,
+                    }
+                });
+            }
+            KeyOutcome::EditUpload => {
+                edit_upload_buffer(terminal, &mut state)?;
+            }
+            KeyOutcome::Create(public) => {
+                let Some(PendingAction::Create { local_path }) = state.pending_action.clone()
+                else {
+                    continue;
+                };
+                let description = state.description_input.to_string();
+                let plan = crate::actions::create_command(&local_path, public, &description);
+
+                spawn_bg(&mut state, &mut bg_rx, "Creating gist…", move || {
+                    let result = crate::actions::execute_command(&plan)
+                        .map(|_| ())
+                        .map_err(|e| e.to_string());
+                    BgTaskOutcome::CreateGist {
+                        result,
+                        local_path,
+                        public,
+                    }
+                });
+            }
+            KeyOutcome::PreviewContent => {
+                // A detail-view number key records the exact file in `preview_request`;
+                // otherwise fall back to the file selected on the list.
+                let key = match state.preview_request.take() {
+                    Some(key) => key,
+                    None => match state.selected_gist() {
+                        Some(gist) => (gist.file.gist_id.clone(), gist.file.filename.clone()),
+                        None => continue,
+                    },
+                };
+                if let Some(cached) = state.gist_content_cache.get(&key) {
+                    state.preview_title = format!("Preview: {} / {}", key.0, key.1);
+                    state.preview_gist_key = Some(key);
+                    state.diff_text = cached.clone();
+                    state.diff_scroll = 0;
+                    state.diff_hscroll = 0;
+                    state.status = None;
+                    state.screen = Screen::Preview;
+                } else {
+                    let gist_id = key.0.clone();
+                    let filename = key.1.clone();
+                    let raw_url = state.gist_file_raw_url(&gist_id, &filename);
+                    let preview_title = format!("Preview: {gist_id} / {filename}");
+                    spawn_bg(&mut state, &mut bg_rx, "Loading preview…", move || {
+                        let result = fetch_gist_content(&gist_id, &filename, raw_url.as_deref());
+                        BgTaskOutcome::PreviewContent {
+                            result,
+                            key,
+                            preview_title,
+                        }
+                    });
+                }
+            }
+            KeyOutcome::RefreshPreview => {
+                if let Some(key) = state.preview_gist_key.clone() {
+                    state.gist_content_cache.remove(&key);
+                    let gist_id = key.0.clone();
+                    let filename = key.1.clone();
+                    let raw_url = state.gist_file_raw_url(&gist_id, &filename);
+                    let preview_title = format!("Preview: {gist_id} / {filename}");
+                    spawn_bg(&mut state, &mut bg_rx, "Loading preview…", move || {
+                        let result = fetch_gist_content(&gist_id, &filename, raw_url.as_deref());
+                        BgTaskOutcome::PreviewContent {
+                            result,
+                            key,
+                            preview_title,
+                        }
+                    });
+                }
+            }
+            KeyOutcome::OpenBrowser => open_browser(&mut state),
+            KeyOutcome::CopyGistUrl => copy_gist_url(&mut state),
+            KeyOutcome::CopyPreviewContent => copy_preview_content(&mut state),
+            KeyOutcome::EditLocal => edit_local(terminal, &mut state)?,
+            KeyOutcome::ExecuteDelete => {
+                let Some(PendingAction::Delete { gist_id, .. }) = state.pending_action.clone()
+                else {
+                    continue;
+                };
+                let plan = crate::actions::delete_command(&gist_id);
+                state.back_to_list();
+
+                spawn_bg(&mut state, &mut bg_rx, "Deleting gist…", move || {
+                    let result = crate::actions::execute_command(&plan)
+                        .map(|_| ())
+                        .map_err(|e| e.to_string());
+                    BgTaskOutcome::DeleteGist { result, gist_id }
+                });
+            }
+            KeyOutcome::ExecuteRemoveFile => {
+                let Some(PendingAction::RemoveFile {
+                    gist_id, filename, ..
+                }) = state.pending_action.clone()
+                else {
+                    continue;
+                };
+                let plan = crate::actions::remove_file_command(&gist_id, &filename);
+                state.back_to_list();
+
+                spawn_bg(&mut state, &mut bg_rx, "Removing file…", move || {
+                    let result = crate::actions::execute_command(&plan)
+                        .map(|_| ())
+                        .map_err(|e| e.to_string());
+                    BgTaskOutcome::RemoveFile {
+                        result,
+                        gist_id,
+                        filename,
+                    }
+                });
+            }
+            KeyOutcome::ExecuteCompactGist => {
+                let Some(PendingAction::CompactGist {
+                    gist_id,
+                    label,
+                    count,
+                }) = state.pending_action.clone()
+                else {
+                    continue;
+                };
+                state.pending_action = None;
+                state.screen = state.compact_return_screen;
+
+                spawn_bg(
+                    &mut state,
+                    &mut bg_rx,
+                    "Compacting revisions…",
+                    move || {
+                        let result = crate::actions::execute_compact_gist(&gist_id)
+                            .map_err(|e| e.to_string());
+                        BgTaskOutcome::CompactGist {
+                            result,
+                            label,
+                            count,
+                        }
+                    },
+                );
+            }
+            KeyOutcome::ApplyDescription => {
+                let gist_id = state
+                    .detail_gist_id
+                    .clone()
+                    .or_else(|| state.selected_group().map(|g| g.id.clone()));
+                let Some(gist_id) = gist_id else {
+                    state.editing_description = false;
+                    continue;
+                };
+                let description = state.description_input.to_string();
+                let plan = crate::actions::edit_description_command(&gist_id, &description);
+                state.editing_description = false;
+                state.description_input.clear();
+
+                spawn_bg(
+                    &mut state,
+                    &mut bg_rx,
+                    "Updating description…",
+                    move || {
+                        let result = crate::actions::execute_command(&plan)
+                            .map(|_| ())
+                            .map_err(|e| e.to_string());
+                        BgTaskOutcome::ApplyDescription { result, gist_id }
+                    },
+                );
+            }
+            KeyOutcome::RefreshLocals => {
+                state.set_status("Scanning files…");
+                state.local_scanning = true;
+                local_rx = Some(spawn_local_scan(
+                    state.cwd.clone(),
+                    state.pinned.clone(),
+                    state.local_recursive,
+                    state.skip_dirs.clone(),
+                    state.scan_depth,
+                ));
+            }
+            KeyOutcome::UnpinAtPin => unpin_at_pin_index(&mut state),
+            KeyOutcome::SyncSelectedPair => {
+                let (Some(local), Some(gist)) = (state.selected_local(), state.selected_gist())
+                else {
+                    continue;
+                };
+                let local_abs = state.cwd.join(&local.path);
+                let gist_id = gist.file.gist_id.clone();
+                let filename = gist.file.filename.clone();
+                let idx = state.pinned.iter().position(|m| {
+                    pin_local_abs(&state, m) == local_abs
+                        && m.gist_id == gist_id
+                        && m.gist_filename == filename
+                });
+                let Some(idx) = idx else {
+                    state.set_status("pair is not pinned — press p to pin first");
+                    continue;
+                };
+                let m = state.pinned[idx].clone();
+                match state.pin_sync_status(idx) {
+                    crate::domain::SyncStatus::Push => spawn_pin_push(&mut state, &mut bg_rx, &m),
+                    crate::domain::SyncStatus::Pull => spawn_pin_pull(&mut state, &mut bg_rx, &m),
+                    crate::domain::SyncStatus::InSync => state.set_status("already in sync"),
+                    crate::domain::SyncStatus::Unknown => state
+                        .set_status("can't tell which side is newer — use u to push or d to pull"),
+                }
+            }
+            KeyOutcome::SyncPinPush => {
+                if let Some(m) = selected_pin(&state) {
+                    spawn_pin_push(&mut state, &mut bg_rx, &m);
+                }
+            }
+            KeyOutcome::SyncPinPull => {
+                if let Some(m) = selected_pin(&state) {
+                    spawn_pin_pull(&mut state, &mut bg_rx, &m);
+                }
+            }
+            KeyOutcome::SyncPinAuto => {
+                let Some(pin_idx) = state.selected_pin_index() else {
+                    continue;
+                };
+                let m = state.pinned[pin_idx].clone();
+                match state.pin_sync_status(pin_idx) {
+                    crate::domain::SyncStatus::InSync => state.set_status("already in sync"),
+                    crate::domain::SyncStatus::Pull => spawn_pin_pull(&mut state, &mut bg_rx, &m),
+                    crate::domain::SyncStatus::Push => {
+                        // Cheap, network-free no-op check: if the local file still
+                        // hashes to last_seen_hash, the newer mtime is a touch with
+                        // no content change. Note: only fires for plain pushes — a
+                        // push whose baseline was a JSON-transformed/redacted upload
+                        // won't match the raw file, so it harmlessly falls through to
+                        // a full push.
+                        let local_abs = pin_local_abs(&state, &m);
+                        let unchanged = m.last_seen_hash.as_deref().is_some_and(|baseline| {
+                            std::fs::read(&local_abs)
+                                .map(|b| crate::domain::sha256_hex(&b) == baseline)
+                                .unwrap_or(false)
+                        });
+                        if unchanged {
+                            state.set_status("already in sync");
+                        } else {
+                            spawn_pin_push(&mut state, &mut bg_rx, &m);
+                        }
+                    }
+                    crate::domain::SyncStatus::Unknown => state
+                        .set_status("can't tell which side is newer — use u to push or d to pull"),
+                }
+            }
+            KeyOutcome::PreviewPinDiff => {
+                if let Some(m) = selected_pin(&state) {
+                    state.diff_return = Screen::Pins;
+                    spawn_pin_diff(&mut state, &mut bg_rx, &m);
+                }
+            }
+            KeyOutcome::PersistDiffContext => persist_diff_context(&mut state),
+            KeyOutcome::ThemeToggle => persist_theme(&mut state),
+            KeyOutcome::FetchRevisions => {
+                let Some(gist_id) = state.revision_gist_id.clone() else {
+                    continue;
+                };
+                spawn_bg(&mut state, &mut bg_rx, "Loading revisions…", move || {
+                    let result = crate::gh::fetch_gist_commits_json(&gist_id)
+                        .map_err(|e| e.to_string())
+                        .and_then(|raw| {
+                            crate::gh::parse_gist_commits_json(&raw).map_err(|e| e.to_string())
+                        });
+                    BgTaskOutcome::RevisionsFetched { gist_id, result }
+                });
+            }
+            KeyOutcome::RevisionDiffIncremental => {
+                let Some(gist_id) = state.revision_gist_id.clone() else {
+                    continue;
+                };
+                let Some(child) = state.selected_revision().cloned() else {
+                    continue;
+                };
+                let filename = state.revision_target_file.clone();
+                let child_version = child.version.clone();
+                let child_label = revision_version_label(&child);
+                let parent = state
+                    .revision_entries
+                    .as_ref()
+                    .and_then(|entries| entries.get(state.revision_index + 1).cloned());
+                let (parent_version, old_label) = match parent {
+                    Some(parent) => {
+                        let label = revision_version_label(&parent);
+                        (Some(parent.version), format!("revision {label}"))
+                    }
+                    None => (None, "(initial)".into()),
+                };
+                let new_label = format!("revision {child_label}");
+                let owner_login = state.gist_owner_login(&gist_id);
+                spawn_bg(&mut state, &mut bg_rx, "Loading diff…", move || {
+                    let result = fetch_revision_incremental_pair(
+                        &gist_id,
+                        &child_version,
+                        parent_version.as_deref(),
+                        &filename,
+                        &owner_login,
+                    );
+                    BgTaskOutcome::RevisionDiff {
+                        result,
+                        old_label,
+                        new_label,
+                    }
+                });
+            }
+            KeyOutcome::RevisionDiff => {
+                let Some(gist_id) = state.revision_gist_id.clone() else {
+                    continue;
+                };
+                let Some(revision) = state.selected_revision().cloned() else {
+                    continue;
+                };
+                let filename = state.revision_target_file.clone();
+                let version = revision.version.clone();
+                let version_label = revision_version_label(&revision);
+                let old_label = format!("revision {version_label}");
+                let new_label = format!("current {filename}");
+                let raw_url = state.gist_file_raw_url(&gist_id, &filename);
+                let owner_login = state.gist_owner_login(&gist_id);
+                spawn_bg(&mut state, &mut bg_rx, "Loading diff…", move || {
+                    let result = fetch_revision_pair(
+                        &gist_id,
+                        &version,
+                        &filename,
+                        raw_url.as_deref(),
+                        &owner_login,
+                        &old_label,
+                        &new_label,
+                    );
+                    BgTaskOutcome::RevisionDiff {
+                        result,
+                        old_label,
+                        new_label,
+                    }
+                });
+            }
+            KeyOutcome::RestoreRevisionPreview => {
+                let Some(gist_id) = state.revision_gist_id.clone() else {
+                    continue;
+                };
+                let Some(revision) = state.selected_revision().cloned() else {
+                    continue;
+                };
+                let filename = state.revision_target_file.clone();
+                let version = revision.version.clone();
+                let version_label = revision_version_label(&revision);
+                let raw_url = state.gist_file_raw_url(&gist_id, &filename);
+                let owner_login = state.gist_owner_login(&gist_id);
+                spawn_bg(&mut state, &mut bg_rx, "Loading revision…", move || {
+                    let result = fetch_revision_pair_for_restore(
+                        &gist_id,
+                        &version,
+                        &filename,
+                        raw_url.as_deref(),
+                        &owner_login,
+                    );
+                    BgTaskOutcome::RestoreRevisionReady {
+                        result,
+                        gist_id,
+                        filename,
+                        version,
+                        version_label,
+                    }
+                });
+            }
+            KeyOutcome::ExecuteRestoreRevision => {
+                let Some(PendingAction::RestoreRevision {
+                    gist_id,
+                    filename,
+                    content,
+                    ..
+                }) = state.pending_action.clone()
+                else {
+                    continue;
+                };
+                let timestamp = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_nanos())
+                    .unwrap_or(0);
+                let temp_dir = state.cwd.join(format!(".gistui_restore_{timestamp}"));
+                if let Err(e) = std::fs::create_dir_all(&temp_dir) {
+                    state.set_status(format!("failed to create temp dir: {e}"));
+                    continue;
+                }
+                let json_path = temp_dir.join("restore.json");
+                let body = crate::actions::restore_revision_json(&filename, &content);
+                if let Err(e) = std::fs::write(&json_path, &body) {
+                    state.set_status(format!("failed to write restore payload: {e}"));
+                    let _ = std::fs::remove_dir_all(&temp_dir);
+                    continue;
+                }
+                let plan = crate::actions::restore_revision_command(&gist_id, &json_path);
+                spawn_bg(&mut state, &mut bg_rx, "Restoring revision…", move || {
+                    let result = crate::actions::execute_command(&plan)
+                        .map(|_| ())
+                        .map_err(|e| e.to_string());
+                    let _ = std::fs::remove_dir_all(&temp_dir);
+                    BgTaskOutcome::RestoreRevisionDone {
+                        result,
+                        gist_id,
+                        filename,
+                    }
+                });
+            }
+            KeyOutcome::ToggleGistStar => {
+                let Some(gist_id) = state.context_gist_id() else {
+                    state.set_status("select a gist first");
+                    continue;
+                };
+                let starring = !state.gist_is_starred(&gist_id);
+                let plan = if starring {
+                    crate::actions::star_gist_command(&gist_id)
+                } else {
+                    crate::actions::unstar_gist_command(&gist_id)
+                };
+                let msg = if starring {
+                    "Starring…"
+                } else {
+                    "Unstarring…"
+                };
+                spawn_bg(&mut state, &mut bg_rx, msg, move || {
+                    let result = crate::actions::execute_command(&plan)
+                        .map(|_| ())
+                        .map_err(|e| e.to_string());
+                    BgTaskOutcome::GistStarToggle {
+                        result,
+                        gist_id,
+                        starred: starring,
+                    }
+                });
+            }
+            KeyOutcome::ForkGist => {
+                let Some(gist_id) = state.context_gist_id() else {
+                    state.set_status("select a gist to fork");
+                    continue;
+                };
+                if state.gist_is_owned(&gist_id) {
+                    state.set_status("already yours — no fork needed");
+                    continue;
+                }
+                let plan = crate::actions::fork_gist_command(&gist_id);
+                spawn_bg(&mut state, &mut bg_rx, "Forking…", move || {
+                    let result = crate::actions::execute_command(&plan)
+                        .map(|_| ())
+                        .map_err(|e| e.to_string());
+                    BgTaskOutcome::ForkGist { result, gist_id }
+                });
+            }
+            KeyOutcome::None => {}
         }
     }
 
@@ -1883,6 +1899,9 @@ fn edit_local(
     };
     let args: Vec<&str> = parts.collect();
 
+    if state.mouse_enabled {
+        execute!(terminal.backend_mut(), DisableMouseCapture)?;
+    }
     disable_raw_mode()?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
     let result = std::process::Command::new(program)
@@ -1891,6 +1910,9 @@ fn edit_local(
         .status();
     enable_raw_mode()?;
     execute!(terminal.backend_mut(), EnterAlternateScreen)?;
+    if state.mouse_enabled {
+        execute!(terminal.backend_mut(), EnableMouseCapture)?;
+    }
     terminal.clear()?;
 
     match result {
@@ -1938,6 +1960,9 @@ fn edit_upload_buffer(
     };
     let args: Vec<&str> = parts.collect();
 
+    if state.mouse_enabled {
+        execute!(terminal.backend_mut(), DisableMouseCapture)?;
+    }
     disable_raw_mode()?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
     let result = std::process::Command::new(program)
@@ -1946,6 +1971,9 @@ fn edit_upload_buffer(
         .status();
     enable_raw_mode()?;
     execute!(terminal.backend_mut(), EnterAlternateScreen)?;
+    if state.mouse_enabled {
+        execute!(terminal.backend_mut(), EnableMouseCapture)?;
+    }
     terminal.clear()?;
 
     match result {

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crossterm::event::KeyCode;
+use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier};
 use std::path::PathBuf;
 
@@ -4117,4 +4118,508 @@ fn fork_key_ignored_on_list_and_gist_manager() {
     state.gists_type_filter = GistTypeFilter::Starred;
     state.gists_index = 0;
     assert_eq!(state.handle_key(KeyCode::Char('F')), KeyOutcome::None);
+}
+
+#[test]
+fn initial_state_enables_mouse_by_default() {
+    assert!(super::initial_state().mouse_enabled);
+}
+
+#[test]
+fn pane_hit_maps_rows_to_indices() {
+    // A pane at y=2, height 6: top border row 2, content rows 3..=6, bottom border row 7.
+    let hit = PaneHit {
+        rect: Rect::new(0, 2, 40, 6),
+        offset: 0,
+    };
+    assert_eq!(hit.index_at(3, 4), Some(0)); // first content row
+    assert_eq!(hit.index_at(6, 4), Some(3)); // fourth content row
+    assert_eq!(hit.index_at(2, 4), None); // top border
+    assert_eq!(hit.index_at(7, 4), None); // bottom border
+    assert_eq!(hit.index_at(6, 2), None); // row maps to idx 3 >= visible_len 2
+}
+
+#[test]
+fn pane_hit_respects_scroll_offset() {
+    let hit = PaneHit {
+        rect: Rect::new(0, 0, 40, 10),
+        offset: 5,
+    };
+    // content starts at row 1; row 1 -> offset 5
+    assert_eq!(hit.index_at(1, 20), Some(5));
+    assert_eq!(hit.index_at(3, 20), Some(7));
+}
+
+#[test]
+fn pane_hit_empty_list_selects_nothing() {
+    let hit = PaneHit {
+        rect: Rect::new(0, 0, 40, 10),
+        offset: 0,
+    };
+    assert_eq!(hit.index_at(1, 0), None);
+}
+
+#[test]
+fn classify_click_detects_double_click() {
+    // Same cell within the threshold -> DoubleClick.
+    let r = super::classify_click(Some((5, 5)), 100, 5, 5);
+    assert_eq!(r, MouseInput::DoubleClick { col: 5, row: 5 });
+}
+
+#[test]
+fn classify_click_single_when_too_slow() {
+    let r = super::classify_click(Some((5, 5)), super::DOUBLE_CLICK_MS + 1, 5, 5);
+    assert_eq!(r, MouseInput::Click { col: 5, row: 5 });
+}
+
+#[test]
+fn classify_click_single_on_different_cell() {
+    let r = super::classify_click(Some((5, 5)), 100, 6, 5);
+    assert_eq!(r, MouseInput::Click { col: 6, row: 5 });
+}
+
+#[test]
+fn classify_click_single_when_no_prior() {
+    let r = super::classify_click(None, 0, 5, 5);
+    assert_eq!(r, MouseInput::Click { col: 5, row: 5 });
+}
+
+#[test]
+fn classify_click_at_exact_threshold() {
+    // Exactly at the boundary: still counts as a double-click (inclusive `<=`).
+    let r = super::classify_click(Some((5, 5)), super::DOUBLE_CLICK_MS, 5, 5);
+    assert_eq!(r, MouseInput::DoubleClick { col: 5, row: 5 });
+}
+
+// ── handle_mouse tests ────────────────────────────────────────────────────────
+
+#[test]
+fn scroll_down_moves_focused_list_by_one() {
+    let mut state = state_with_local_paths(&["a.rs", "b.rs", "c.rs"]);
+    state.screen = Screen::List;
+    state.focus = FocusPane::Local;
+    state.local_index = 0;
+    let out = state.handle_mouse(MouseInput::ScrollDown, &MouseLayout::default());
+    assert_eq!(out, KeyOutcome::None);
+    assert_eq!(state.local_index, 1);
+}
+
+#[test]
+fn scroll_up_moves_focused_list_by_one() {
+    let mut state = state_with_local_paths(&["a.rs", "b.rs", "c.rs"]);
+    state.screen = Screen::List;
+    state.focus = FocusPane::Local;
+    state.local_index = 2;
+    let out = state.handle_mouse(MouseInput::ScrollUp, &MouseLayout::default());
+    assert_eq!(out, KeyOutcome::None);
+    assert_eq!(state.local_index, 1);
+}
+
+#[test]
+fn scroll_down_moves_content_three_lines() {
+    // Set up a Diff screen with enough lines that diff_scroll can reach 3.
+    let mut state = state_with_selection();
+    state.enter_diff(
+        "line1\nline2\nline3\nline4\nline5".into(),
+        "remote".into(),
+        std::path::PathBuf::from("/tmp/x"),
+        std::path::PathBuf::from("/tmp/cwd/x"),
+    );
+    assert_eq!(state.screen, Screen::Diff);
+    assert_eq!(state.diff_scroll, 0);
+    state.handle_mouse(MouseInput::ScrollDown, &MouseLayout::default());
+    assert_eq!(state.diff_scroll, 3);
+}
+
+#[test]
+fn scroll_up_moves_content_three_lines() {
+    let mut state = state_with_selection();
+    state.enter_diff(
+        "line1\nline2\nline3\nline4\nline5".into(),
+        "remote".into(),
+        std::path::PathBuf::from("/tmp/x"),
+        std::path::PathBuf::from("/tmp/cwd/x"),
+    );
+    state.diff_scroll = 3;
+    state.handle_mouse(MouseInput::ScrollUp, &MouseLayout::default());
+    assert_eq!(state.diff_scroll, 0);
+}
+
+#[test]
+fn close_button_click_returns_from_help() {
+    let mut state = state_with_gists();
+    // Simulate entering Help (mirrors what open_help() does).
+    state.help_return = Screen::List;
+    state.screen = Screen::Help;
+    let layout = MouseLayout {
+        close_button: Some(Rect::new(36, 0, 5, 1)),
+        ..Default::default()
+    };
+    let out = state.handle_mouse(MouseInput::Click { col: 38, row: 0 }, &layout);
+    assert_eq!(out, KeyOutcome::None);
+    assert_eq!(state.screen, Screen::List);
+}
+
+#[test]
+fn close_button_click_outside_is_noop() {
+    let mut state = state_with_gists();
+    state.help_return = Screen::List;
+    state.screen = Screen::Help;
+    let layout = MouseLayout {
+        close_button: Some(Rect::new(36, 0, 5, 1)),
+        ..Default::default()
+    };
+    // col 35 is just outside the left edge of the close button
+    let out = state.handle_mouse(MouseInput::Click { col: 35, row: 0 }, &layout);
+    assert_eq!(out, KeyOutcome::None);
+    assert_eq!(state.screen, Screen::Help);
+}
+
+#[test]
+fn list_click_selects_and_focuses_gist_pane() {
+    let mut state = state_with_gists();
+    state.screen = Screen::List;
+    state.focus = FocusPane::Local;
+    state.gist_hscroll = 5;
+    let hit = PaneHit {
+        rect: Rect::new(20, 0, 20, 10),
+        offset: 0,
+    };
+    let layout = MouseLayout {
+        gist: Some(hit),
+        ..Default::default()
+    };
+    // row 2 -> content idx 1 (top border is row 0, row 1 = idx 0, row 2 = idx 1)
+    let out = state.handle_mouse(MouseInput::Click { col: 25, row: 2 }, &layout);
+    assert_eq!(out, KeyOutcome::None);
+    assert_eq!(state.focus, FocusPane::Gist);
+    assert_eq!(state.gist_index, 1);
+    assert_eq!(state.gist_hscroll, 0);
+}
+
+#[test]
+fn list_click_selects_and_focuses_local_pane() {
+    let mut state = state_with_local_paths(&["a.rs", "b.rs", "c.rs"]);
+    state.gists = vec![];
+    state.screen = Screen::List;
+    state.focus = FocusPane::Gist;
+    state.local_hscroll = 5;
+    let hit = PaneHit {
+        rect: Rect::new(0, 0, 20, 10),
+        offset: 0,
+    };
+    let layout = MouseLayout {
+        local: Some(hit),
+        ..Default::default()
+    };
+    // row 1 -> idx 0 (first content row after top border)
+    let out = state.handle_mouse(MouseInput::Click { col: 5, row: 1 }, &layout);
+    assert_eq!(out, KeyOutcome::None);
+    assert_eq!(state.focus, FocusPane::Local);
+    assert_eq!(state.local_index, 0);
+    assert_eq!(state.local_hscroll, 0);
+}
+
+#[test]
+fn list_double_click_opens_diff() {
+    let mut state = state_with_gists();
+    state.screen = Screen::List;
+    let hit = PaneHit {
+        rect: Rect::new(20, 0, 20, 10),
+        offset: 0,
+    };
+    let layout = MouseLayout {
+        gist: Some(hit),
+        ..Default::default()
+    };
+    // row 1 -> idx 0 (first gist)
+    let out = state.handle_mouse(MouseInput::DoubleClick { col: 25, row: 1 }, &layout);
+    assert_eq!(state.focus, FocusPane::Gist);
+    assert_eq!(state.gist_index, 0);
+    assert_eq!(out, KeyOutcome::PreviewDiff);
+}
+
+#[test]
+fn click_in_pane_blank_focuses_without_selecting() {
+    let mut state = state_with_gists();
+    state.screen = Screen::List;
+    state.focus = FocusPane::Local;
+    state.gist_index = 0;
+    let hit = PaneHit {
+        rect: Rect::new(20, 0, 20, 4),
+        offset: 0,
+    };
+    let layout = MouseLayout {
+        gist: Some(hit),
+        ..Default::default()
+    };
+    // row 0 is the top border (no row there): clicking the gist pane's blank/border area
+    // switches focus to it but selects nothing.
+    let out = state.handle_mouse(MouseInput::Click { col: 25, row: 0 }, &layout);
+    assert_eq!(out, KeyOutcome::None);
+    assert_eq!(state.focus, FocusPane::Gist);
+    assert_eq!(state.gist_index, 0);
+}
+
+#[test]
+fn click_off_list_screen_is_noop() {
+    let mut state = state_with_gists();
+    state.help_return = Screen::List;
+    state.screen = Screen::Help;
+    let hit = PaneHit {
+        rect: Rect::new(20, 0, 20, 10),
+        offset: 0,
+    };
+    let layout = MouseLayout {
+        gist: Some(hit),
+        ..Default::default()
+    };
+    let before_screen = state.screen;
+    let out = state.handle_mouse(MouseInput::Click { col: 25, row: 1 }, &layout);
+    assert_eq!(out, KeyOutcome::None);
+    assert_eq!(state.screen, before_screen);
+}
+
+#[test]
+fn scroll_down_clamps_at_list_end() {
+    // Only 1 item in local; scrolling down should clamp (no panic, no index change).
+    let mut state = state_with_local_paths(&["a.rs"]);
+    state.screen = Screen::List;
+    state.focus = FocusPane::Local;
+    state.local_index = 0;
+    state.handle_mouse(MouseInput::ScrollDown, &MouseLayout::default());
+    assert_eq!(state.local_index, 0);
+}
+
+#[test]
+fn close_button_click_confirm_cancel_clears_pending() {
+    // Close button on Screen::Confirm dispatches Esc, which cancels the pending action.
+    // Using PendingAction::Download: Esc sets pending_action = None and screen = Screen::Diff.
+    let mut state = state_with_gists();
+    state.diff_text = "line1\nline2\nline3".into();
+    state.screen = Screen::Confirm;
+    state.pending_action = Some(PendingAction::Download);
+    let layout = MouseLayout {
+        close_button: Some(Rect::new(36, 0, 5, 1)),
+        ..Default::default()
+    };
+    let out = state.handle_mouse(MouseInput::Click { col: 38, row: 0 }, &layout);
+    assert_eq!(out, KeyOutcome::None);
+    assert!(state.pending_action.is_none());
+    assert_eq!(state.screen, Screen::Diff);
+}
+
+#[test]
+fn close_button_click_create_description_cancels_not_types() {
+    // Regression: close button while editing the create-description sub-state must cancel
+    // (Esc), NOT append 'n' to the description field.  This test fails against the old
+    // `KeyCode::Char('n')` dispatch and passes with `KeyCode::Esc`.
+    let mut state = initial_state();
+    state.screen = Screen::Confirm;
+    state.pending_action = Some(PendingAction::Create {
+        local_path: std::path::PathBuf::from("notes.txt"),
+    });
+    state.editing_description = true;
+    // Pre-fill description so we can assert it was cleared (not grown by a typed 'n').
+    state.description_input = "my desc".into();
+    let layout = MouseLayout {
+        close_button: Some(Rect::new(36, 0, 5, 1)),
+        ..Default::default()
+    };
+    state.handle_mouse(MouseInput::Click { col: 38, row: 0 }, &layout);
+    // Esc on create-description clears description, exits editing, and calls back_to_list.
+    assert!(
+        !state.editing_description,
+        "editing_description must be false after close"
+    );
+    assert!(
+        state.description_input.is_empty(),
+        "description must be cleared, not have 'n' appended"
+    );
+    assert_eq!(state.screen, Screen::List);
+    assert!(state.pending_action.is_none());
+}
+
+#[test]
+fn wheel_step_gist_detail_moves_three() {
+    // GistDetail content pane: one scroll-down tick must advance detail_scroll by 3.
+    let mut state = state_with_gists();
+    state.screen = Screen::GistDetail;
+    state.detail_gist_id = Some("g1".into());
+    // Use Comments focus so detail_nav moves detail_scroll (not the file cursor).
+    state.detail_focus = DetailFocus::Comments;
+    state.detail_comments = Some(Vec::new());
+    assert_eq!(state.detail_scroll, 0);
+    state.handle_mouse(MouseInput::ScrollDown, &MouseLayout::default());
+    assert_eq!(state.detail_scroll, 3);
+}
+
+#[test]
+fn wheel_step_help_body_moves_three() {
+    // Help body (help_index_open = false): one scroll-down tick must advance help_scroll by 3.
+    let mut state = initial_state();
+    state.screen = Screen::Help;
+    state.help_index_open = false;
+    state.help_scroll = 0;
+    state.handle_mouse(MouseInput::ScrollDown, &MouseLayout::default());
+    assert_eq!(state.help_scroll, 3);
+}
+
+#[test]
+fn wheel_step_help_index_moves_one() {
+    // Help topic index (help_index_open = true): one scroll-down tick must move index by 1.
+    let mut state = initial_state();
+    state.screen = Screen::Help;
+    state.help_index_open = true;
+    state.help_index_sel = 0;
+    state.handle_mouse(MouseInput::ScrollDown, &MouseLayout::default());
+    assert_eq!(state.help_index_sel, 1);
+}
+
+#[test]
+fn gists_click_selects_and_double_click_matches_enter() {
+    let mut state = gists_screen_state(); // 2 groups, Screen::Gists
+    state.gists_index = 0;
+    let hit = PaneHit {
+        rect: Rect::new(0, 0, 40, 10),
+        offset: 0,
+    };
+    let layout = MouseLayout {
+        list: Some(hit),
+        ..Default::default()
+    };
+    // Row 2 is the 2nd content row (border at row 0) -> idx 1.
+    let out = state.handle_mouse(MouseInput::Click { col: 5, row: 2 }, &layout);
+    assert_eq!(out, KeyOutcome::None);
+    assert_eq!(state.gists_index, 1);
+    // Double-click activates the same row, exactly as Enter would.
+    let mut by_key = state.clone();
+    let key_out = by_key.handle_key(KeyCode::Enter);
+    let by_mouse = state.handle_mouse(MouseInput::DoubleClick { col: 5, row: 2 }, &layout);
+    assert_eq!(by_mouse, key_out);
+    assert_eq!(by_mouse, KeyOutcome::OpenGistDetail);
+}
+
+#[test]
+fn pins_click_selects_and_double_click_matches_enter() {
+    let mut state = state_with_pins(&[("a.txt", "g1", "a.txt"), ("b.txt", "g2", "b.txt")]);
+    let hit = PaneHit {
+        rect: Rect::new(0, 0, 40, 10),
+        offset: 0,
+    };
+    let layout = MouseLayout {
+        list: Some(hit),
+        ..Default::default()
+    };
+    let out = state.handle_mouse(MouseInput::Click { col: 5, row: 2 }, &layout);
+    assert_eq!(out, KeyOutcome::None);
+    assert_eq!(state.pins_index, 1);
+    let mut by_key = state.clone();
+    let key_out = by_key.handle_key(KeyCode::Enter);
+    let by_mouse = state.handle_mouse(MouseInput::DoubleClick { col: 5, row: 2 }, &layout);
+    assert_eq!(by_mouse, key_out);
+}
+
+#[test]
+fn revisions_click_selects_and_double_click_matches_enter() {
+    let mut state = state_with_gists();
+    state.screen = Screen::Revisions;
+    state.revision_index = 0;
+    state.revision_entries = Some(vec![
+        crate::domain::GistRevision {
+            version: "v2".into(),
+            committed_at: "2026-06-10T00:00:00Z".into(),
+            user: "u".into(),
+            change_status: crate::domain::GistRevisionChangeStatus {
+                total: 1,
+                additions: 1,
+                deletions: 0,
+            },
+        },
+        crate::domain::GistRevision {
+            version: "v1".into(),
+            committed_at: "2026-06-01T00:00:00Z".into(),
+            user: "u".into(),
+            change_status: crate::domain::GistRevisionChangeStatus {
+                total: 2,
+                additions: 2,
+                deletions: 0,
+            },
+        },
+    ]);
+    let hit = PaneHit {
+        rect: Rect::new(0, 0, 40, 10),
+        offset: 0,
+    };
+    let layout = MouseLayout {
+        list: Some(hit),
+        ..Default::default()
+    };
+    let out = state.handle_mouse(MouseInput::Click { col: 5, row: 2 }, &layout);
+    assert_eq!(out, KeyOutcome::None);
+    assert_eq!(state.revision_index, 1);
+    let mut by_key = state.clone();
+    let key_out = by_key.handle_key(KeyCode::Enter);
+    let by_mouse = state.handle_mouse(MouseInput::DoubleClick { col: 5, row: 2 }, &layout);
+    assert_eq!(by_mouse, key_out);
+    assert_eq!(by_mouse, KeyOutcome::RevisionDiffIncremental);
+}
+
+#[test]
+fn gist_detail_file_click_selects_and_double_previews() {
+    let mut state = state_with_gists(); // g1: a.txt (0), b.txt (1)
+    state.screen = Screen::GistDetail;
+    state.detail_gist_id = Some("g1".into());
+    state.detail_focus = DetailFocus::Comments; // start elsewhere to prove the focus switch
+    let hit = PaneHit {
+        rect: Rect::new(0, 0, 40, 10),
+        offset: 0,
+    };
+    let layout = MouseLayout {
+        detail_files: Some(hit),
+        ..Default::default()
+    };
+    // Click the 2nd file row -> Files focus + cursor 1, but no open yet.
+    let out = state.handle_mouse(MouseInput::Click { col: 5, row: 2 }, &layout);
+    assert_eq!(out, KeyOutcome::None);
+    assert_eq!(state.detail_focus, DetailFocus::Files);
+    assert_eq!(state.detail_file_cursor, 1);
+    // Double-click previews that file (there is no Enter for files).
+    let out = state.handle_mouse(MouseInput::DoubleClick { col: 5, row: 2 }, &layout);
+    assert_eq!(out, KeyOutcome::PreviewContent);
+    assert_eq!(state.preview_request, Some(("g1".into(), "b.txt".into())));
+}
+
+#[test]
+fn gist_detail_tab_click_switches_focus() {
+    let mut state = state_with_gists();
+    state.screen = Screen::GistDetail;
+    state.detail_gist_id = Some("g1".into());
+    state.detail_focus = DetailFocus::Files;
+    // Header at chunks[0] y=0: content_x = 2, tabs_y = 2; " Files " (7), " Comments " (10 @ +10).
+    let layout = MouseLayout {
+        detail_tab_files: Some(Rect::new(2, 2, 7, 1)),
+        detail_tab_comments: Some(Rect::new(12, 2, 10, 1)),
+        ..Default::default()
+    };
+    // Click the Comments tab: switches focus and (comments unloaded) requests a fetch.
+    let out = state.handle_mouse(MouseInput::Click { col: 14, row: 2 }, &layout);
+    assert_eq!(state.detail_focus, DetailFocus::Comments);
+    assert_eq!(out, KeyOutcome::FetchComments);
+    // Click the Files tab back.
+    let out = state.handle_mouse(MouseInput::Click { col: 4, row: 2 }, &layout);
+    assert_eq!(state.detail_focus, DetailFocus::Files);
+    assert_eq!(out, KeyOutcome::None);
+}
+
+#[test]
+fn wheel_step_gist_detail_files_moves_one() {
+    // The file list (Files tab) steps one file per wheel tick, not 3.
+    let mut state = state_with_gists();
+    state.screen = Screen::GistDetail;
+    state.detail_gist_id = Some("g1".into());
+    state.detail_focus = DetailFocus::Files;
+    state.detail_file_cursor = 0;
+    state.handle_mouse(MouseInput::ScrollDown, &MouseLayout::default());
+    assert_eq!(state.detail_file_cursor, 1);
 }


### PR DESCRIPTION
## Summary

Adds full mouse support to the TUI (closes #142). Mouse is on by default; disable with `mouse = false` in `config.toml` or the `--no-mouse` flag.

## Changes

- **Scroll wheel** scrolls the focused list / content pane (item lists 1 row/tick; content panes 3 lines/tick; the GistDetail file list steps 1 file/tick while its comments body scrolls 3 lines/tick).
- **Click** selects a row (List panes also switch focus; clicking a pane's blank area focuses it). **Double-click** opens it — List diff, gist detail, pin diff, revision diff, or GistDetail file preview.
- **Tabs**: click the GistDetail Files / Comments headers to switch focus (Comments triggers the lazy comment fetch).
- **`[✕]` close button** on every pop-up screen and modal (acts as Esc / back; drawn on the modal box for centered dialogs).
- **Opt-out**: config `mouse` (default `true`) + `--no-mouse` CLI flag.
- Architecture: pure, unit-tested `AppState::handle_mouse` mirroring `handle_key_with` (reuses `apply_navigation` / `handle_key_with`); per-frame hit regions in a `run_loop`-owned `MouseLayout` filled by `render`; double-click clock + `Enable`/`DisableMouseCapture` (incl. around external editors, unconditional disable in teardown) in `run_loop`/`run`.
- Bumps version to `0.13.0` (Cargo.toml/lock). **CHANGELOG entry stays under `[Unreleased]`** — 0.13.0 is formally released after the rest of the milestone lands.

## Testing

- [x] `cargo fmt --check`
- [x] `cargo test` (404 unit + 12 integration)
- [x] `cargo check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Manually verified in the TUI

## Related Issues

Closes #142. Part of milestone **0.13.0** (with #143 startup update check, #144 diff word-wrap).

## Notes

The README demo GIF is intentionally **not** re-recorded here — it will be regenerated once with #144 (diff word-wrap) to avoid churning the binary asset multiple times.