### PR TITLE
chore: emoji + clearer release-note categories

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,18 +7,18 @@ changelog:
     labels:
       - skip-changelog
   categories:
-    - title: Features
+    - title: 🚀 Features
       labels:
         - enhancement
-    - title: Bug Fixes
+    - title: 🐛 Bug Fixes
       labels:
         - bug
-    - title: Documentation
+    - title: 📚 Documentation
       labels:
         - documentation
-    - title: Dependencies
+    - title: ⬆️ Dependencies
       labels:
         - dependencies
-    - title: Other Changes
+    - title: 🧰 Maintenance
       labels:
         - "*"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Key points:
 1. Fork and create a branch (`feat/my-feature` or `fix/issue-123`).
 2. Keep commits focused; follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `chore:`).
 3. Open a PR against `main`; the CI gate must be green.
-4. **Label the PR** so it lands in the right release-note section (`.github/release.yml`): `enhancement` (Features), `bug` (Bug Fixes), `documentation` (Documentation), `dependencies`, or `skip-changelog` to omit it. Unlabeled PRs fall under "Other Changes".
+4. **Label the PR** so it lands in the right release-note section (`.github/release.yml`): `enhancement` (🚀 Features), `bug` (🐛 Bug Fixes), `documentation` (📚 Documentation), `dependencies` (⬆️ Dependencies), or `skip-changelog` to omit it. Unlabeled PRs fall under "🧰 Maintenance".
 
 ## Releasing
 


### PR DESCRIPTION
## Summary

Polish the GitHub auto-generated release-note sections (`.github/release.yml`) ahead of the 0.13.0 release: add conventional emoji and rename the catch-all.

## Changes

- Category titles now carry emoji: **🚀 Features**, **🐛 Bug Fixes**, **📚 Documentation**, **⬆️ Dependencies**.
- Rename the unlabeled `*` catch-all from **"Other Changes"** to **"🧰 Maintenance"** (in a well-labeled repo it collects chore/refactor/ci/test work).
- Update the matching label→section reference in `CONTRIBUTING.md` so docs stay in lockstep.

No code changes; structure/labels are unchanged (only titles). `skip-changelog` labeled — this config change shouldn't appear in the notes it generates.

## Testing

- [x] YAML validated (`ruby -ryaml`)
- [x] Labels/structure unchanged — only section titles edited

## Related Issues

Part of milestone **0.13.0** (release-notes polish).