### PR TITLE
feat(tui): newest-first paged gist comments + restyled pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Gist comments now load newest-first in pages of 30 (popular gists no longer dump every comment or silently stop at 100); `m` or clicking the top line loads 30 older comments. The Comments pane is restyled with a per-comment header, relative time, and a loaded-range title.
 - Diff view: a difference that is *only* a file-final newline no longer shows as a phantom change and no longer forces an overwrite confirm (GitHub stores gists with a trailing newline that local files often lack); disable with `ignore_trailing_newline = false` for byte-exact diffs.
 
 ## [0.13.0] — 2026-06-20

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ without resetting order. Pinned pairs show `📌`; same-filename candidates are 
 | `n` | create a new gist from the selected local file |
 | `p` / `P` | pin pair / open Pins view |
 | `g` | gist manager (per-gist view; `Enter` for detail, `v` visibility, `*` star) |
+| `m` | load 30 older comments (Gist detail → Comments tab; also click the top line) |
 | `a` | flip anchor pane · `/` filter focused pane · `?` help |
 
 Press **`?`** anytime for the **full, contextual keymap** — it opens the current screen's
@@ -85,7 +86,7 @@ The footer also shows keys for the focused pane.
 | Wheel up/down | scroll the focused list or content pane |
 | Click a row | select it (List panes also switch focus) |
 | Double-click a row | open it — List diff, gist detail, pin diff, revision diff, or file preview (same as `Enter`) |
-| Click a tab (Gist details) | switch between Files / Comments |
+| Click a tab (Gist details) | switch between Files / Comments (newest 30 comments load first; `m` or clicking the top line loads 30 older comments) |
 | Click `[✕]` button (pop-up screens) | close / go back |
 
 ## Safety

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -213,30 +213,6 @@ pub fn gist_comments_page_plan(gist_id: &str, page: u32, per_page: u32) -> Comma
     }
 }
 
-/// Plan for fetching all gist comments via the REST API (paginated).
-/// Kept for backward compatibility; will be removed when run_loop is rewired in a later task.
-#[allow(dead_code)]
-pub fn gist_comments_plan(gist_id: &str) -> CommandPlan {
-    CommandPlan {
-        program: "gh".into(),
-        args: vec![
-            "api".into(),
-            "--paginate".into(),
-            format!("/gists/{gist_id}/comments?per_page=100"),
-        ],
-    }
-}
-
-#[allow(dead_code)]
-pub fn fetch_gist_comments_json(gist_id: &str) -> Result<String> {
-    fetch_gist_comments_json_with(&SystemRunner, gist_id)
-}
-
-#[allow(dead_code)]
-pub fn fetch_gist_comments_json_with(runner: &dyn CommandRunner, gist_id: &str) -> Result<String> {
-    run_command(runner, &gist_comments_plan(gist_id))
-}
-
 pub fn fetch_gist_comments_probe(gist_id: &str) -> Result<String> {
     fetch_gist_comments_probe_with(&SystemRunner, gist_id)
 }

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -115,7 +115,107 @@ pub fn gist_view_plan(gist_id: &str, filename: &str) -> CommandPlan {
     }
 }
 
-/// Plan for fetching a gist's comments via the REST API.
+/// Comments are fetched a page at a time, newest page first. 30 keeps each page small
+/// for popular gists with hundreds–thousands of comments.
+pub const COMMENTS_PAGE_SIZE: u32 = 30;
+
+/// 1-based index of the last page holding `total` items at `per_page` each. Never 0, so
+/// the caller always has a page to request (it skips the fetch entirely when total == 0).
+pub fn last_page(total: u32, per_page: u32) -> u32 {
+    if total == 0 {
+        return 1;
+    }
+    total.div_ceil(per_page)
+}
+
+/// Everything in `raw` before the first blank line — the HTTP header block from `gh api -i`.
+fn http_headers_section(raw: &str) -> &str {
+    if let Some(i) = raw.find("\r\n\r\n") {
+        &raw[..i]
+    } else if let Some(i) = raw.find("\n\n") {
+        &raw[..i]
+    } else {
+        raw
+    }
+}
+
+/// Everything after the first blank line — the JSON body from `gh api -i`.
+fn http_body_section(raw: &str) -> &str {
+    if let Some(i) = raw.find("\r\n\r\n") {
+        &raw[i + 4..]
+    } else if let Some(i) = raw.find("\n\n") {
+        &raw[i + 2..]
+    } else {
+        ""
+    }
+}
+
+/// Read the `page=` number for a given `rel` ("next" / "last" / …) from an RFC 5988
+/// `Link` header inside `gh api -i` output. Keys off `&page=` / `?page=` so the
+/// `per_page=` parameter in the same URL is never mistaken for `page=`.
+pub fn parse_link_rel(raw: &str, rel: &str) -> Option<u32> {
+    let headers = http_headers_section(raw);
+    let link = headers
+        .lines()
+        .find(|l| l.to_ascii_lowercase().starts_with("link:"))?;
+    let needle = format!("rel=\"{rel}\"");
+    for part in link.split(',') {
+        if !part.contains(&needle) {
+            continue;
+        }
+        for marker in ["&page=", "?page="] {
+            if let Some(idx) = part.find(marker) {
+                let digits: String = part[idx + marker.len()..]
+                    .chars()
+                    .take_while(|c| c.is_ascii_digit())
+                    .collect();
+                if let Ok(n) = digits.parse::<u32>() {
+                    return Some(n);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Exact comment count from the `per_page=1` probe: the `Link` `rel="last"` page number
+/// equals the total. With 0 or 1 comments there is no `Link` header, so fall back to the
+/// item count in the probe body.
+pub fn comments_total_from_probe(raw_i: &str) -> u32 {
+    if let Some(last) = parse_link_rel(raw_i, "last") {
+        return last;
+    }
+    parse_gist_comments_json(http_body_section(raw_i))
+        .map(|v| v.len() as u32)
+        .unwrap_or(0)
+}
+
+/// `gh api -i …per_page=1` — a tiny request whose `Link: rel="last"` reveals the total.
+pub fn gist_comments_probe_plan(gist_id: &str) -> CommandPlan {
+    CommandPlan {
+        program: "gh".into(),
+        args: vec![
+            "api".into(),
+            "-i".into(),
+            format!("/gists/{gist_id}/comments?per_page=1"),
+        ],
+    }
+}
+
+/// Fetch exactly one page of comments (no `--paginate`, no headers — JSON body only).
+pub fn gist_comments_page_plan(gist_id: &str, page: u32, per_page: u32) -> CommandPlan {
+    CommandPlan {
+        program: "gh".into(),
+        args: vec![
+            "api".into(),
+            format!("/gists/{gist_id}/comments?per_page={per_page}&page={page}"),
+        ],
+    }
+}
+
+/// Plan for fetching all gist comments via the REST API (paginated).
+/// Kept for backward compatibility; will be removed when run_loop is rewired in a later task.
+#[allow(dead_code)]
 pub fn gist_comments_plan(gist_id: &str) -> CommandPlan {
     CommandPlan {
         program: "gh".into(),
@@ -127,12 +227,35 @@ pub fn gist_comments_plan(gist_id: &str) -> CommandPlan {
     }
 }
 
+#[allow(dead_code)]
 pub fn fetch_gist_comments_json(gist_id: &str) -> Result<String> {
     fetch_gist_comments_json_with(&SystemRunner, gist_id)
 }
 
+#[allow(dead_code)]
 pub fn fetch_gist_comments_json_with(runner: &dyn CommandRunner, gist_id: &str) -> Result<String> {
     run_command(runner, &gist_comments_plan(gist_id))
+}
+
+pub fn fetch_gist_comments_probe(gist_id: &str) -> Result<String> {
+    fetch_gist_comments_probe_with(&SystemRunner, gist_id)
+}
+
+pub fn fetch_gist_comments_probe_with(runner: &dyn CommandRunner, gist_id: &str) -> Result<String> {
+    run_command(runner, &gist_comments_probe_plan(gist_id))
+}
+
+pub fn fetch_gist_comments_page(gist_id: &str, page: u32, per_page: u32) -> Result<String> {
+    fetch_gist_comments_page_with(&SystemRunner, gist_id, page, per_page)
+}
+
+pub fn fetch_gist_comments_page_with(
+    runner: &dyn CommandRunner,
+    gist_id: &str,
+    page: u32,
+    per_page: u32,
+) -> Result<String> {
+    run_command(runner, &gist_comments_page_plan(gist_id, page, per_page))
 }
 
 pub fn check_gh_ready() -> Result<()> {
@@ -1090,5 +1213,76 @@ mod tests {
         assert_eq!(counts.get("abc123").copied(), Some(2));
         // The gist with no `comments` field falls back to 0 via `#[serde(default)]`.
         assert_eq!(counts.get("def456").copied(), Some(0));
+    }
+
+    #[test]
+    fn last_page_is_ceiling_division() {
+        assert_eq!(last_page(910, 30), 31); // 910/30 = 30.33 → 31
+        assert_eq!(last_page(900, 30), 30); // exact
+        assert_eq!(last_page(1, 30), 1);
+        assert_eq!(last_page(0, 30), 1); // never zero — caller skips fetch when total==0
+    }
+
+    #[test]
+    fn parse_link_rel_extracts_page_not_per_page() {
+        // The trap: the URL has BOTH per_page=1 and page=910. Must return 910, not 1.
+        let raw = "HTTP/2.0 200 OK\r\n\
+Link: <https://api.github.com/gists/x/comments?per_page=1&page=2>; rel=\"next\", \
+<https://api.github.com/gists/x/comments?per_page=1&page=910>; rel=\"last\"\r\n\
+Content-Type: application/json\r\n\r\n[]";
+        assert_eq!(parse_link_rel(raw, "last"), Some(910));
+        assert_eq!(parse_link_rel(raw, "next"), Some(2));
+        assert_eq!(parse_link_rel(raw, "prev"), None);
+    }
+
+    #[test]
+    fn parse_link_rel_none_when_no_link_header() {
+        let raw = "HTTP/2.0 200 OK\r\nContent-Type: application/json\r\n\r\n[]";
+        assert_eq!(parse_link_rel(raw, "last"), None);
+    }
+
+    #[test]
+    fn comments_total_from_probe_uses_rel_last() {
+        let raw = "HTTP/2.0 200 OK\r\n\
+Link: <https://api.github.com/gists/x/comments?per_page=1&page=910>; rel=\"last\"\r\n\r\n\
+[{\"user\":{\"login\":\"a\"},\"created_at\":\"2026-01-01T00:00:00Z\",\"body\":\"hi\"}]";
+        assert_eq!(comments_total_from_probe(raw), 910);
+    }
+
+    #[test]
+    fn comments_total_from_probe_counts_body_when_single_page() {
+        // 0 comments → empty body, no Link header → total 0.
+        let zero = "HTTP/2.0 200 OK\r\nContent-Type: application/json\r\n\r\n[]";
+        assert_eq!(comments_total_from_probe(zero), 0);
+        // 1 comment → one item, no Link header → total 1.
+        let one = "HTTP/2.0 200 OK\r\n\r\n\
+[{\"user\":{\"login\":\"a\"},\"created_at\":\"2026-01-01T00:00:00Z\",\"body\":\"hi\"}]";
+        assert_eq!(comments_total_from_probe(one), 1);
+    }
+
+    #[test]
+    fn comments_page_plan_builds_single_page_request() {
+        let plan = gist_comments_page_plan("abc", 31, 30);
+        assert_eq!(plan.program, "gh");
+        assert_eq!(
+            plan.args,
+            vec![
+                "api".to_string(),
+                "/gists/abc/comments?per_page=30&page=31".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn comments_probe_plan_uses_include_and_per_page_1() {
+        let plan = gist_comments_probe_plan("abc");
+        assert_eq!(
+            plan.args,
+            vec![
+                "api".to_string(),
+                "-i".to_string(),
+                "/gists/abc/comments?per_page=1".to_string(),
+            ]
+        );
     }
 }

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -697,30 +697,6 @@ impl AppState {
         }
     }
 
-    /// Apply a finished comment fetch, ignoring it if the user has since navigated to a
-    /// different gist (stale response). On error, comments become an empty list and the
-    /// error message is retained so the detail view can surface it.
-    pub fn apply_fetched_comments(
-        &mut self,
-        gist_id: &str,
-        result: Result<Vec<GistComment>, String>,
-    ) {
-        if self.detail_gist_id.as_deref() != Some(gist_id) {
-            return;
-        }
-        self.detail_comments_loading = false;
-        match result {
-            Ok(comments) => {
-                self.detail_comments = Some(comments);
-                self.detail_comments_error = None;
-            }
-            Err(error) => {
-                self.detail_comments = Some(Vec::new());
-                self.detail_comments_error = Some(error);
-            }
-        }
-    }
-
     /// Number of navigation steps per mouse wheel tick. List/index screens move one row;
     /// content panes (Diff, Preview, Confirm, GistDetail) scroll three lines for faster
     /// panning. Help body also scrolls three; the Help topic index is a list (one row).

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -604,6 +604,11 @@ impl AppState {
                     }
                 }
             }
+            KeyCode::Char('m') if self.detail_focus == DetailFocus::Comments => {
+                if self.can_load_older_comments() {
+                    return KeyOutcome::LoadOlderComments;
+                }
+            }
             KeyCode::Char('?') => self.open_help(),
             _ => {}
         }
@@ -878,6 +883,23 @@ impl AppState {
         None
     }
 
+    /// A click on the GistDetail "load older comments" affordance line.
+    fn click_comments_load_older(
+        &mut self,
+        col: u16,
+        row: u16,
+        layout: &MouseLayout,
+    ) -> Option<KeyOutcome> {
+        if self.screen != Screen::GistDetail || self.detail_focus != DetailFocus::Comments {
+            return None;
+        }
+        let rect = layout.comments_load_older?;
+        if point_in(rect, col, row) && self.can_load_older_comments() {
+            return Some(KeyOutcome::LoadOlderComments);
+        }
+        None
+    }
+
     /// Translate a classified mouse intent into a state change, reusing existing keyboard
     /// logic. Pure (no IO, no clock); returns a `KeyOutcome` so `run_loop` can perform any
     /// follow-up IO (e.g. `PreviewDiff` on double-click).
@@ -906,6 +928,9 @@ impl AppState {
                 }
                 // A GistDetail tab header click switches focus (single-click action).
                 if let Some(outcome) = self.click_detail_tab(col, row, layout) {
+                    return outcome;
+                }
+                if let Some(outcome) = self.click_comments_load_older(col, row, layout) {
                     return outcome;
                 }
                 self.click_select(col, row, layout);

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -319,6 +319,7 @@ pub enum KeyOutcome {
     OpenGistDetail,
     /// Fetch comments for the gist shown on `Screen::GistDetail` (lazy, on Comments tab).
     FetchComments,
+    LoadOlderComments,
     /// Analyse the selected Gist-manager gist's revision count, then ask to confirm a compaction.
     CompactGist,
     /// Run the confirmed compaction (clone → squash → force-push) on the pending gist.
@@ -397,6 +398,11 @@ pub struct MouseLayout {
     pub detail_tab_files: Option<Rect>,
     pub detail_tab_comments: Option<Rect>,
     pub close_button: Option<Rect>,
+    /// GistDetail Comments: the clickable "load older" affordance line.
+    pub comments_load_older: Option<Rect>,
+    /// GistDetail Comments: max useful vertical scroll (set by render; used by run_loop
+    /// to honour a one-shot scroll-to-bottom after the newest page loads).
+    pub comments_max_scroll: Option<u16>,
 }
 
 /// A classified mouse intent handed to the pure `handle_mouse`.
@@ -557,6 +563,14 @@ pub struct AppState {
     pub detail_comments_loading: bool,
     /// Comment-fetch error message, if any.
     pub detail_comments_error: Option<String>,
+    /// Exact total comment count (from the per_page=1 probe); for the title only.
+    pub comments_total: Option<u32>,
+    /// Smallest 1-based page index currently loaded. 0 = none loaded yet.
+    pub comments_loaded_oldest_page: u32,
+    /// A "load older" request is in flight (distinct from the initial load).
+    pub comments_loading_more: bool,
+    /// One-shot: run_loop scrolls the comments pane to the bottom on the next draw.
+    pub comments_scroll_to_bottom: bool,
     /// Comment-pane scroll offset.
     pub detail_scroll: u16,
     /// Which detail-view pane Tab/arrows currently drive (Comments vs Files).
@@ -1457,6 +1471,10 @@ pub fn initial_state() -> AppState {
         detail_comments: None,
         detail_comments_loading: false,
         detail_comments_error: None,
+        comments_total: None,
+        comments_loaded_oldest_page: 0,
+        comments_loading_more: false,
+        comments_scroll_to_bottom: false,
         detail_scroll: 0,
         detail_focus: DetailFocus::Files,
         detail_file_cursor: 0,
@@ -1599,6 +1617,94 @@ impl AppState {
     pub fn pin_sync_status(&self, index: usize) -> crate::domain::SyncStatus {
         let (local_ts, remote_ts) = self.pin_mtimes(index);
         crate::domain::sync_status(local_ts, remote_ts)
+    }
+}
+
+/// The result of the initial newest-first comment load: the newest page plus the metadata
+/// needed to page backwards.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InitialComments {
+    pub comments: Vec<GistComment>,
+    pub total: u32,
+    pub oldest_page: u32,
+}
+
+impl AppState {
+    /// Reset comment-pagination state (called when (re)opening a gist detail or switching
+    /// the loaded gist), so a fresh Tab re-fetches from the newest page.
+    pub fn reset_comment_pagination(&mut self) {
+        self.detail_comments = None;
+        self.detail_comments_loading = false;
+        self.detail_comments_error = None;
+        self.comments_total = None;
+        self.comments_loaded_oldest_page = 0;
+        self.comments_loading_more = false;
+        self.comments_scroll_to_bottom = false;
+    }
+
+    /// Apply the initial newest-page load. Ignored if the user navigated to another gist
+    /// (stale response). On success, requests a one-shot scroll-to-bottom so the newest
+    /// comment is visible.
+    pub fn apply_initial_comments(
+        &mut self,
+        gist_id: &str,
+        result: Result<InitialComments, String>,
+    ) {
+        if self.detail_gist_id.as_deref() != Some(gist_id) {
+            return;
+        }
+        self.detail_comments_loading = false;
+        match result {
+            Ok(init) => {
+                self.comments_total = Some(init.total);
+                self.comments_loaded_oldest_page = init.oldest_page;
+                self.detail_comments = Some(init.comments);
+                self.comments_scroll_to_bottom = true;
+            }
+            Err(error) => {
+                self.detail_comments_error = Some(error);
+            }
+        }
+    }
+
+    /// Apply a "load older" page: prepend it (older comments sort first) and bump
+    /// `detail_scroll` by the prepended line count so the viewport stays put. Ignored on
+    /// stale gist.
+    pub fn apply_older_comments(
+        &mut self,
+        gist_id: &str,
+        result: Result<Vec<GistComment>, String>,
+    ) {
+        if self.detail_gist_id.as_deref() != Some(gist_id) {
+            return;
+        }
+        self.comments_loading_more = false;
+        match result {
+            Ok(mut older) => {
+                let added = crate::tui::render::comment_lines_count(&older);
+                if let Some(existing) = self.detail_comments.as_mut() {
+                    older.append(existing);
+                    *existing = older;
+                } else {
+                    self.detail_comments = Some(older);
+                }
+                self.comments_loaded_oldest_page =
+                    self.comments_loaded_oldest_page.saturating_sub(1).max(1);
+                self.detail_scroll = self.detail_scroll.saturating_add(added);
+            }
+            Err(error) => {
+                self.detail_comments_error = Some(error);
+            }
+        }
+    }
+
+    /// Whether a "load older" action should be offered: comments are loaded, an older page
+    /// exists, and no load is already in flight.
+    pub fn can_load_older_comments(&self) -> bool {
+        self.detail_comments.is_some()
+            && self.comments_loaded_oldest_page > 1
+            && !self.comments_loading_more
+            && !self.detail_comments_loading
     }
 }
 

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1092,39 +1092,87 @@ pub(super) fn comment_lines_count(comments: &[GistComment]) -> u16 {
         .min(u16::MAX as usize) as u16
 }
 
-/// Comments pane: loading / error / empty / list (plain text wrapped to width, scrollable).
-pub(super) fn render_gist_comments(frame: &mut Frame, area: Rect, state: &AppState) {
+/// Dim helper line (matches the existing dim placeholder styling).
+fn dim_line<'a>(text: &'a str, state: &AppState) -> Line<'a> {
+    Line::from(Span::styled(text, Style::default().fg(state.theme.dim)))
+}
+
+/// Title for the comments block: shows the loaded range out of the total when known.
+fn comments_title(state: &AppState) -> String {
+    match (&state.detail_comments, state.comments_total) {
+        (Some(c), _) if state.detail_comments_error.is_some() => format!("Comments ({})", c.len()),
+        (Some(c), Some(total)) if !c.is_empty() => {
+            let loaded = c.len() as u32;
+            let first = total.saturating_sub(loaded) + 1;
+            format!("Comments ({first}–{total} / {total})")
+        }
+        (Some(c), None) if !c.is_empty() => format!("Comments (newest {})", c.len()),
+        _ => "Comments".to_string(),
+    }
+}
+
+/// Comments pane: loading / error / empty / a paged window (newest page first; older pages
+/// prepended). Renders a clickable "load older" affordance at the top, styles each comment,
+/// and publishes the affordance rect + max scroll into `layout`.
+pub(super) fn render_gist_comments(
+    frame: &mut Frame,
+    area: Rect,
+    state: &AppState,
+    layout: &mut MouseLayout,
+) {
     let now = unix_now();
-    let body: Vec<Line> = match (
+    let mut body: Vec<Line> = Vec::new();
+    let mut affordance_present = false;
+
+    match (
         &state.detail_comments,
         state.detail_comments_loading,
         &state.detail_comments_error,
     ) {
-        (None, true, _) => vec![Line::from(Span::styled(
-            "Loading comments…",
-            Style::default().fg(state.theme.dim),
-        ))],
-        (None, false, _) => vec![Line::from(Span::styled(
-            "Tab here to load comments",
-            Style::default().fg(state.theme.dim),
-        ))],
-        (Some(_), _, Some(err)) => vec![Line::from(Span::styled(
+        (None, true, _) => body.push(dim_line("Loading comments…", state)),
+        (None, false, _) => body.push(dim_line("Tab here to load comments", state)),
+        (Some(_), _, Some(err)) => body.push(Line::from(Span::styled(
             format!("comments error: {err}"),
             Style::default().fg(Color::Red),
-        ))],
-        (Some(comments), _, None) if comments.is_empty() => vec![Line::from(Span::styled(
-            "No comments",
-            Style::default().fg(state.theme.dim),
-        ))],
-        (Some(comments), _, None) => comment_lines(comments, &state.theme, now as i64),
+        ))),
+        (Some(comments), _, None) if comments.is_empty() => {
+            body.push(dim_line("No comments", state))
+        }
+        (Some(comments), _, None) => {
+            // Top affordance line: load-older / loading / start-of-thread.
+            let label = if state.comments_loading_more {
+                "Loading…"
+            } else if state.comments_loaded_oldest_page > 1 {
+                affordance_present = true;
+                "↑ Load 30 older comments"
+            } else {
+                "— Start of thread —"
+            };
+            body.push(dim_line(label, state));
+            body.push(Line::from(""));
+            body.extend(comment_lines(comments, &state.theme, now as i64));
+        }
+    }
+
+    // Record the affordance hit region (line 0 inside the bordered area) for mouse clicks.
+    layout.comments_load_older = if affordance_present {
+        Some(Rect::new(
+            area.x + 1,
+            area.y + 1,
+            area.width.saturating_sub(2),
+            1,
+        ))
+    } else {
+        None
     };
-    let title = match &state.detail_comments {
-        Some(c) if state.detail_comments_error.is_none() => format!("Comments ({})", c.len()),
-        _ => "Comments".to_string(),
-    };
+
     // The scrollbar uses the logical line count, which shares units with `detail_scroll`, so the
     // thumb position is exact (its size is approximate when long comments soft-wrap).
     let total_lines = body.len();
+    let inner_rows = area.height.saturating_sub(2);
+    layout.comments_max_scroll = Some((total_lines as u16).saturating_sub(inner_rows));
+
+    let title = comments_title(state);
     frame.render_widget(
         Paragraph::new(body)
             .style(state.theme.base_style())
@@ -1135,8 +1183,7 @@ pub(super) fn render_gist_comments(frame: &mut Frame, area: Rect, state: &AppSta
                     .title(title)
                     .borders(Borders::ALL)
                     .border_type(BorderType::Rounded)
-                    .style(state.theme.base_style())
-                    .padding(Padding::horizontal(1)),
+                    .style(state.theme.base_style()),
             ),
         area,
     );
@@ -1233,7 +1280,7 @@ pub(super) fn render_gist_detail(frame: &mut Frame, state: &AppState, layout: &m
         render_detail_header(frame, chunks[0], state, id, layout);
         match state.detail_focus {
             DetailFocus::Files => render_gist_file_list(frame, chunks[1], state, id, layout),
-            DetailFocus::Comments => render_gist_comments(frame, chunks[1], state),
+            DetailFocus::Comments => render_gist_comments(frame, chunks[1], state, layout),
         }
     }
     render_footer(frame, chunks[2], "", &footer, colored, &state.theme);
@@ -1244,6 +1291,7 @@ pub(super) fn render_gist_detail(frame: &mut Frame, state: &AppState, layout: &m
         layout.detail_files = None;
         layout.detail_tab_files = None;
         layout.detail_tab_comments = None;
+        layout.comments_load_older = None;
         Some(render_centered_modal_input(
             frame,
             "Edit description (Enter apply · Esc cancel)",

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1084,7 +1084,6 @@ pub(super) fn comment_lines<'a>(
 
 /// Logical line count of `comment_lines(comments, …)` — the amount to add to
 /// `detail_scroll` when older comments are prepended, so the viewport does not jump.
-#[allow(dead_code)] // consumed by a later task; test coverage in tui::tests
 pub(super) fn comment_lines_count(comments: &[GistComment]) -> u16 {
     comments
         .iter()

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -152,6 +152,7 @@ Mouse (on by default; disable with mouse = false in config or --no-mouse)
   Tab        switch tab: Files / Comments (one shows at a time; opens on Files)
   Up/Down    move the file cursor (Files tab) or scroll comments (also j / k)
   PageUp/Dn  page comments / file cursor by 10 (also Ctrl+b / Ctrl+f)
+  m          load 30 older comments (Comments tab; also click the top line)
   Enter      preview the cursor-selected file (file list focused; blocked for binary)
   1-9        preview the content of the Nth file (full-screen; R refresh, q back)
              non-text files are tagged (binary) in the list

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1058,6 +1058,41 @@ fn render_gist_file_list(
     );
 }
 
+/// Build the styled lines for a run of comments (author·age header, 2-space-indented body,
+/// trailing blank). Pure so the count below can mirror it exactly for scroll compensation.
+pub(super) fn comment_lines<'a>(
+    comments: &'a [GistComment],
+    theme: &Theme,
+    now: i64,
+) -> Vec<Line<'a>> {
+    let mut lines = Vec::new();
+    for c in comments {
+        let age = crate::domain::parse_rfc3339_to_unix(&c.created_at)
+            .map(|t| crate::domain::humanize_age(now - t as i64))
+            .unwrap_or_else(|| "?".into());
+        lines.push(Line::from(Span::styled(
+            format!("{} · {age}", c.author),
+            Style::default().fg(theme.accent),
+        )));
+        for raw in c.body.lines() {
+            lines.push(Line::from(format!("  {raw}")));
+        }
+        lines.push(Line::from(""));
+    }
+    lines
+}
+
+/// Logical line count of `comment_lines(comments, …)` — the amount to add to
+/// `detail_scroll` when older comments are prepended, so the viewport does not jump.
+#[allow(dead_code)] // consumed by a later task; test coverage in tui::tests
+pub(super) fn comment_lines_count(comments: &[GistComment]) -> u16 {
+    comments
+        .iter()
+        .map(|c| 2 + c.body.lines().count())
+        .sum::<usize>()
+        .min(u16::MAX as usize) as u16
+}
+
 /// Comments pane: loading / error / empty / list (plain text wrapped to width, scrollable).
 pub(super) fn render_gist_comments(frame: &mut Frame, area: Rect, state: &AppState) {
     let now = unix_now();
@@ -1082,23 +1117,7 @@ pub(super) fn render_gist_comments(frame: &mut Frame, area: Rect, state: &AppSta
             "No comments",
             Style::default().fg(state.theme.dim),
         ))],
-        (Some(comments), _, None) => {
-            let mut lines = Vec::new();
-            for c in comments {
-                let age = crate::domain::parse_rfc3339_to_unix(&c.created_at)
-                    .map(|t| crate::domain::humanize_age(now as i64 - t as i64))
-                    .unwrap_or_else(|| "?".into());
-                lines.push(Line::from(Span::styled(
-                    format!("{} · {age}", c.author),
-                    Style::default().fg(state.theme.accent),
-                )));
-                for raw in c.body.lines() {
-                    lines.push(Line::from(format!("  {raw}")));
-                }
-                lines.push(Line::from(""));
-            }
-            lines
-        }
+        (Some(comments), _, None) => comment_lines(comments, &state.theme, now as i64),
     };
     let title = match &state.detail_comments {
         Some(c) if state.detail_comments_error.is_none() => format!("Comments ({})", c.len()),

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -1380,6 +1380,7 @@ pub(super) fn run_loop(
                     BgTaskOutcome::ForkGist { result, gist_id }
                 });
             }
+            KeyOutcome::LoadOlderComments => {}
             KeyOutcome::None => {}
         }
     }

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -44,6 +44,12 @@ pub(super) fn run_loop(
 
     loop {
         terminal.draw(|frame| render(frame, &state, &mut mouse_layout))?;
+        if state.comments_scroll_to_bottom {
+            if let Some(max) = mouse_layout.comments_max_scroll {
+                state.detail_scroll = max;
+            }
+            state.comments_scroll_to_bottom = false;
+        }
         // Advance the spinner once per iteration; the poll below caps the loop at ~150ms, so
         // in-progress states (scanning/loading/working) animate even with no input.
         state.spinner_frame = state.spinner_frame.wrapping_add(1);
@@ -459,8 +465,11 @@ pub(super) fn run_loop(
                         }
                         Err(error) => state.set_status(format!("compact failed: {error}")),
                     },
-                    BgTaskOutcome::CommentsFetched { gist_id, result } => {
-                        state.apply_fetched_comments(&gist_id, result);
+                    BgTaskOutcome::CommentsInitialLoaded { gist_id, result } => {
+                        state.apply_initial_comments(&gist_id, result);
+                    }
+                    BgTaskOutcome::CommentsOlderLoaded { gist_id, result } => {
+                        state.apply_older_comments(&gist_id, result);
                     }
                     BgTaskOutcome::RevisionsFetched { gist_id, result } => {
                         if state.revision_gist_id.as_deref() != Some(gist_id.as_str()) {
@@ -722,9 +731,7 @@ pub(super) fn run_loop(
                 let gist_id = group.id.clone();
                 state.screen = Screen::GistDetail;
                 state.detail_gist_id = Some(gist_id);
-                state.detail_comments = None;
-                state.detail_comments_loading = false;
-                state.detail_comments_error = None;
+                state.reset_comment_pagination();
                 state.detail_scroll = 0;
                 state.detail_focus = DetailFocus::Files;
                 state.detail_file_cursor = 0;
@@ -739,16 +746,46 @@ pub(super) fn run_loop(
                 state.detail_comments_loading = true;
                 let fetch_id = gist_id.clone();
                 spawn_bg(&mut state, &mut bg_rx, "Loading comments…", move || {
-                    let result = crate::gh::fetch_gist_comments_json(&fetch_id)
-                        .map_err(|e| e.to_string())
-                        .and_then(|raw| {
-                            crate::gh::parse_gist_comments_json(&raw).map_err(|e| e.to_string())
-                        });
-                    BgTaskOutcome::CommentsFetched {
+                    let result = load_initial_comments(&fetch_id);
+                    BgTaskOutcome::CommentsInitialLoaded {
                         gist_id: fetch_id,
                         result,
                     }
                 });
+            }
+            KeyOutcome::LoadOlderComments => {
+                let Some(gist_id) = state.detail_gist_id.clone() else {
+                    continue;
+                };
+                if !state.can_load_older_comments() {
+                    continue;
+                }
+                let page = state.comments_loaded_oldest_page.saturating_sub(1);
+                if page == 0 {
+                    continue;
+                }
+                state.comments_loading_more = true;
+                let fetch_id = gist_id.clone();
+                spawn_bg(
+                    &mut state,
+                    &mut bg_rx,
+                    "Loading older comments…",
+                    move || {
+                        let result = crate::gh::fetch_gist_comments_page(
+                            &fetch_id,
+                            page,
+                            crate::gh::COMMENTS_PAGE_SIZE,
+                        )
+                        .map_err(|e| e.to_string())
+                        .and_then(|raw| {
+                            crate::gh::parse_gist_comments_json(&raw).map_err(|e| e.to_string())
+                        });
+                        BgTaskOutcome::CommentsOlderLoaded {
+                            gist_id: fetch_id,
+                            result,
+                        }
+                    },
+                );
             }
             KeyOutcome::CompactGist => {
                 let Some(gist_id) = state.context_gist_id() else {
@@ -1380,7 +1417,6 @@ pub(super) fn run_loop(
                     BgTaskOutcome::ForkGist { result, gist_id }
                 });
             }
-            KeyOutcome::LoadOlderComments => {}
             KeyOutcome::None => {}
         }
     }
@@ -1453,7 +1489,11 @@ enum BgTaskOutcome {
         label: String,
         count: usize,
     },
-    CommentsFetched {
+    CommentsInitialLoaded {
+        gist_id: String,
+        result: Result<crate::tui::InitialComments, String>,
+    },
+    CommentsOlderLoaded {
         gist_id: String,
         result: Result<Vec<GistComment>, String>,
     },
@@ -1734,6 +1774,30 @@ where
     std::thread::spawn(move || {
         let _ = tx.send(work());
     });
+}
+
+/// Initial newest-first comment load: probe the total, then fetch the newest page.
+/// Thin IO boundary (network) — not unit-tested.
+fn load_initial_comments(gist_id: &str) -> Result<crate::tui::InitialComments, String> {
+    let probe = crate::gh::fetch_gist_comments_probe(gist_id).map_err(|e| e.to_string())?;
+    let total = crate::gh::comments_total_from_probe(&probe);
+    if total == 0 {
+        return Ok(crate::tui::InitialComments {
+            comments: Vec::new(),
+            total: 0,
+            oldest_page: 1,
+        });
+    }
+    let oldest_page = crate::gh::last_page(total, crate::gh::COMMENTS_PAGE_SIZE);
+    let raw =
+        crate::gh::fetch_gist_comments_page(gist_id, oldest_page, crate::gh::COMMENTS_PAGE_SIZE)
+            .map_err(|e| e.to_string())?;
+    let comments = crate::gh::parse_gist_comments_json(&raw).map_err(|e| e.to_string())?;
+    Ok(crate::tui::InitialComments {
+        comments,
+        total,
+        oldest_page,
+    })
 }
 
 /// The pin currently selected in the Pins screen, if any.

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -4756,3 +4756,41 @@ fn can_load_older_false_while_loading_more() {
     s.comments_loading_more = true;
     assert!(!s.can_load_older_comments());
 }
+
+#[test]
+fn m_key_loads_older_when_available() {
+    use crate::tui::InitialComments;
+    let mut s = crate::tui::initial_state();
+    s.screen = Screen::GistDetail;
+    s.detail_focus = DetailFocus::Comments;
+    s.detail_gist_id = Some("g1".into());
+    s.apply_initial_comments(
+        "g1",
+        Ok(InitialComments {
+            comments: vec![sample_comment("a", "x")],
+            total: 90,
+            oldest_page: 3,
+        }),
+    );
+    let out = s.handle_key(KeyCode::Char('m'));
+    assert!(matches!(out, KeyOutcome::LoadOlderComments));
+}
+
+#[test]
+fn m_key_noop_when_at_oldest_page() {
+    use crate::tui::InitialComments;
+    let mut s = crate::tui::initial_state();
+    s.screen = Screen::GistDetail;
+    s.detail_focus = DetailFocus::Comments;
+    s.detail_gist_id = Some("g1".into());
+    s.apply_initial_comments(
+        "g1",
+        Ok(InitialComments {
+            comments: vec![sample_comment("a", "x")],
+            total: 10,
+            oldest_page: 1,
+        }),
+    );
+    let out = s.handle_key(KeyCode::Char('m'));
+    assert!(matches!(out, KeyOutcome::None));
+}

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -4672,3 +4672,87 @@ fn comment_lines_count_matches_built_lines() {
     assert_eq!(comment_lines_count(&comments), 7);
     assert_eq!(comment_lines(&comments, &theme, 0).len(), 7);
 }
+
+fn sample_comment(author: &str, body: &str) -> crate::domain::GistComment {
+    crate::domain::GistComment {
+        author: author.into(),
+        created_at: "2026-01-01T00:00:00Z".into(),
+        body: body.into(),
+    }
+}
+
+#[test]
+fn apply_initial_comments_sets_window_and_requests_bottom_scroll() {
+    use crate::tui::InitialComments;
+    let mut s = crate::tui::initial_state();
+    s.detail_gist_id = Some("g1".into());
+    s.apply_initial_comments(
+        "g1",
+        Ok(InitialComments {
+            comments: vec![sample_comment("a", "x")],
+            total: 910,
+            oldest_page: 31,
+        }),
+    );
+    assert_eq!(s.comments_total, Some(910));
+    assert_eq!(s.comments_loaded_oldest_page, 31);
+    assert!(s.comments_scroll_to_bottom);
+    assert!(s.can_load_older_comments()); // page 31 > 1
+    assert_eq!(s.detail_comments.as_ref().unwrap().len(), 1);
+}
+
+#[test]
+fn apply_initial_comments_ignored_when_gist_changed() {
+    use crate::tui::InitialComments;
+    let mut s = crate::tui::initial_state();
+    s.detail_gist_id = Some("g2".into());
+    s.apply_initial_comments(
+        "g1",
+        Ok(InitialComments {
+            comments: vec![],
+            total: 0,
+            oldest_page: 1,
+        }),
+    );
+    assert!(s.detail_comments.is_none()); // stale response dropped
+}
+
+#[test]
+fn apply_older_comments_prepends_and_compensates_scroll() {
+    use crate::tui::InitialComments;
+    let mut s = crate::tui::initial_state();
+    s.detail_gist_id = Some("g1".into());
+    s.apply_initial_comments(
+        "g1",
+        Ok(InitialComments {
+            comments: vec![sample_comment("newer", "n")],
+            total: 60,
+            oldest_page: 2,
+        }),
+    );
+    s.detail_scroll = 5;
+    // One older comment = 1 header + 1 body + 1 blank = 3 lines prepended.
+    s.apply_older_comments("g1", Ok(vec![sample_comment("older", "o")]));
+    assert_eq!(s.comments_loaded_oldest_page, 1);
+    assert!(!s.can_load_older_comments()); // reached page 1
+    assert_eq!(s.detail_comments.as_ref().unwrap()[0].author, "older"); // prepended
+    assert_eq!(s.detail_scroll, 5 + 3); // viewport held in place
+    assert!(!s.comments_loading_more);
+}
+
+#[test]
+fn can_load_older_false_while_loading_more() {
+    use crate::tui::InitialComments;
+    let mut s = crate::tui::initial_state();
+    s.detail_gist_id = Some("g1".into());
+    s.apply_initial_comments(
+        "g1",
+        Ok(InitialComments {
+            comments: vec![sample_comment("a", "x")],
+            total: 90,
+            oldest_page: 3,
+        }),
+    );
+    s.comments_loading_more = true;
+    assert!(!s.can_load_older_comments());
+}

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -4649,3 +4649,26 @@ fn wheel_step_gist_detail_files_moves_one() {
     state.handle_mouse(MouseInput::ScrollDown, &MouseLayout::default());
     assert_eq!(state.detail_file_cursor, 1);
 }
+
+#[test]
+fn comment_lines_count_matches_built_lines() {
+    use crate::domain::GistComment;
+    use crate::tui::render::{comment_lines, comment_lines_count};
+    let theme = crate::tui::theme::Theme::for_choice(crate::config::ThemeChoice::Dark);
+    let comments = vec![
+        GistComment {
+            author: "alice".into(),
+            created_at: "2026-01-01T00:00:00Z".into(),
+            body: "one line".into(),
+        },
+        GistComment {
+            author: "bob".into(),
+            created_at: "2026-01-02T00:00:00Z".into(),
+            body: "two\nlines".into(),
+        },
+    ];
+    // Each comment: 1 header + body.lines() + 1 blank.
+    // alice: 1 + 1 + 1 = 3 ; bob: 1 + 2 + 1 = 4 ; total 7.
+    assert_eq!(comment_lines_count(&comments), 7);
+    assert_eq!(comment_lines(&comments, &theme, 0).len(), 7);
+}

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -3031,48 +3031,6 @@ fn list_screen_capital_s_syncs_selected_pair() {
 }
 
 #[test]
-fn fetched_comments_apply_when_viewing_same_gist() {
-    let mut state = initial_state();
-    state.detail_gist_id = Some("g1".into());
-    state.apply_fetched_comments(
-        "g1",
-        Ok(vec![GistComment {
-            author: "alice".into(),
-            created_at: "2026-06-10T00:00:00Z".into(),
-            body: "hi".into(),
-        }]),
-    );
-    assert_eq!(state.detail_comments.as_ref().unwrap().len(), 1);
-    assert!(state.detail_comments_error.is_none());
-}
-
-#[test]
-fn fetched_comments_ignored_when_gist_changed() {
-    let mut state = initial_state();
-    state.detail_gist_id = Some("g2".into());
-    state.detail_comments = None;
-    state.apply_fetched_comments(
-        "g1",
-        Ok(vec![GistComment {
-            author: "alice".into(),
-            created_at: "2026-06-10T00:00:00Z".into(),
-            body: "stale".into(),
-        }]),
-    );
-    // Result was for g1 but user is on g2 → ignored.
-    assert!(state.detail_comments.is_none());
-}
-
-#[test]
-fn fetched_comments_error_sets_empty_list_and_message() {
-    let mut state = initial_state();
-    state.detail_gist_id = Some("g1".into());
-    state.apply_fetched_comments("g1", Err("boom".into()));
-    assert_eq!(state.detail_comments.as_ref().unwrap().len(), 0);
-    assert_eq!(state.detail_comments_error.as_deref(), Some("boom"));
-}
-
-#[test]
 fn gist_group_row_age_tracks_active_sort() {
     let group = GistGroup {
         id: "g1".into(),

--- a/tests/gh_integration.rs
+++ b/tests/gh_integration.rs
@@ -12,9 +12,10 @@ use std::path::PathBuf;
 use gistui::actions::{run_command, upload_command, CommandOutput, CommandPlan, CommandRunner};
 use gistui::domain::GistFile;
 use gistui::gh::{
-    auth_status_plan, check_gh_ready_with, fetch_gist_comments_json_with,
-    fetch_gist_file_content_with, fetch_gist_list_json_with, gh_version_plan, gist_comments_plan,
-    gist_list_plan, gist_view_plan, parse_gist_comments_json, parse_gist_list_json,
+    auth_status_plan, check_gh_ready_with, fetch_gist_comments_page_with,
+    fetch_gist_file_content_with, fetch_gist_list_json_with, gh_version_plan,
+    gist_comments_page_plan, gist_list_plan, gist_view_plan, parse_gist_comments_json,
+    parse_gist_list_json,
 };
 
 /// A scripted runner: returns queued outputs in order and records every plan it
@@ -177,7 +178,7 @@ fn run_command_surfaces_stderr_on_failure() {
 fn fetch_and_parse_gist_comments_via_fake_runner() {
     let runner = FakeRunner::new(vec![FakeRunner::ok(GIST_COMMENTS_JSON)]);
 
-    let raw = fetch_gist_comments_json_with(&runner, "abc123").unwrap();
+    let raw = fetch_gist_comments_page_with(&runner, "abc123", 1, 30).unwrap();
     let comments = parse_gist_comments_json(&raw).unwrap();
 
     assert_eq!(comments.len(), 3);
@@ -187,14 +188,17 @@ fn fetch_and_parse_gist_comments_via_fake_runner() {
     assert_eq!(comments[2].author, "(unknown)");
     assert_eq!(comments[2].body, "ghost comment");
     assert_eq!(comments[2].created_at, "2026-06-11T01:00:00Z");
-    assert_eq!(runner.calls.borrow()[0], gist_comments_plan("abc123"));
+    assert_eq!(
+        runner.calls.borrow()[0],
+        gist_comments_page_plan("abc123", 1, 30)
+    );
 }
 
 #[test]
 fn fetch_gist_comments_surfaces_stderr_on_failure() {
     let runner = FakeRunner::new(vec![FakeRunner::fail("HTTP 404: Not Found")]);
 
-    let err = fetch_gist_comments_json_with(&runner, "missing").unwrap_err();
+    let err = fetch_gist_comments_page_with(&runner, "missing", 1, 30).unwrap_err();
     assert!(err.to_string().contains("Not Found"));
 }
 


### PR DESCRIPTION
## Summary

Gist comments now load **newest-first in pages of 30** instead of dumping every comment at once (and silently dropping anything past 100). Popular/starred gists with hundreds–thousands of comments stay responsive.

- **Initial load** (Tab into the Comments tab): probe the exact total via `gh api -i …/comments?per_page=1` → `Link: rel="last"`, then fetch the newest page (`ceil(total/30)`). The `Link` header is authoritative for paging — the cached `gist_comment_counts` is used only for the title, never to compute the last page (avoids a stale-count correctness bug).
- **Load older:** `m` or clicking the top `↑ Load 30 older comments` line fetches the previous page and prepends it, with `detail_scroll` compensation so the viewport doesn't jump. Page 1 shows `— Start of thread —`.
- **Restyled pane:** per-comment header, relative time, and a loaded-range title (`Comments (881–910 / 910)`); auto-scroll to the newest on initial load.

Markdown rendering and auto-load-on-scroll are intentionally out of scope.

## Why `Link`-header paging

The GitHub gist-comments endpoint is oldest-first with no sort param (verified against `karpathy/442a6bf5…`, ~910 comments). So "newest first" means deriving the last page; the `Link` header (`rel="last"`/`rel="next"`) gives that authoritatively and also fixes the previous silent 100-comment truncation.

## Architecture

Pure/IO split preserved: page math, `Link` parsing, the comment line builder, and all state-apply transitions are unit-tested; the `gh` fetch helpers and `run_loop` wiring are thin untested IO boundaries (per project convention — tests never touch the network).

## Docs updated (same PR)

`README.md` (keymap + Comments behaviour), `?` help text (Gist detail → `m`), `CHANGELOG.md` (`[Unreleased]`).

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` (0 warnings), `cargo test` (430 lib + 12 integration green), `cargo check`, `cargo build`, `gh --check` — all pass. Interactive TUI e2e against the ~910-comment gist is recommended before merge (the network-driven path the unit suite intentionally doesn't cover).