### PR TITLE
fix: P1 correctness hardening (GraphQL escaping + latent panic)

### DIFF
--- a/src/gh.rs
+++ b/src/gh.rs
@@ -486,10 +486,18 @@ pub fn collect_gist_fork_counts(
 
 const STARGAZER_GRAPHQL_CHUNK: usize = 40;
 
+/// Escape a value for safe interpolation inside a GraphQL double-quoted string literal:
+/// backslash first, then the quote (GraphQL string literals follow JSON escaping). Keeps a
+/// stray `"`/`\` in an API-supplied node id from breaking out of the query.
+fn escape_graphql_string(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
 /// Build a batched GraphQL query (`n0`…`n{k}` aliases) for stargazer counts.
 pub fn build_stargazer_graphql_query(node_ids: &[String]) -> String {
     let mut query = String::from("query { ");
     for (i, id) in node_ids.iter().enumerate() {
+        let id = escape_graphql_string(id);
         query.push_str(&format!(
             "n{i}: node(id: \"{id}\") {{ ... on Gist {{ name stargazerCount }} }} "
         ));
@@ -1003,6 +1011,19 @@ mod tests {
         assert!(q.contains(r#"n0: node(id: "G_a")"#));
         assert!(q.contains(r#"n1: node(id: "G_b")"#));
         assert!(q.contains("stargazerCount"));
+    }
+
+    #[test]
+    fn build_stargazer_graphql_query_escapes_quotes_and_backslashes() {
+        // A node_id carrying a double-quote or backslash must stay inside its string
+        // literal rather than break out of the query (defensive against malformed ids).
+        let q = build_stargazer_graphql_query(&["a\"b".into(), "c\\d".into()]);
+        assert!(q.contains(r#"n0: node(id: "a\"b")"#));
+        assert!(q.contains(r#"n1: node(id: "c\\d")"#));
+        // The injected quote does not prematurely close the literal: a break-out attempt
+        // like `") {} #` stays escaped, so no bare `) {` from the payload appears.
+        let inj = build_stargazer_graphql_query(&["x\") { __typename } #".into()]);
+        assert!(inj.contains(r#"node(id: "x\") { __typename } #")"#));
     }
 
     #[test]

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -820,10 +820,10 @@ pub(super) fn run_loop(
             KeyOutcome::Unpin => unpin_selected(&mut state),
             KeyOutcome::UploadAdd => {
                 let (local_path, gist_id) = if state.is_pin_diff_context() {
-                    (
-                        state.preview_local.clone(),
-                        state.download_gist_id.clone().unwrap(),
-                    )
+                    let Some(gist_id) = state.download_gist_id.clone() else {
+                        continue;
+                    };
+                    (state.preview_local.clone(), gist_id)
                 } else {
                     let (Some(local), Some(gist)) = (state.selected_local(), state.selected_gist())
                     else {
@@ -849,8 +849,10 @@ pub(super) fn run_loop(
             }
             KeyOutcome::UploadPreview => {
                 let (local_path, gist_id, gist_file) = if state.is_pin_diff_context() {
+                    let Some(gist_id) = state.download_gist_id.clone() else {
+                        continue;
+                    };
                     let local_path = state.preview_local.clone();
-                    let gist_id = state.download_gist_id.clone().unwrap();
                     let filename = state.download_gist_filename.clone().unwrap_or_default();
                     let gist_file = state
                         .gists


### PR DESCRIPTION
Two highest-priority correctness findings from the audit, each a surgical fix.

- **`escape node ids in the stargazer GraphQL query`** (corr-1) — `build_stargazer_graphql_query` interpolated API-supplied node ids straight into a `"…"` GraphQL string; a stray `"`/`\` could break out. Now escapes backslash + quote. Unit-tested (RED→GREEN) incl. a break-out payload. Closes #152.
- **`remove latent panic in pin-diff upload path`** (corr-2) — `UploadAdd`/`UploadPreview` unwrapped `download_gist_id` behind a hand-synced `is_pin_diff_context()` guard; replaced with `let-else` that bails cleanly. Closes #153.

Both are defensive/latent (not reachable in normal use today), so no CHANGELOG entry — internal hardening with no observable behavior change.

## Verification
`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` (0 warnings), `cargo test` (431 lib incl. 1 new + 12 integration). 

Closes #152
Closes #153