### PR TITLE
fix(tui): misc correctness (browser freeze, cwd temp dirs, silent upload read)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed three rough edges: opening a gist in the browser (`o`) no longer briefly freezes the UI; upload/restore temp files are written to the system temp directory instead of the working directory (no stray `.gistui_*` dirs if the process is killed mid-op); and an unreadable local file now reports an error instead of silently showing the whole gist as additions on upload.
 - Performance: syntax-highlighted diff and preview panes are memoised, so scrolling no longer re-tokenises the whole buffer on every frame — smoother on large, highlighted files.
 - TUI polish: the Gists and Gist-detail footers now surface `y copy url`; destructive-key and comment-error colours follow the theme (keeping contrast in light mode); and the filter hint wording is consistent (`Enter apply`).
 - Gist comments now load newest-first in pages of 30 (popular gists no longer dump every comment or silently stop at 100); `m` or clicking the top line loads 30 older comments. The Comments pane is restyled with a per-comment header, relative time, and a loaded-range title.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -679,14 +679,18 @@ impl AppState {
         self.diff_text = diff;
     }
 
+    /// Prime the upload-diff state from the local file. Returns the read error instead of
+    /// silently defaulting to empty content — an unreadable/deleted/non-UTF-8 file would
+    /// otherwise render the whole gist as additions, so the caller must surface it and abort
+    /// the upload rather than show a bogus diff.
     pub fn init_upload_state(
         &mut self,
         local_path: &std::path::Path,
         remote_content: Option<String>,
         local_label: String,
         gist_label: String,
-    ) {
-        self.upload_original_content = std::fs::read_to_string(local_path).unwrap_or_default();
+    ) -> std::io::Result<()> {
+        self.upload_original_content = std::fs::read_to_string(local_path)?;
         self.upload_edited_content = None;
         self.upload_json_pretty = false;
         self.upload_json_sort = false;
@@ -694,6 +698,7 @@ impl AppState {
         self.upload_local_label = Some(local_label);
         self.upload_gist_label = Some(gist_label);
         self.update_upload_diff();
+        Ok(())
     }
 
     fn list_gist_source(&self) -> &[GistFile] {

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -308,16 +308,26 @@ pub(super) fn run_loop(
                                 filename,
                                 local_path: local_path.clone(),
                             });
-                            state.init_upload_state(
+                            match state.init_upload_state(
                                 &local_path,
                                 Some(remote),
                                 local_label,
                                 gist_label,
-                            );
-                            state.diff_scroll = 0;
-                            state.diff_hscroll = 0;
-                            state.status = None;
-                            state.screen = Screen::Confirm;
+                            ) {
+                                Ok(()) => {
+                                    state.diff_scroll = 0;
+                                    state.diff_hscroll = 0;
+                                    state.status = None;
+                                    state.screen = Screen::Confirm;
+                                }
+                                Err(error) => {
+                                    state.pending_action = None;
+                                    state.set_status(format!(
+                                        "cannot read {}: {error}",
+                                        crate::config::display_path(&local_path)
+                                    ));
+                                }
+                            }
                         }
                         Err(error) => state.set_status(format!("fetch failed: {error}")),
                     },
@@ -844,8 +854,21 @@ pub(super) fn run_loop(
 
                 let local_label = format!("local: {}", crate::config::display_path(&local_path));
                 let gist_label = "(new file)".to_string();
-                state.init_upload_state(&local_path, Some(String::new()), local_label, gist_label);
-                state.screen = Screen::Confirm;
+                match state.init_upload_state(
+                    &local_path,
+                    Some(String::new()),
+                    local_label,
+                    gist_label,
+                ) {
+                    Ok(()) => state.screen = Screen::Confirm,
+                    Err(error) => {
+                        state.pending_action = None;
+                        state.set_status(format!(
+                            "cannot read {}: {error}",
+                            crate::config::display_path(&local_path)
+                        ));
+                    }
+                }
             }
             KeyOutcome::UploadPreview => {
                 let (local_path, gist_id, gist_file) = if state.is_pin_diff_context() {
@@ -920,7 +943,7 @@ pub(super) fn run_loop(
                     .duration_since(std::time::UNIX_EPOCH)
                     .map(|d| d.as_nanos())
                     .unwrap_or(0);
-                let temp_dir = state.cwd.join(format!(".gistui_upload_{timestamp}"));
+                let temp_dir = std::env::temp_dir().join(format!(".gistui_upload_{timestamp}"));
 
                 if let Err(e) = std::fs::create_dir_all(&temp_dir) {
                     state.set_status(format!("failed to create temp dir: {e}"));
@@ -1350,7 +1373,7 @@ pub(super) fn run_loop(
                     .duration_since(std::time::UNIX_EPOCH)
                     .map(|d| d.as_nanos())
                     .unwrap_or(0);
-                let temp_dir = state.cwd.join(format!(".gistui_restore_{timestamp}"));
+                let temp_dir = std::env::temp_dir().join(format!(".gistui_restore_{timestamp}"));
                 if let Err(e) = std::fs::create_dir_all(&temp_dir) {
                     state.set_status(format!("failed to create temp dir: {e}"));
                     continue;
@@ -1986,10 +2009,14 @@ fn open_browser(state: &mut AppState) {
         return;
     };
     let plan = crate::actions::open_browser_command(&gist_id);
-    match crate::actions::execute_command(&plan) {
-        Ok(_) => state.set_status(format!("Opened gist {gist_id} in the browser")),
-        Err(error) => state.set_status(format!("open failed: {error}")),
-    }
+    // Fire-and-forget on a detached thread: `gh gist view --web` resolves the URL and shells
+    // out to the OS opener, which can stall the event loop for a perceptible window if run
+    // inline. A launch failure is rare and self-evident (no browser appears), so we report
+    // optimistically rather than thread the result back through a background outcome.
+    std::thread::spawn(move || {
+        let _ = crate::actions::execute_command(&plan);
+    });
+    state.set_status(format!("Opening gist {gist_id} in the browser…"));
 }
 
 /// Copies the context gist's web URL to the system clipboard. On the Preview screen the


### PR DESCRIPTION
Audit corr-3 / corr-6 / corr-7.

- **corr-3** `open_browser` ran `gh gist view --web` inline on the event-loop thread → brief UI freeze. Now a detached thread (fire-and-forget; a launch failure is rare and self-evident), reported optimistically.
- **corr-6** upload/restore temp dirs were created in `cwd` (`.gistui_upload_*` / `.gistui_restore_*`) → stray dirs if killed mid-op. Now `std::env::temp_dir()`.
- **corr-7** `init_upload_state` used `read_to_string(...).unwrap_or_default()` → a deleted/unreadable/non-UTF-8 local file silently showed the whole gist as additions. Now returns `io::Result`; both callers surface the error and abort the upload (no bogus confirm).

IO-boundary changes (run_loop) — untested by design; gate green (fmt/clippy/test 433). CHANGELOG updated.

Closes #157