### PR TITLE
refactor: DRY remainder — scroll arms + GistFile::for_sync

### DIFF
--- a/src/domain.rs
+++ b/src/domain.rs
@@ -235,6 +235,26 @@ pub struct GistGroup {
 }
 
 impl GistFile {
+    /// A bare row carrying only the identity a sync/diff/upload operation needs —
+    /// `gist_id`, `filename`, and `raw_url`. All display/metadata fields default to empty,
+    /// so adding a new field to `GistFile` no longer means editing every call site that
+    /// builds one of these throwaway targets.
+    pub fn for_sync(gist_id: String, filename: String, raw_url: Option<String>) -> Self {
+        GistFile {
+            gist_id,
+            description: String::new(),
+            filename,
+            public: false,
+            updated_at: String::new(),
+            created_at: String::new(),
+            owner_login: String::new(),
+            fork_of_id: None,
+            raw_url,
+            content_type: None,
+            node_id: None,
+        }
+    }
+
     pub fn is_owned_by(&self, login: &str) -> bool {
         !login.is_empty() && self.owner_login == login
     }

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -261,29 +261,8 @@ impl AppState {
                 }
                 true
             }
-            Screen::Diff => {
-                match action {
-                    NavAction::Down => self.scroll_diff_down(),
-                    NavAction::Up => self.scroll_diff_up(),
-                    NavAction::PageDown => self.scroll_diff_page_down(PAGE_SCROLL),
-                    NavAction::PageUp => self.scroll_diff_page_up(PAGE_SCROLL),
-                    NavAction::Right => self.scroll_diff_right(),
-                    NavAction::Left => self.scroll_diff_left(),
-                }
-                true
-            }
-            Screen::Preview => {
-                match action {
-                    NavAction::Down => self.scroll_diff_down(),
-                    NavAction::Up => self.scroll_diff_up(),
-                    NavAction::PageDown => self.scroll_diff_page_down(PAGE_SCROLL),
-                    NavAction::PageUp => self.scroll_diff_page_up(PAGE_SCROLL),
-                    NavAction::Right => self.scroll_diff_right(),
-                    NavAction::Left => self.scroll_diff_left(),
-                }
-                true
-            }
-            Screen::Confirm => {
+            // Diff, Preview and Confirm all scroll the same diff/preview buffer identically.
+            Screen::Diff | Screen::Preview | Screen::Confirm => {
                 match action {
                     NavAction::Down => self.scroll_diff_down(),
                     NavAction::Up => self.scroll_diff_up(),

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -882,18 +882,8 @@ pub(super) fn run_loop(
                         .iter()
                         .find(|g| g.gist_id == gist_id && g.filename == filename)
                         .cloned()
-                        .unwrap_or_else(|| GistFile {
-                            gist_id: gist_id.clone(),
-                            description: String::new(),
-                            filename: filename.clone(),
-                            public: false,
-                            updated_at: String::new(),
-                            created_at: String::new(),
-                            owner_login: String::new(),
-                            fork_of_id: None,
-                            raw_url: None,
-                            content_type: None,
-                            node_id: None,
+                        .unwrap_or_else(|| {
+                            GistFile::for_sync(gist_id.clone(), filename.clone(), None)
                         });
                     (local_path, gist_id, gist_file)
                 } else {
@@ -963,19 +953,7 @@ pub(super) fn run_loop(
                     .any(|g| g.gist_id == gist_id && g.filename == filename);
 
                 let plan = if has_same_name {
-                    let target = GistFile {
-                        gist_id: gist_id.clone(),
-                        description: String::new(),
-                        filename: filename.clone(),
-                        public: false,
-                        updated_at: String::new(),
-                        created_at: String::new(),
-                        owner_login: String::new(),
-                        fork_of_id: None,
-                        raw_url: None,
-                        content_type: None,
-                        node_id: None,
-                    };
+                    let target = GistFile::for_sync(gist_id.clone(), filename.clone(), None);
                     crate::actions::upload_command(&temp_file_path, &target)
                 } else {
                     crate::actions::upload_add_command(&temp_file_path, &gist_id)
@@ -1853,19 +1831,7 @@ fn spawn_pin_push(state: &mut AppState, bg_rx: &mut BgRx, m: &crate::domain::Pin
         local_path: local_path.clone(),
     });
     let raw_url = state.gist_file_raw_url(&gist_id, &filename);
-    let gist_file = GistFile {
-        gist_id: gist_id.clone(),
-        description: String::new(),
-        filename: filename.clone(),
-        public: false,
-        updated_at: String::new(),
-        created_at: String::new(),
-        owner_login: String::new(),
-        fork_of_id: None,
-        raw_url: raw_url.clone(),
-        content_type: None,
-        node_id: None,
-    };
+    let gist_file = GistFile::for_sync(gist_id.clone(), filename.clone(), raw_url.clone());
     let (local_label, gist_label) = diff_labels(Some(&local_path), &gist_file);
     spawn_bg(state, bg_rx, "Loading diff…", move || {
         let result = fetch_gist_content(&gist_id, &filename, raw_url.as_deref());
@@ -1888,19 +1854,7 @@ fn spawn_pin_pull(state: &mut AppState, bg_rx: &mut BgRx, m: &crate::domain::Pin
     let gist_id = m.gist_id.clone();
     let filename = m.gist_filename.clone();
     let raw_url = state.gist_file_raw_url(&gist_id, &filename);
-    let gist_file = GistFile {
-        gist_id: gist_id.clone(),
-        description: String::new(),
-        filename: filename.clone(),
-        public: false,
-        updated_at: String::new(),
-        created_at: String::new(),
-        owner_login: String::new(),
-        fork_of_id: None,
-        raw_url: raw_url.clone(),
-        content_type: None,
-        node_id: None,
-    };
+    let gist_file = GistFile::for_sync(gist_id.clone(), filename.clone(), raw_url.clone());
     let (local_label, gist_label) = diff_labels(Some(&target), &gist_file);
     spawn_bg(state, bg_rx, "Downloading…", move || {
         let result = fetch_gist_content(&gist_id, &filename, raw_url.as_deref());
@@ -1935,17 +1889,8 @@ fn spawn_pin_diff(state: &mut AppState, bg_rx: &mut BgRx, m: &crate::domain::Pin
         .unwrap_or_default();
     let raw_url = state.gist_file_raw_url(&gist_id, &filename);
     let gist_file = GistFile {
-        gist_id: gist_id.clone(),
-        description: String::new(),
-        filename: filename.clone(),
-        public: false,
         updated_at,
-        created_at: String::new(),
-        owner_login: String::new(),
-        fork_of_id: None,
-        raw_url: raw_url.clone(),
-        content_type: None,
-        node_id: None,
+        ..GistFile::for_sync(gist_id.clone(), filename.clone(), raw_url.clone())
     };
     let (local_label, gist_label) = diff_labels(Some(&local_abs), &gist_file);
     let target = local_abs.clone();


### PR DESCRIPTION
Continues #160 (after #169's simp-1/2/7). Behavior-preserving; 439-test suite is the safety net; `skip-changelog`.

- [x] **simp-4** collapse the three identical `Screen::Diff | Preview | Confirm` diff-scroll match arms into one.
- [x] **simp-5** `GistFile::for_sync(gist_id, filename, raw_url)` — replaces 5 hand-built throwaway-target stubs (struct-update syntax preserves the one `updated_at` override), so adding a `GistFile` field no longer means editing every call site.

Still open on #160 (behavior-sensitive / fiddlier — left for a fresh pass):
- [ ] **simp-3** extract `IMAGE_EXTENSIONS` (restructures binary/image detection consts).
- [ ] **simp-6** apply `cycling_enum!` to `GistTypeFilter`.

Gate: fmt/clippy -D warnings/test (439) green.

Refs #160