### PR TITLE
refactor: DRY cleanups (all_gist_files, parse_gh_gists, diff_vscroll_max)

### DIFF
--- a/src/gh.rs
+++ b/src/gh.rs
@@ -248,8 +248,15 @@ pub fn check_gh_ready_with(runner: &dyn CommandRunner) -> Result<()> {
     Ok(())
 }
 
+/// Parse a `gh api /gists…` JSON array into raw `GhGist` rows. Centralises the
+/// `from_str + context` boilerplate shared by the list / comment-count / fork-count /
+/// starred-id parsers.
+fn parse_gh_gists(raw: &str) -> Result<Vec<GhGist>> {
+    serde_json::from_str(raw).context("parse gh gist list JSON")
+}
+
 pub fn parse_gist_list_json(raw: &str) -> Result<Vec<GistFile>> {
-    let gists: Vec<GhGist> = serde_json::from_str(raw).context("parse gh gist list JSON")?;
+    let gists = parse_gh_gists(raw)?;
     let mut files = Vec::new();
 
     for gist in gists {
@@ -307,14 +314,14 @@ pub fn merge_gist_node_id_maps(
 /// Map each gist id to its comment count, parsed from the same gist-list JSON. The count rides
 /// along in the list response, so this needs no extra `gh` call.
 pub fn parse_gist_comment_counts(raw: &str) -> Result<HashMap<String, u32>> {
-    let gists: Vec<GhGist> = serde_json::from_str(raw).context("parse gh gist list JSON")?;
+    let gists = parse_gh_gists(raw)?;
     Ok(gists.into_iter().map(|g| (g.id, g.comments)).collect())
 }
 
 /// Map each gist id to how many forks it has. Uses the `forks` array when the JSON
 /// includes it (full gist); list responses omit it and return 0.
 pub fn parse_gist_fork_counts(raw: &str) -> Result<HashMap<String, u32>> {
-    let gists: Vec<GhGist> = serde_json::from_str(raw).context("parse gh gist list JSON")?;
+    let gists = parse_gh_gists(raw)?;
     Ok(gists
         .into_iter()
         .map(|g| (g.id, g.forks.len() as u32))
@@ -631,7 +638,7 @@ pub fn fetch_current_user_login_with(runner: &dyn CommandRunner) -> Result<Strin
 
 /// Unique gist ids from a parsed gist-list JSON payload.
 pub fn parse_starred_gist_ids(raw: &str) -> Result<std::collections::HashSet<String>> {
-    let gists: Vec<GhGist> = serde_json::from_str(raw).context("parse gh gist list JSON")?;
+    let gists = parse_gh_gists(raw)?;
     Ok(gists.into_iter().map(|g| g.id).collect())
 }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1314,15 +1314,19 @@ impl AppState {
     }
 
     pub fn scroll_diff_down(&mut self) {
-        let max = self
-            .diff_text
-            .lines()
-            .count()
-            .saturating_sub(1)
-            .min(u16::MAX as usize) as u16;
+        let max = self.diff_vscroll_max();
         if self.diff_scroll < max {
             self.diff_scroll += 1;
         }
+    }
+
+    /// Bottom clamp for the diff/preview vertical scroll: the last addressable line index.
+    fn diff_vscroll_max(&self) -> u16 {
+        self.diff_text
+            .lines()
+            .count()
+            .saturating_sub(1)
+            .min(u16::MAX as usize) as u16
     }
 
     pub fn scroll_diff_up(&mut self) {
@@ -1331,12 +1335,7 @@ impl AppState {
 
     /// Page the diff/preview down by `lines`, clamped to the same bottom as `scroll_diff_down`.
     pub fn scroll_diff_page_down(&mut self, lines: u16) {
-        let max = self
-            .diff_text
-            .lines()
-            .count()
-            .saturating_sub(1)
-            .min(u16::MAX as usize) as u16;
+        let max = self.diff_vscroll_max();
         self.diff_scroll = self.diff_scroll.saturating_add(lines).min(max);
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -713,10 +713,14 @@ impl AppState {
     }
 
     /// `owner.login` for a gist id from the in-memory owned or starred lists.
+    /// Iterator over every in-memory gist file — owned first, then starred. The shared base
+    /// for the many lookups that must search both lists.
+    fn all_gist_files(&self) -> impl Iterator<Item = &GistFile> {
+        self.gists.iter().chain(self.starred_gists.iter())
+    }
+
     pub fn gist_owner_login(&self, gist_id: &str) -> String {
-        self.gists
-            .iter()
-            .chain(self.starred_gists.iter())
+        self.all_gist_files()
             .find(|g| g.gist_id == gist_id)
             .map(|g| g.owner_login.clone())
             .unwrap_or_default()
@@ -724,18 +728,14 @@ impl AppState {
 
     /// `raw_url` from the in-memory gist lists for a `(gist_id, filename)` pair.
     pub fn gist_file_raw_url(&self, gist_id: &str, filename: &str) -> Option<String> {
-        self.gists
-            .iter()
-            .chain(self.starred_gists.iter())
+        self.all_gist_files()
             .find(|g| g.gist_id == gist_id && g.filename == filename)
             .and_then(|g| g.raw_url.clone())
     }
 
     pub fn gist_is_owned(&self, gist_id: &str) -> bool {
         if let Some(me) = self.current_user_login.as_deref() {
-            self.gists
-                .iter()
-                .chain(self.starred_gists.iter())
+            self.all_gist_files()
                 .find(|g| g.gist_id == gist_id)
                 .is_some_and(|g| g.is_owned_by(me))
         } else {
@@ -973,27 +973,21 @@ impl AppState {
     /// Number of files the given gist holds in the current in-memory list. Used to guard
     /// against removing a gist's only file (GitHub forbids a fileless gist).
     fn gist_file_count(&self, gist_id: &str) -> usize {
-        self.gists
-            .iter()
-            .chain(self.starred_gists.iter())
+        self.all_gist_files()
             .filter(|g| g.gist_id == gist_id)
             .count()
     }
 
     /// Filenames the given gist holds in the current in-memory list (gh order).
     pub fn gist_filenames(&self, gist_id: &str) -> Vec<String> {
-        self.gists
-            .iter()
-            .chain(self.starred_gists.iter())
+        self.all_gist_files()
             .filter(|g| g.gist_id == gist_id)
             .map(|g| g.filename.clone())
             .collect()
     }
 
     pub fn gist_file_content_type(&self, gist_id: &str, filename: &str) -> Option<String> {
-        self.gists
-            .iter()
-            .chain(self.starred_gists.iter())
+        self.all_gist_files()
             .find(|g| g.gist_id == gist_id && g.filename == filename)
             .and_then(|g| g.content_type.clone())
     }
@@ -1141,9 +1135,7 @@ impl AppState {
 
     pub fn group_by_id(&self, gist_id: &str) -> Option<GistGroup> {
         let files: Vec<GistFile> = self
-            .gists
-            .iter()
-            .chain(self.starred_gists.iter())
+            .all_gist_files()
             .filter(|g| g.gist_id == gist_id)
             .cloned()
             .collect();


### PR DESCRIPTION
Behavior-preserving de-dups from the audit (#160). The 431-test suite is the safety net (green); `skip-changelog` (internal, no user-facing change).

Done in this PR:
- [x] **simp-1** `all_gist_files()` — collapses 7× `gists.iter().chain(starred_gists.iter())`.
- [x] **simp-2** `parse_gh_gists()` — collapses 4× identical list-parse boilerplate.
- [x] **simp-7** `diff_vscroll_max()` — shares the diff bottom-clamp between two scroll fns.

Deferred to a follow-up on #160 (behavior-sensitive / fiddlier — left for a fresh pass to avoid rushing):
- [ ] **simp-3** extract `IMAGE_EXTENSIONS` (restructures binary/image detection consts).
- [ ] **simp-4** collapse the 3 Diff/Preview/Confirm scroll match arms (touches key dispatch).
- [ ] **simp-5** `GistFile::for_sync()` for 5 stub constructions.
- [ ] **simp-6** apply `cycling_enum!` to `GistTypeFilter`.

Gate: fmt/clippy -D warnings/test all green.

Refs #160