### PR TITLE
docs: fix help/README drift (topic count, o-hint, config table, m-key)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ without resetting order. Pinned pairs show `📌`; same-filename candidates are 
 | `n` | create a new gist from the selected local file |
 | `p` / `P` | pin pair / open Pins view |
 | `g` | gist manager (per-gist view; `Enter` for detail, `v` visibility, `*` star) |
-| `m` | load 30 older comments (Gist detail → Comments tab; also click the top line) |
 | `a` | flip anchor pane · `/` filter focused pane · `?` help |
 
 Press **`?`** anytime for the **full, contextual keymap** — it opens the current screen's
@@ -113,8 +112,13 @@ automatically the first time you pin a file. All fields are optional.
 | Field | Type | Description |
 |-------|------|-------------|
 | `scan_depth` | `integer` | Maximum directory depth for recursive discovery (`r` key). Default `2`. |
-| `skip_dirs` | `[string]` | Directory names skipped during recursive discovery (`r` key). Defaults to common build/dependency dirs (`node_modules`, `target`, …). Hidden dirs (`.`-prefix) are always skipped. |
+| `diff_context` | `integer` | Unchanged context lines kept around each change in the diff view; `c` toggles between this radius and the full file. Default `3`. |
+| `diff_show_full` | `bool` | Remembered state of the diff `c` toggle: `true` shows the full file, `false` collapses to `diff_context` lines. Rewritten when you press `c`. Default `false`. |
+| `theme` | `string` | Built-in colour theme: `"dark"` (default) or `"light"` (for light-background terminals). |
+| `mouse` | `bool` | Enable mouse support (wheel scroll, click/double-click, close button). Default `true`; `--no-mouse` forces it off for one session. |
+| `check_updates` | `bool` | Check GitHub once a day on startup for a newer release and show a footer hint. Default `true`; `--no-update-check` forces it off for one session. |
 | `ignore_trailing_newline` | `bool` | Treat a difference that is *only* a file-final newline as no change in the diff view and the overwrite-confirm gate. Default `true`; set `false` for strict, byte-exact diffs. |
+| `skip_dirs` | `[string]` | Directory names skipped during recursive discovery (`r` key). Defaults to common build/dependency dirs (`node_modules`, `target`, …). Hidden dirs (`.`-prefix) are always skipped. |
 | `[[pinned]]` | `table array` | Local-file ↔ gist mappings managed by the `p`/`P` keys. Can also be edited by hand. |
 
 Copy [`config.example.toml`](config.example.toml) from the repo for an annotated

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -93,7 +93,7 @@ Actions (on the selected local file + gist)
              pane — Gist pane = download view, Local pane = upload view
              (--- old / +++ new; local label = yellow, gist label = blue)
   Space      preview the gist file's content (R in preview to force-refresh;
-             blocked for images/binary — use o or d instead)
+             blocked for images/binary — use d to download instead)
   H          open revision history for the selected gist file
   d          download the gist into the cwd
   u          upload the local file into the gist
@@ -232,7 +232,7 @@ pub(super) fn render_help(frame: &mut Frame, state: &AppState, layout: &mut Mous
         let list = List::new(items)
             .block(
                 Block::default()
-                    .title("Help — pick a topic (1-8 / ↑↓ Enter · Esc back)")
+                    .title("Help — pick a topic (1-9 / ↑↓ Enter · Esc back)")
                     .borders(Borders::ALL)
                     .border_type(BorderType::Rounded)
                     .style(state.theme.base_style())


### PR DESCRIPTION
Fixes four verified doc/help inaccuracies (audit docs-1..4):

- Help index title `1-8` → `1-9` (`HelpTopic::all()` has 9 topics).
- List binary hint `use o or d instead` → `use d to download instead` (`o` is unbound on the List screen — verified it's a Pins-sort / detail-browser key, not List).
- README config table: added `diff_context, diff_show_full, theme, mouse, check_updates` (was missing 5 of 9 fields).
- Removed the `m` row from the main-list keys table — `m` only works in Gist detail → Comments; already covered by the mouse table + `?` help.

Doc-only; no CHANGELOG entry. Gate: fmt/clippy/test all green.

Closes #158