### PR TITLE
feat: check for a newer release on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Mouse support: wheel scroll, click to focus/select, double-click to open, and a clickable close button on pop-up screens (on by default; disable with `mouse = false` or `--no-mouse`).
+- Startup update check: on launch gistui checks GitHub (once a day, silently) for a newer release and shows a footer hint with the right upgrade command if one exists (disable with `check_updates = false` or `--no-update-check`).
 
 ## [0.12.0] — 2026-06-19
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ file is never overwritten without a diff and `y/n` confirmation; destructive rem
 each get their own confirm. Others' gists (e.g. starred) are read-only for pin/upload/delete
 — fork with `F` in gist detail. No GitHub token is stored; gist content is never written to
 config. Mouse is on by default and can be disabled with `mouse = false` in the config file or
-the `--no-mouse` flag.
+the `--no-mouse` flag. On startup gistui checks GitHub once a day for a newer release and shows
+a footer hint if one exists (no telemetry; fails silently offline) — disable with
+`check_updates = false` or `--no-update-check`.
 
 Full rules: **[reference/SAFETY.md](reference/SAFETY.md)**.
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -19,9 +19,14 @@ diff_show_full = false
 # theme = "dark"
 
 # Enable mouse support: wheel scroll, click to focus/select, double-click to open,
-# and a clickable [Esc]/[n] close button on pop-up screens. Default: true.
+# and a clickable [✕] close button on pop-up screens. Default: true.
 # (The `--no-mouse` CLI flag also forces it off for a single session.)
 mouse = true
+
+# Check GitHub on startup for a newer release and show a hint if one exists. Default: true.
+# Throttled to once per day; fails silently when offline.
+# (The `--no-update-check` CLI flag also forces it off for a single session.)
+check_updates = true
 
 # Directories skipped when recursive local file discovery is active (r key).
 # Hidden directories (names starting with ".") are always skipped regardless

--- a/scripts/demo/record.py
+++ b/scripts/demo/record.py
@@ -69,7 +69,8 @@ def main():
     pid, master = pty.fork()
     if pid == 0:
         os.chdir(WORK)
-        os.execvpe(BIN, [BIN, WORK], env)
+        # --no-update-check keeps the recording deterministic and offline (no GitHub call).
+        os.execvpe(BIN, [BIN, "--no-update-check", WORK], env)
         os._exit(127)
 
     fcntl.ioctl(master, termios.TIOCSWINSZ, struct.pack("HHHH", ROWS, COLS, 0, 0))

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,10 @@ fn default_mouse() -> bool {
     true
 }
 
+fn default_check_updates() -> bool {
+    true
+}
+
 fn default_skip_dirs() -> Vec<String> {
     [
         "node_modules",
@@ -72,6 +76,10 @@ pub struct AppConfig {
     /// set `false` to opt out (the `--no-mouse` CLI flag also forces it off).
     #[serde(default = "default_mouse")]
     pub mouse: bool,
+    /// Check GitHub on startup for a newer release and show a hint if one exists. Default
+    /// `true`; set `false` to opt out (the `--no-update-check` CLI flag also forces it off).
+    #[serde(default = "default_check_updates")]
+    pub check_updates: bool,
 }
 
 impl Default for AppConfig {
@@ -84,6 +92,7 @@ impl Default for AppConfig {
             diff_show_full: false,
             theme: ThemeChoice::Dark,
             mouse: true,
+            check_updates: true,
         }
     }
 }
@@ -183,6 +192,12 @@ pub fn resolve_mouse_enabled(config_mouse: bool, no_mouse: bool) -> bool {
     config_mouse && !no_mouse
 }
 
+/// Effective update-check state: the config value, with the `--no-update-check` CLI flag
+/// able to force it off (no `--update-check` flag — edit the config to force on).
+pub fn resolve_update_check(config_check: bool, no_update_check: bool) -> bool {
+    config_check && !no_update_check
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -241,6 +256,7 @@ mod tests {
             diff_show_full: false,
             theme: ThemeChoice::Dark,
             mouse: true,
+            check_updates: true,
         };
 
         save_config(&path, &config).unwrap();
@@ -436,5 +452,21 @@ mod tests {
         assert!(!resolve_mouse_enabled(true, true)); // flag forces off
         assert!(!resolve_mouse_enabled(false, false)); // config off
         assert!(!resolve_mouse_enabled(false, true)); // both off
+    }
+
+    #[test]
+    fn check_updates_defaults_to_true_when_absent() {
+        // A config file with no `check_updates` key must load as enabled.
+        let toml = "scan_depth = 4\n";
+        let config: AppConfig = toml::from_str(toml).unwrap();
+        assert!(config.check_updates);
+    }
+
+    #[test]
+    fn resolve_update_check_truth_table() {
+        assert!(resolve_update_check(true, false)); // default on, no flag
+        assert!(!resolve_update_check(true, true)); // flag forces off
+        assert!(!resolve_update_check(false, false)); // config off
+        assert!(!resolve_update_check(false, true)); // both off
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,5 @@ pub mod local;
 pub mod lru;
 pub mod ranking;
 pub mod tui;
+pub mod update_check;
 pub mod upgrade;

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,11 @@ struct Cli {
         help = "Disable mouse capture (scroll/click) for this session"
     )]
     no_mouse: bool,
+    #[arg(
+        long = "no-update-check",
+        help = "Skip the startup check for a newer release for this session"
+    )]
+    no_update_check: bool,
 }
 
 fn main() -> Result<()> {
@@ -56,5 +61,5 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    gistui::tui::run(cli.no_mouse)
+    gistui::tui::run(cli.no_mouse, cli.no_update_check)
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -483,6 +483,14 @@ pub struct AppState {
     /// Whether mouse capture is active this session (config `mouse` AND-NOT `--no-mouse`).
     /// Gates the `Event::Mouse` branch and the close-button rendering.
     pub mouse_enabled: bool,
+    /// Whether the startup update check runs this session (config `check_updates` AND-NOT
+    /// `--no-update-check`).
+    pub update_check_enabled: bool,
+    /// Newer release version found by the background check, if any (footer hint on the List).
+    pub update_available: Option<String>,
+    /// How this binary was installed — resolved once at startup so the update hint can show
+    /// the right upgrade command without per-frame IO.
+    pub install_method: crate::upgrade::InstallMethod,
     pub preview_gist_key: Option<(String, String)>,
     /// Screen to return to when leaving the full-screen preview (default: List; set to
     /// GistDetail when a detail-view file preview is launched).
@@ -1388,6 +1396,9 @@ pub fn initial_state() -> AppState {
         preview_wrap: false,
         syntax_highlight: true,
         mouse_enabled: true,
+        update_check_enabled: true,
+        update_available: None,
+        install_method: crate::upgrade::InstallMethod::Standalone,
         preview_gist_key: None,
         preview_return: Screen::List,
         preview_request: None,
@@ -1452,7 +1463,7 @@ pub fn initial_state() -> AppState {
     }
 }
 
-pub fn load_startup_state(no_mouse: bool) -> Result<AppState> {
+pub fn load_startup_state(no_mouse: bool, no_update_check: bool) -> Result<AppState> {
     let mut state = initial_state();
     let config_path = crate::config::config_path()?;
     let config = crate::config::load_config(&config_path)?;
@@ -1468,6 +1479,20 @@ pub fn load_startup_state(no_mouse: bool) -> Result<AppState> {
     // Honour NO_COLOR for the syntax-highlight feature only (existing semantic colours stay).
     state.syntax_highlight = std::env::var_os("NO_COLOR").is_none();
     state.mouse_enabled = crate::config::resolve_mouse_enabled(config.mouse, no_mouse);
+    state.update_check_enabled =
+        crate::config::resolve_update_check(config.check_updates, no_update_check);
+    // Surface a previously-seen newer release immediately (even when the daily check is
+    // throttled), so the hint persists across launches without re-hitting the network.
+    if state.update_check_enabled {
+        if let Ok(exe) = std::env::current_exe() {
+            state.install_method = crate::upgrade::detect_install_method(&exe);
+        }
+        if let Ok(path) = crate::update_check::state_path() {
+            let seen = crate::update_check::load_state(&path).latest_seen;
+            state.update_available =
+                crate::update_check::is_newer(&seen, env!("CARGO_PKG_VERSION"));
+        }
+    }
     state.locals = crate::local::discover_local_candidates(
         &cwd,
         &state.pinned,
@@ -1497,14 +1522,14 @@ pub fn load_startup_state(no_mouse: bool) -> Result<AppState> {
     Ok(state)
 }
 
-pub fn run(no_mouse: bool) -> Result<()> {
+pub fn run(no_mouse: bool, no_update_check: bool) -> Result<()> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen)?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let result = run_loop(&mut terminal, no_mouse);
+    let result = run_loop(&mut terminal, no_mouse, no_update_check);
 
     let _ = disable_raw_mode();
     let _ = execute!(terminal.backend_mut(), LeaveAlternateScreen);

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1547,6 +1547,11 @@ pub(super) fn render_list(frame: &mut Frame, state: &AppState, layout: &mut Mous
     };
     // Only the command-hint variant gets key colouring; filter input and status stay plain.
     let footer_is_command = !state.filtering && state.status.is_none();
+    // A newer-release hint rides the footer's top-border title slot (non-intrusive, persistent).
+    let footer_title = match &state.update_available {
+        Some(v) => crate::update_check::update_hint(v, &state.install_method),
+        None => String::new(),
+    };
     // Width inside the footer block: minus the 2 horizontal padding columns (no side borders).
     let footer_lines = wrap_line_count(&footer_body, area.width.saturating_sub(2)).max(1);
     let chunks = Layout::default()
@@ -1689,7 +1694,7 @@ pub(super) fn render_list(frame: &mut Frame, state: &AppState, layout: &mut Mous
         render_footer(
             frame,
             chunks[1],
-            "",
+            &footer_title,
             &footer_body,
             footer_is_command,
             &state.theme,

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -6,13 +6,31 @@ use std::io;
 pub(super) fn run_loop(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     no_mouse: bool,
+    no_update_check: bool,
 ) -> Result<()> {
-    let mut state = load_startup_state(no_mouse)?;
+    let mut state = load_startup_state(no_mouse, no_update_check)?;
     if state.mouse_enabled {
         execute!(terminal.backend_mut(), EnableMouseCapture)?;
     }
     let mut mouse_layout = MouseLayout::default();
     let mut last_click: Option<(u16, u16, std::time::Instant)> = None;
+
+    // Background "is a newer release available?" check — off-thread, throttled to once a day,
+    // silent on failure. The result (if any) is absorbed in the loop below.
+    let update_check_path = crate::update_check::state_path().ok();
+    let mut update_rx: Option<std::sync::mpsc::Receiver<crate::update_check::UpdateCheckOutcome>> =
+        None;
+    if state.update_check_enabled {
+        let due = update_check_path.as_ref().is_none_or(|path| {
+            crate::update_check::should_check(
+                crate::update_check::load_state(path).last_check,
+                crate::update_check::now_secs(),
+            )
+        });
+        if due {
+            update_rx = Some(spawn_update_check());
+        }
+    }
     let mut gist_rx = Some(spawn_gist_fetch());
     let mut fork_rx: Option<std::sync::mpsc::Receiver<std::collections::HashMap<String, u32>>> =
         None;
@@ -127,6 +145,42 @@ pub(super) fn run_loop(
                     state.local_scanning = false;
                     state.status = None;
                     local_rx = None;
+                }
+            }
+        }
+
+        // Absorb the background update-check result: show the hint and persist the throttle.
+        // Failed checks are silent and not recorded, so they retry on the next launch.
+        if let Some(ref rx) = update_rx {
+            if let Ok(outcome) = rx.try_recv() {
+                update_rx = None;
+                let now = crate::update_check::now_secs();
+                match outcome {
+                    crate::update_check::UpdateCheckOutcome::Newer(version) => {
+                        if let Some(ref path) = update_check_path {
+                            crate::update_check::save_state(
+                                path,
+                                &crate::update_check::UpdateCheckState {
+                                    last_check: now,
+                                    latest_seen: version.clone(),
+                                },
+                            );
+                        }
+                        state.update_available = Some(version);
+                    }
+                    crate::update_check::UpdateCheckOutcome::UpToDate => {
+                        if let Some(ref path) = update_check_path {
+                            crate::update_check::save_state(
+                                path,
+                                &crate::update_check::UpdateCheckState {
+                                    last_check: now,
+                                    latest_seen: String::new(),
+                                },
+                            );
+                        }
+                        state.update_available = None;
+                    }
+                    crate::update_check::UpdateCheckOutcome::Failed => {}
                 }
             }
         }
@@ -1535,6 +1589,18 @@ type GistFetchResult = (
     Option<String>,
     Option<String>,
 );
+
+/// Off-thread: ask GitHub for the latest release tag and classify it against the running
+/// version. Network failures map to `Failed` (silent; the loop won't record the throttle).
+fn spawn_update_check() -> std::sync::mpsc::Receiver<crate::update_check::UpdateCheckOutcome> {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let outcome =
+            crate::update_check::check(&crate::upgrade::UreqClient, env!("CARGO_PKG_VERSION"));
+        let _ = tx.send(outcome);
+    });
+    rx
+}
 
 fn spawn_gist_fetch() -> std::sync::mpsc::Receiver<GistFetchResult> {
     let (tx, rx) = std::sync::mpsc::channel();

--- a/src/update_check.rs
+++ b/src/update_check.rs
@@ -1,0 +1,199 @@
+//! Background "is there a newer release?" check shown on startup.
+//!
+//! Reuses the [`crate::upgrade`] release client and version helpers. The network fetch is a
+//! thin IO boundary; the comparison/throttle/hint logic is pure and unit-tested. The check
+//! fails silently (offline, rate-limited, parse error) and is throttled to once per day.
+
+use crate::upgrade::{normalize_tag, upgrade_hint, version_cmp, InstallMethod, ReleaseClient};
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Minimum gap between startup checks (once per day), to be polite to the GitHub API
+/// (unauthenticated `api.github.com` is 60 requests/hour/IP).
+pub const CHECK_INTERVAL_SECS: u64 = 86_400;
+
+/// Outcome of an attempted background check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpdateCheckOutcome {
+    /// A newer release is available (normalized version, e.g. `"0.14.0"`).
+    Newer(String),
+    /// Checked successfully; already on the latest version.
+    UpToDate,
+    /// The check could not complete (offline / rate-limited / parse error). Stay silent and
+    /// retry on the next launch — do NOT record it against the throttle.
+    Failed,
+}
+
+/// Persisted throttle state (`$XDG_CACHE_HOME/gistui/update_check.json`).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UpdateCheckState {
+    /// Unix seconds of the last completed check.
+    #[serde(default)]
+    pub last_check: u64,
+    /// Latest release tag seen at the last check (normalized); lets the hint persist across
+    /// launches within the throttle window without re-hitting the network.
+    #[serde(default)]
+    pub latest_seen: String,
+}
+
+pub fn state_path() -> Result<PathBuf> {
+    let dir = dirs::cache_dir().context("locate cache directory")?;
+    Ok(dir.join("gistui").join("update_check.json"))
+}
+
+pub fn load_state(path: &Path) -> UpdateCheckState {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+        .unwrap_or_default()
+}
+
+pub fn save_state(path: &Path, state: &UpdateCheckState) {
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(json) = serde_json::to_string_pretty(state) {
+        let _ = std::fs::write(path, json);
+    }
+}
+
+pub fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Whether enough time has passed since `last_check` to run another network check.
+pub fn should_check(last_check: u64, now: u64) -> bool {
+    now.saturating_sub(last_check) >= CHECK_INTERVAL_SECS
+}
+
+/// `Some(normalized)` when `latest` is a strictly newer version than `current`, else `None`.
+pub fn is_newer(latest: &str, current: &str) -> Option<String> {
+    let latest = normalize_tag(latest);
+    if latest.is_empty() {
+        return None;
+    }
+    (version_cmp(&latest, current) == Ordering::Greater).then_some(latest)
+}
+
+/// Footer hint for an available update, tailored to how the binary was installed.
+pub fn update_hint(latest: &str, method: &InstallMethod) -> String {
+    let cmd = upgrade_hint(method)
+        .map(str::to_string)
+        .or_else(|| match method {
+            InstallMethod::Standalone => Some("gistui --upgrade".to_string()),
+            _ => None,
+        });
+    match cmd {
+        Some(cmd) => format!("⬆ v{latest} available — run {cmd}"),
+        None => format!("⬆ v{latest} available"),
+    }
+}
+
+/// Run the network check against `client`, comparing the latest tag with `current`.
+/// Thin IO boundary; pure classification lives in [`is_newer`].
+pub fn check(client: &impl ReleaseClient, current: &str) -> UpdateCheckOutcome {
+    match client.fetch_latest_tag() {
+        Ok(tag) => match is_newer(&tag, current) {
+            Some(v) => UpdateCheckOutcome::Newer(v),
+            None => UpdateCheckOutcome::UpToDate,
+        },
+        Err(_) => UpdateCheckOutcome::Failed,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_check_respects_the_daily_interval() {
+        assert!(should_check(0, CHECK_INTERVAL_SECS));
+        assert!(should_check(0, CHECK_INTERVAL_SECS + 10));
+        assert!(!should_check(100, 100));
+        assert!(!should_check(100, 100 + CHECK_INTERVAL_SECS - 1));
+    }
+
+    #[test]
+    fn is_newer_only_for_strictly_greater() {
+        assert_eq!(is_newer("v0.14.0", "0.13.0"), Some("0.14.0".to_string()));
+        assert_eq!(is_newer("0.13.0", "0.13.0"), None);
+        assert_eq!(is_newer("v0.12.0", "0.13.0"), None);
+        assert_eq!(is_newer("", "0.13.0"), None);
+    }
+
+    #[test]
+    fn update_hint_is_install_method_aware() {
+        assert_eq!(
+            update_hint("0.14.0", &InstallMethod::Homebrew),
+            "⬆ v0.14.0 available — run brew upgrade gistui"
+        );
+        assert_eq!(
+            update_hint("0.14.0", &InstallMethod::Standalone),
+            "⬆ v0.14.0 available — run gistui --upgrade"
+        );
+        assert_eq!(
+            update_hint("0.14.0", &InstallMethod::Refuse { hint: "x".into() }),
+            "⬆ v0.14.0 available"
+        );
+    }
+
+    #[test]
+    fn check_classifies_outcomes_via_a_fake_client() {
+        struct Fake {
+            tag: Option<&'static str>,
+        }
+        impl ReleaseClient for Fake {
+            fn fetch_latest_tag(&self) -> Result<String> {
+                self.tag
+                    .map(str::to_string)
+                    .ok_or_else(|| anyhow::anyhow!("offline"))
+            }
+            fn download(&self, _url: &str) -> Result<Vec<u8>> {
+                unreachable!("update check never downloads")
+            }
+        }
+        assert_eq!(
+            check(
+                &Fake {
+                    tag: Some("v0.14.0")
+                },
+                "0.13.0"
+            ),
+            UpdateCheckOutcome::Newer("0.14.0".to_string())
+        );
+        assert_eq!(
+            check(
+                &Fake {
+                    tag: Some("v0.13.0")
+                },
+                "0.13.0"
+            ),
+            UpdateCheckOutcome::UpToDate
+        );
+        assert_eq!(
+            check(&Fake { tag: None }, "0.13.0"),
+            UpdateCheckOutcome::Failed
+        );
+    }
+
+    #[test]
+    fn state_round_trips_through_disk() {
+        let dir = std::env::temp_dir().join(format!("gistui-uctest-{}", std::process::id()));
+        let path = dir.join("update_check.json");
+        let state = UpdateCheckState {
+            last_check: 12345,
+            latest_seen: "0.14.0".to_string(),
+        };
+        save_state(&path, &state);
+        assert_eq!(load_state(&path), state);
+        // Missing file loads the default.
+        let _ = std::fs::remove_dir_all(&dir);
+        assert_eq!(load_state(&path), UpdateCheckState::default());
+    }
+}


### PR DESCRIPTION
## Summary

On startup, gistui checks GitHub once a day (in the background, silently) for a newer release and shows a footer hint with the right upgrade command if one exists. Closes #143.

## Changes

- Background, non-blocking check (same channel pattern as the gist fetch), **throttled to once per day** via a small cache file (`$XDG_CACHE_HOME/gistui/update_check.json`); **fails silently** when offline / rate-limited (never an error nag).
- When a newer release exists, a hint rides the List footer's top-border title slot: `⬆ vX.Y.Z available — run <cmd>`, with `<cmd>` tailored to the detected install method (Homebrew / Scoop / cargo / standalone). The last-seen newer version persists so the hint survives launches within the throttle window without re-hitting the network.
- **Opt-out**: `check_updates = true` in `config.toml` (default on) + a `--no-update-check` CLI flag.
- New `update_check` module holds the pure comparison / throttle / hint logic (unit-tested); the network fetch reuses the `upgrade` crate's `ReleaseClient` and stays a thin IO boundary (fake client in tests).
- Demo harness passes `--no-update-check` so recordings stay deterministic and offline.
- Drive-by: corrects a stale `[Esc]/[n]` → `[✕]` in the mouse `config.example.toml` comment.

No version bump or CHANGELOG dated section here — version is already `0.13.0` on `main`; the entry stays under `[Unreleased]` until the milestone is released.

## Testing

- [x] `cargo fmt --check`
- [x] `cargo test` (411 unit + 12 integration)
- [x] `cargo check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Manually verified the footer hint (via a seeded `update_check.json`) and that `--no-update-check` is fully inert

## Related Issues

Closes #143. Part of milestone **0.13.0** (with #142 mouse support, #144 diff word-wrap).