### PR TITLE
refactor(tui): group upload_* fields into UploadState (AppState decomp 1/N)

### DIFF
--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -1417,11 +1417,11 @@ impl AppState {
                 }
                 KeyCode::Char('e') => return KeyOutcome::EditUpload,
                 KeyCode::Char('p') if is_json_file(local_path) => {
-                    self.upload_json_pretty = !self.upload_json_pretty;
+                    self.upload.json_pretty = !self.upload.json_pretty;
                     self.update_upload_diff();
                 }
                 KeyCode::Char('s') if is_json_file(local_path) => {
-                    self.upload_json_sort = !self.upload_json_sort;
+                    self.upload.json_sort = !self.upload.json_sort;
                     self.update_upload_diff();
                 }
                 _ => {}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -433,6 +433,19 @@ pub fn classify_click(
     }
 }
 
+/// Per-screen upload-diff state (the `u` flow). Data only — the upload methods
+/// (`init_upload_state`, `content_to_upload`, `update_upload_diff`) stay on `AppState`.
+#[derive(Debug, Clone, Default)]
+pub struct UploadState {
+    pub original_content: String,
+    pub edited_content: Option<String>,
+    pub json_pretty: bool,
+    pub json_sort: bool,
+    pub remote_content: Option<String>,
+    pub local_label: Option<String>,
+    pub gist_label: Option<String>,
+}
+
 #[derive(Debug, Clone)]
 pub struct AppState {
     pub locals: Vec<LocalCandidate>,
@@ -542,13 +555,7 @@ pub struct AppState {
     pub help_index_open: bool,
     /// Highlighted row in the Help topic index.
     pub help_index_sel: usize,
-    pub upload_original_content: String,
-    pub upload_edited_content: Option<String>,
-    pub upload_json_pretty: bool,
-    pub upload_json_sort: bool,
-    pub upload_remote_content: Option<String>,
-    pub upload_local_label: Option<String>,
-    pub upload_gist_label: Option<String>,
+    pub upload: UploadState,
     /// gist_id of the active download (set when entering the diff Confirm for a pull).
     pub download_gist_id: Option<String>,
     /// filename of the active download (set when entering the diff Confirm for a pull).
@@ -642,15 +649,16 @@ impl AppState {
 
     pub fn content_to_upload(&self) -> String {
         let base = self
-            .upload_edited_content
+            .upload
+            .edited_content
             .as_ref()
-            .unwrap_or(&self.upload_original_content);
+            .unwrap_or(&self.upload.original_content);
         if let Some(local_path) = self.upload_local_path() {
             if is_json_file(&local_path) {
                 if let Ok(transformed) = crate::domain::transform_json(
                     base,
-                    self.upload_json_pretty,
-                    self.upload_json_sort,
+                    self.upload.json_pretty,
+                    self.upload.json_sort,
                 ) {
                     return transformed;
                 }
@@ -662,12 +670,13 @@ impl AppState {
     pub fn update_upload_diff(&mut self) {
         let local_content = self.content_to_upload();
         let remote = self
-            .upload_remote_content
+            .upload
+            .remote_content
             .as_ref()
             .cloned()
             .unwrap_or_default();
-        let local_label = self.upload_local_label.clone().unwrap_or_default();
-        let gist_label = self.upload_gist_label.clone().unwrap_or_default();
+        let local_label = self.upload.local_label.clone().unwrap_or_default();
+        let gist_label = self.upload.gist_label.clone().unwrap_or_default();
 
         let diff = crate::diff::unified_diff(
             &gist_label,
@@ -690,13 +699,13 @@ impl AppState {
         local_label: String,
         gist_label: String,
     ) -> std::io::Result<()> {
-        self.upload_original_content = std::fs::read_to_string(local_path)?;
-        self.upload_edited_content = None;
-        self.upload_json_pretty = false;
-        self.upload_json_sort = false;
-        self.upload_remote_content = remote_content;
-        self.upload_local_label = Some(local_label);
-        self.upload_gist_label = Some(gist_label);
+        self.upload.original_content = std::fs::read_to_string(local_path)?;
+        self.upload.edited_content = None;
+        self.upload.json_pretty = false;
+        self.upload.json_sort = false;
+        self.upload.remote_content = remote_content;
+        self.upload.local_label = Some(local_label);
+        self.upload.gist_label = Some(gist_label);
         self.update_upload_diff();
         Ok(())
     }
@@ -1453,13 +1462,7 @@ pub fn initial_state() -> AppState {
         help_topic: HelpTopic::List,
         help_index_open: false,
         help_index_sel: 0,
-        upload_original_content: String::new(),
-        upload_edited_content: None,
-        upload_json_pretty: false,
-        upload_json_sort: false,
-        upload_remote_content: None,
-        upload_local_label: None,
-        upload_gist_label: None,
+        upload: UploadState::default(),
         download_gist_id: None,
         download_gist_filename: None,
         diff_return: Screen::List,

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -2141,19 +2141,19 @@ pub(super) fn confirm_prompt(state: &AppState) -> String {
             filename,
             local_path,
         }) => {
-            let edited_status = if state.upload_edited_content.is_some() {
+            let edited_status = if state.upload.edited_content.is_some() {
                 " [edited]"
             } else {
                 ""
             };
             let mut opts = format!("y yes  n/Esc cancel  e edit{edited_status}");
             if is_json_file(local_path) {
-                let pretty_status = if state.upload_json_pretty {
+                let pretty_status = if state.upload.json_pretty {
                     " [on]"
                 } else {
                     " [off]"
                 };
-                let sort_status = if state.upload_json_sort {
+                let sort_status = if state.upload.json_sort {
                     " [on]"
                 } else {
                     " [off]"

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -2103,7 +2103,7 @@ fn edit_upload_buffer(
     match result {
         Ok(_) => match std::fs::read_to_string(&temp_file_path) {
             Ok(edited_content) => {
-                state.upload_edited_content = Some(edited_content);
+                state.upload.edited_content = Some(edited_content);
                 state.update_upload_diff();
                 state.set_status("Edited redact buffer");
             }

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -2320,20 +2320,20 @@ fn confirm_upload_json_toggles() {
         local_path: PathBuf::from("/tmp/settings.json"),
     });
     state.screen = Screen::Confirm;
-    assert!(!state.upload_json_pretty);
-    assert!(!state.upload_json_sort);
+    assert!(!state.upload.json_pretty);
+    assert!(!state.upload.json_sort);
 
     // Toggle pretty
     assert_eq!(state.handle_key(KeyCode::Char('p')), KeyOutcome::None);
-    assert!(state.upload_json_pretty);
+    assert!(state.upload.json_pretty);
 
     // Toggle sort
     assert_eq!(state.handle_key(KeyCode::Char('s')), KeyOutcome::None);
-    assert!(state.upload_json_sort);
+    assert!(state.upload.json_sort);
 
     // Toggle pretty off
     assert_eq!(state.handle_key(KeyCode::Char('p')), KeyOutcome::None);
-    assert!(!state.upload_json_pretty);
+    assert!(!state.upload.json_pretty);
 }
 
 #[test]


### PR DESCRIPTION
First increment of the incremental `AppState` decomposition (#163, audit arch-1) — the proof-of-pattern.

The seven `upload_*` fields move into a data-only `#[derive(Debug, Clone, Default)] UploadState` on `AppState`, accessed as `self.upload.<field>` (prefix dropped). **No methods move** (`init_upload_state`/`content_to_upload`/`update_upload_diff` stay on `AppState`); shared core untouched; no semantic change.

Pure refactor → **no new tests**; correctness is the existing suite staying green: **441 tests, identical to baseline**, plus fmt/clippy `-D warnings`/check all green. `skip-changelog`.

Establishes the pattern for the remaining groups (Revisions → Help → Pins → Gists-manager → Detail+Comments → Diff/Preview), each a later PR.

Refs #163