### PR TITLE
perf(tui): memoise syntax highlighting across frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Performance: syntax-highlighted diff and preview panes are memoised, so scrolling no longer re-tokenises the whole buffer on every frame — smoother on large, highlighted files.
 - TUI polish: the Gists and Gist-detail footers now surface `y copy url`; destructive-key and comment-error colours follow the theme (keeping contrast in light mode); and the filter hint wording is consistent (`Enter apply`).
 - Gist comments now load newest-first in pages of 30 (popular gists no longer dump every comment or silently stop at 100); `m` or clicking the top line loads 30 older comments. The Comments pane is restyled with a per-comment header, relative time, and a loaded-range title.
 - Diff view: a difference that is *only* a file-final newline no longer shows as a phantom change and no longer forces an overwrite confirm (GitHub stores gists with a trailing newline that local files often lack); disable with `ignore_trailing_newline = false` for byte-exact diffs.

--- a/src/tui/highlight.rs
+++ b/src/tui/highlight.rs
@@ -6,8 +6,12 @@
 //! `AppState::syntax_highlight` (off when `NO_COLOR` is set) at the call sites in `render`.
 
 use super::theme::Theme;
+use crate::lru::LruCache;
 use ratatui::style::{Color, Style};
 use ratatui::text::Span;
+use std::cell::RefCell;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 use synoptic::{from_extension, Highlighter, TokOpt};
 
 /// Tab display width handed to synoptic; it expands `\t` to this many spaces in highlighted text.
@@ -32,11 +36,54 @@ fn token_color(kind: &str, theme: &Theme) -> Option<Color> {
     })
 }
 
+thread_local! {
+    /// Per-thread memo of highlighted buffers. The render loop re-highlights the same
+    /// `diff_text`/preview content on every ~150ms frame even when only the scroll offset
+    /// changed; synoptic tokenisation is the costly part, so caching it (keyed on the exact
+    /// inputs that determine the output) turns a steady-state frame into a cheap clone.
+    /// Capacity 16 comfortably holds the few buffers in play (current diff/preview + recents)
+    /// and bounds memory. Render runs on the main thread, so a thread-local is sufficient.
+    static HIGHLIGHT_CACHE: RefCell<LruCache<u64, Vec<Vec<Span<'static>>>>> =
+        RefCell::new(LruCache::new(16));
+}
+
+/// Hash the full set of inputs `highlight_buffer` is a pure function of: the grammar (`ext`),
+/// the content (`lines`), and the token palette (`theme.syntax`, the only theme data
+/// `token_color` reads). Any change to these yields a different key, so a stale palette or
+/// edited content can never serve a cached result.
+fn highlight_key(ext: &str, lines: &[String], theme: &Theme) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    ext.hash(&mut hasher);
+    lines.hash(&mut hasher);
+    theme.syntax.hash(&mut hasher);
+    hasher.finish()
+}
+
 /// Highlight a whole buffer, correct across multi-line strings/comments (synoptic tracks state
 /// over the run). Returns one span vector per input line, 1:1 with `lines`. `ext` selects the
 /// grammar; an unsupported extension yields all-plain spans so callers always get a usable
 /// result of the same shape. `theme` selects the token palette.
+///
+/// Transparently memoised (see `HIGHLIGHT_CACHE`): identical `(ext, lines, theme.syntax)`
+/// returns the same spans without re-tokenising. The cache is an implementation detail — the
+/// result is byte-for-byte what a direct computation would produce.
 pub fn highlight_buffer(ext: &str, lines: &[String], theme: &Theme) -> Vec<Vec<Span<'static>>> {
+    let key = highlight_key(ext, lines, theme);
+    if let Some(hit) = HIGHLIGHT_CACHE.with(|c| c.borrow_mut().get(&key).cloned()) {
+        return hit;
+    }
+    let computed = highlight_buffer_uncached(ext, lines, theme);
+    HIGHLIGHT_CACHE.with(|c| c.borrow_mut().insert(key, computed.clone()));
+    computed
+}
+
+/// The actual synoptic tokenisation, without the memo. Split out so [`highlight_buffer`] is a
+/// thin cache front and tests can exercise the computation directly.
+fn highlight_buffer_uncached(
+    ext: &str,
+    lines: &[String],
+    theme: &Theme,
+) -> Vec<Vec<Span<'static>>> {
     let Some(mut highlighter): Option<Highlighter> = from_extension(ext, TAB_WIDTH) else {
         return lines.iter().map(|l| vec![Span::raw(l.clone())]).collect();
     };
@@ -87,6 +134,31 @@ mod tests {
         assert!(out[0]
             .iter()
             .any(|s| s.style.fg == Some(Color::Magenta) && s.content.contains("fn")));
+    }
+
+    #[test]
+    fn memo_matches_uncached_and_does_not_corrupt_across_keys() {
+        // The memo must be transparent: a cached result equals a direct computation, and
+        // interleaving a different buffer must not contaminate an earlier key's entry.
+        let a = vec!["fn a() {}".to_string()];
+        let b = vec!["let b = 2; // note".to_string()];
+        let direct_a = highlight_buffer_uncached("rs", &a, &Theme::DARK);
+
+        let a1 = highlight_buffer("rs", &a, &Theme::DARK); // miss → compute + store
+        let _b = highlight_buffer("rs", &b, &Theme::DARK); // different key
+        let a2 = highlight_buffer("rs", &a, &Theme::DARK); // hit → must still be a's result
+        assert_eq!(a1, direct_a);
+        assert_eq!(a2, direct_a);
+    }
+
+    #[test]
+    fn memo_keys_on_theme_palette() {
+        // Same content + grammar but a different palette must not collide in the cache:
+        // the light theme recolours tokens, so its spans differ from the dark theme's.
+        let lines = vec!["let x = 1; // c".to_string()];
+        let dark = highlight_buffer("rs", &lines, &Theme::DARK);
+        let light = highlight_buffer("rs", &lines, &Theme::LIGHT);
+        assert_ne!(dark, light);
     }
 
     #[test]

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -5,7 +5,7 @@ use ratatui::style::{Color, Style};
 /// The dark set are bright ANSI hues tuned for a terminal-native background; the light set are
 /// fixed 256-colour dark shades that keep contrast on the light-grey canvas (bright ANSI hues
 /// wash out there). Kinds that share a hue (digit/boolean, attribute/header) map to one field.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct SyntaxPalette {
     /// `comment` tokens.
     pub comment: Color,


### PR DESCRIPTION
Audit perf-2. The render loop re-tokenises the diff/preview buffer on every ~150ms frame even when only the scroll offset changed.

**Approach:** a transparent thread-local LRU memo (cap 16) inside `highlight.rs`, keyed on a hash of `(ext, lines, theme.syntax)` — the exact inputs `highlight_buffer` is a pure function of. A steady-state frame becomes a cheap clone instead of a synoptic re-tokenise. Chosen over an `AppState` cache because it needs **no** AppState field, run_loop wiring, or render signature changes, and the content hash *is* the invalidation key (no manual invalidation).

- `SyntaxPalette` gains `Hash` so the palette is part of the key — a `T` theme toggle yields a different key (can't serve stale colours).
- Output is **byte-for-byte identical** to the uncached path (the memo is an implementation detail).
- Render runs on the main thread → thread-local is sufficient.

**Tests:** new `memo_matches_uncached_and_does_not_corrupt_across_keys` (transparency + no cross-key contamination) and `memo_keys_on_theme_palette` (dark ≠ light, proving the palette is in the key). Gate: fmt/clippy -D warnings/test (433) green.

Closes #155