### PR TITLE
fix(gh): paginate fork detection + surface its failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed: owned-fork detection now paginates past 100 gists (the `forked` filter no longer misses forks on large accounts), and a failed fork-detection query surfaces a `fork detection unavailable` hint instead of silently showing no forks.
 - Fixed three rough edges: opening a gist in the browser (`o`) no longer briefly freezes the UI; upload/restore temp files are written to the system temp directory instead of the working directory (no stray `.gistui_*` dirs if the process is killed mid-op); and an unreadable local file now reports an error instead of silently showing the whole gist as additions on upload.
 - Performance: syntax-highlighted diff and preview panes are memoised, so scrolling no longer re-tokenises the whole buffer on every frame — smoother on large, highlighted files.
 - TUI polish: the Gists and Gist-detail footers now surface `y copy url`; destructive-key and comment-error colours follow the theme (keeping contrast in light mode); and the filter hint wording is consistent (`Enter apply`).

--- a/src/gh.rs
+++ b/src/gh.rs
@@ -351,16 +351,32 @@ pub fn fetch_gist_fork_count_with(runner: &dyn CommandRunner, gist_id: &str) -> 
 }
 
 /// GraphQL query: the REST gist *list* omits `fork_of`, but `isFork` is reliable here.
-const GIST_FORK_FLAGS_QUERY: &str = "{ viewer { gists(first: 100) { nodes { name isFork } } } }";
+/// One page of the viewer's gists with their `isFork` flag. Accounts with >100 gists need
+/// pagination: `after` carries the previous page's `endCursor` (escaped, since it is opaque
+/// API text), and the response's `pageInfo` drives the loop in
+/// [`fetch_forked_gist_ids_graphql_with`].
+fn gist_fork_flags_graphql_query(after: Option<&str>) -> String {
+    let connection = match after {
+        Some(cursor) => format!(
+            "gists(first: 100, after: \"{}\")",
+            escape_graphql_string(cursor)
+        ),
+        None => "gists(first: 100)".to_string(),
+    };
+    format!(
+        "{{ viewer {{ {connection} {{ nodes {{ name isFork }} \
+         pageInfo {{ hasNextPage endCursor }} }} }} }}"
+    )
+}
 
-pub fn gist_fork_flags_graphql_plan() -> CommandPlan {
+pub fn gist_fork_flags_graphql_plan(after: Option<&str>) -> CommandPlan {
     CommandPlan {
         program: "gh".into(),
         args: vec![
             "api".into(),
             "graphql".into(),
             "-f".into(),
-            format!("query={GIST_FORK_FLAGS_QUERY}"),
+            format!("query={}", gist_fork_flags_graphql_query(after)),
         ],
     }
 }
@@ -378,8 +394,18 @@ pub fn fetch_forked_gist_ids_graphql() -> Result<HashSet<String>> {
 }
 
 pub fn fetch_forked_gist_ids_graphql_with(runner: &dyn CommandRunner) -> Result<HashSet<String>> {
-    let raw = run_command(runner, &gist_fork_flags_graphql_plan())?;
-    parse_forked_gist_ids_graphql(&raw)
+    let mut all = HashSet::new();
+    let mut after: Option<String> = None;
+    loop {
+        let raw = run_command(runner, &gist_fork_flags_graphql_plan(after.as_deref()))?;
+        let (ids, next) = parse_fork_flags_page(&raw)?;
+        all.extend(ids);
+        match next {
+            Some(cursor) => after = Some(cursor),
+            None => break,
+        }
+    }
+    Ok(all)
 }
 
 #[derive(Debug, Deserialize)]
@@ -400,6 +426,17 @@ struct GraphqlForkFlagsViewer {
 #[derive(Debug, Deserialize)]
 struct GraphqlForkFlagsConnection {
     nodes: Vec<GraphqlForkFlagsNode>,
+    /// Absent in older single-page fixtures, so default to a terminal page.
+    #[serde(rename = "pageInfo", default)]
+    page_info: GraphqlPageInfo,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct GraphqlPageInfo {
+    #[serde(rename = "hasNextPage", default)]
+    has_next_page: bool,
+    #[serde(rename = "endCursor", default)]
+    end_cursor: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -410,19 +447,30 @@ struct GraphqlForkFlagsNode {
     is_fork: bool,
 }
 
-/// Owned gist ids flagged as forks by the GraphQL viewer query.
-pub fn parse_forked_gist_ids_graphql(raw: &str) -> Result<HashSet<String>> {
+/// Parse one fork-flags page into its fork ids plus the cursor for the next page (`None`
+/// when `hasNextPage` is false).
+fn parse_fork_flags_page(raw: &str) -> Result<(HashSet<String>, Option<String>)> {
     let resp: GraphqlForkFlagsResponse =
         serde_json::from_str(raw).context("parse gist fork flags GraphQL")?;
-    Ok(resp
-        .data
-        .viewer
-        .gists
+    let connection = resp.data.viewer.gists;
+    let ids = connection
         .nodes
         .into_iter()
         .filter(|n| n.is_fork)
         .map(|n| n.name)
-        .collect())
+        .collect();
+    let next = connection
+        .page_info
+        .has_next_page
+        .then_some(connection.page_info.end_cursor)
+        .flatten();
+    Ok((ids, next))
+}
+
+/// Owned gist ids flagged as forks by a single GraphQL viewer page (the cursor is dropped).
+/// Pagination is handled by [`fetch_forked_gist_ids_graphql_with`].
+pub fn parse_forked_gist_ids_graphql(raw: &str) -> Result<HashSet<String>> {
+    parse_fork_flags_page(raw).map(|(ids, _)| ids)
 }
 
 pub fn fetch_gist_fork_of_id(gist_id: &str) -> Result<Option<String>> {
@@ -440,18 +488,20 @@ pub fn fetch_gist_fork_of_id_with(
 
 /// Map owned gist id → upstream `fork_of` id. Uses GraphQL `isFork` (one call) then
 /// `GET /gists/{id}` only for the handful of owned forks (list JSON omits `fork_of`).
-pub fn collect_owned_fork_of_ids(owned_ids: HashSet<String>) -> HashMap<String, Option<String>> {
-    let fork_ids = match fetch_forked_gist_ids_graphql() {
-        Ok(ids) => ids,
-        Err(_) => return HashMap::new(),
-    };
+pub fn collect_owned_fork_of_ids(
+    owned_ids: HashSet<String>,
+) -> Result<HashMap<String, Option<String>>, String> {
+    // Surface a failure of the single fork-detection query — a transient error or expired
+    // token would otherwise leave every owned fork undetected with no hint why the `forked`
+    // filter is empty. Per-gist `fork_of` lookups stay best-effort (one bad gist is skipped).
+    let fork_ids = fetch_forked_gist_ids_graphql().map_err(|e| e.to_string())?;
     let mut out = HashMap::new();
     for id in fork_ids.intersection(&owned_ids) {
         if let Ok(fork_of) = fetch_gist_fork_of_id(id) {
             out.insert(id.clone(), fork_of);
         }
     }
-    out
+    Ok(out)
 }
 
 /// Stamp `fork_of_id` onto every [`GistFile`] row for gists present in `fork_of`.
@@ -1060,6 +1110,36 @@ mod tests {
         assert_eq!(ids.len(), 2);
         assert!(ids.contains("fork1"));
         assert!(ids.contains("fork2"));
+    }
+
+    #[test]
+    fn fork_flags_page_reports_next_cursor_then_stops() {
+        // A page with hasNextPage drives the pagination loop forward via its endCursor.
+        let more = r#"{ "data": { "viewer": { "gists": {
+            "nodes": [{"name": "fork1", "isFork": true}, {"name": "owned1", "isFork": false}],
+            "pageInfo": {"hasNextPage": true, "endCursor": "CUR2"}
+        } } } }"#;
+        let (ids, next) = parse_fork_flags_page(more).unwrap();
+        assert_eq!(
+            ids.into_iter().collect::<Vec<_>>(),
+            vec!["fork1".to_string()]
+        );
+        assert_eq!(next, Some("CUR2".to_string()));
+
+        // The last page has no next cursor — the loop terminates.
+        let last = r#"{ "data": { "viewer": { "gists": {
+            "nodes": [{"name": "fork2", "isFork": true}],
+            "pageInfo": {"hasNextPage": false, "endCursor": "CUR9"}
+        } } } }"#;
+        let (_, next) = parse_fork_flags_page(last).unwrap();
+        assert_eq!(next, None);
+    }
+
+    #[test]
+    fn fork_flags_query_escapes_cursor_and_omits_after_on_first_page() {
+        assert!(!gist_fork_flags_graphql_query(None).contains("after"));
+        let q = gist_fork_flags_graphql_query(Some("a\"b"));
+        assert!(q.contains(r#"after: "a\"b""#));
     }
 
     #[test]

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -3,6 +3,10 @@ use crossterm::event::{self, Event, KeyCode, KeyEventKind, MouseButton, MouseEve
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io;
 
+/// Owned-fork metadata (gist id → upstream id), or the reason fork detection failed. Named so
+/// the channel/receiver types stay readable.
+type ForkMetaResult = Result<std::collections::HashMap<String, Option<String>>, String>;
+
 pub(super) fn run_loop(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     no_mouse: bool,
@@ -36,9 +40,7 @@ pub(super) fn run_loop(
         None;
     let mut star_rx: Option<std::sync::mpsc::Receiver<std::collections::HashMap<String, u32>>> =
         None;
-    let mut fork_meta_rx: Option<
-        std::sync::mpsc::Receiver<std::collections::HashMap<String, Option<String>>>,
-    > = None;
+    let mut fork_meta_rx: Option<std::sync::mpsc::Receiver<ForkMetaResult>> = None;
     let mut local_rx: Option<std::sync::mpsc::Receiver<Vec<LocalCandidate>>> = None;
     let mut bg_rx: Option<std::sync::mpsc::Receiver<BgTaskOutcome>> = None;
 
@@ -128,9 +130,14 @@ pub(super) fn run_loop(
         }
 
         if let Some(ref rx) = fork_meta_rx {
-            if let Ok(fork_of) = rx.try_recv() {
-                crate::gh::apply_fork_of_ids(&mut state.gists, &fork_of);
-                persist_gist_cache_from_state(&state);
+            if let Ok(result) = rx.try_recv() {
+                match result {
+                    Ok(fork_of) => {
+                        crate::gh::apply_fork_of_ids(&mut state.gists, &fork_of);
+                        persist_gist_cache_from_state(&state);
+                    }
+                    Err(error) => state.set_status(format!("fork detection unavailable: {error}")),
+                }
                 fork_meta_rx = None;
             }
         }
@@ -1756,7 +1763,7 @@ fn spawn_star_count_fetch(
 
 fn spawn_fork_metadata_fetch(
     owned_ids: std::collections::HashSet<String>,
-) -> std::sync::mpsc::Receiver<std::collections::HashMap<String, Option<String>>> {
+) -> std::sync::mpsc::Receiver<ForkMetaResult> {
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
         let fork_of = crate::gh::collect_owned_fork_of_ids(owned_ids);


### PR DESCRIPTION
Audit corr-4 / corr-5.

- **corr-5 (pagination):** `GIST_FORK_FLAGS_QUERY` used `gists(first: 100)` with no cursor → owners of >100 gists silently lost fork detection on the overflow. The query now requests `pageInfo`, and `fetch_forked_gist_ids_graphql_with` loops over `after:` cursors (escaped via the existing `escape_graphql_string`) until `hasNextPage` is false. Old single-page fixtures still parse (`pageInfo` defaults to a terminal page).
- **corr-4 (surface failures):** `collect_owned_fork_of_ids` swallowed errors from the one fork-detection query and returned an empty map — a transient/auth failure left all forks undetected with no hint. It now returns `Result`; the background receiver shows a `fork detection unavailable` status. Per-gist `fork_of` lookups stay best-effort.

Tests: `fork_flags_page_reports_next_cursor_then_stops`, `fork_flags_query_escapes_cursor_and_omits_after_on_first_page`. Gate green (441). CHANGELOG updated.

Closes #156