### PR TITLE
refactor(tui): group revision_* fields into RevisionState (AppState decomp 2/N)

### DIFF
--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -222,30 +222,30 @@ impl AppState {
                 true
             }
             Screen::Revisions => {
-                let entries_len = self.revision_entries.as_ref().map(|e| e.len()).unwrap_or(0);
+                let entries_len = self.revision.entries.as_ref().map(|e| e.len()).unwrap_or(0);
                 if entries_len == 0 {
                     return false;
                 }
                 match action {
                     NavAction::Down => {
-                        self.revision_index = (self.revision_index + 1).min(entries_len - 1);
+                        self.revision.index = (self.revision.index + 1).min(entries_len - 1);
                     }
                     NavAction::Up => {
-                        self.revision_index = self.revision_index.saturating_sub(1);
+                        self.revision.index = self.revision.index.saturating_sub(1);
                     }
                     NavAction::PageDown => {
-                        self.revision_index =
-                            (self.revision_index + PAGE_SCROLL as usize).min(entries_len - 1);
+                        self.revision.index =
+                            (self.revision.index + PAGE_SCROLL as usize).min(entries_len - 1);
                     }
                     NavAction::PageUp => {
-                        self.revision_index =
-                            self.revision_index.saturating_sub(PAGE_SCROLL as usize);
+                        self.revision.index =
+                            self.revision.index.saturating_sub(PAGE_SCROLL as usize);
                     }
                     NavAction::Left => {
-                        self.revision_hscroll = self.revision_hscroll.saturating_sub(1);
+                        self.revision.hscroll = self.revision.hscroll.saturating_sub(1);
                     }
                     NavAction::Right => {
-                        self.revision_hscroll = self.revision_hscroll.saturating_add(1);
+                        self.revision.hscroll = self.revision.hscroll.saturating_add(1);
                     }
                 }
                 true
@@ -596,15 +596,15 @@ impl AppState {
 
     fn handle_key_revisions(&mut self, code: KeyCode) -> KeyOutcome {
         self.status = None;
-        let entries_len = self.revision_entries.as_ref().map(|e| e.len()).unwrap_or(0);
+        let entries_len = self.revision.entries.as_ref().map(|e| e.len()).unwrap_or(0);
         match code {
             KeyCode::Char('q') | KeyCode::Esc => {
-                self.screen = self.revision_return_screen;
+                self.screen = self.revision.return_screen;
             }
             KeyCode::Enter if entries_len > 0 => {
                 if let (Some(id), file) = (
-                    self.revision_gist_id.clone(),
-                    self.revision_target_file.clone(),
+                    self.revision.gist_id.clone(),
+                    self.revision.target_file.clone(),
                 ) {
                     if self.block_if_non_previewable_gist_file(&id, &file) {
                         return KeyOutcome::None;
@@ -612,10 +612,10 @@ impl AppState {
                 }
                 return KeyOutcome::RevisionDiffIncremental;
             }
-            KeyCode::Char('D') if entries_len > 0 && self.revision_index > 0 => {
+            KeyCode::Char('D') if entries_len > 0 && self.revision.index > 0 => {
                 if let (Some(id), file) = (
-                    self.revision_gist_id.clone(),
-                    self.revision_target_file.clone(),
+                    self.revision.gist_id.clone(),
+                    self.revision.target_file.clone(),
                 ) {
                     if self.block_if_non_previewable_gist_file(&id, &file) {
                         return KeyOutcome::None;
@@ -626,8 +626,8 @@ impl AppState {
             KeyCode::Char('D') if entries_len > 0 => {
                 self.set_status("already at current revision");
             }
-            KeyCode::Char('r') if entries_len > 1 && self.revision_index > 0 => {
-                if let Some(id) = self.revision_gist_id.clone() {
+            KeyCode::Char('r') if entries_len > 1 && self.revision.index > 0 => {
+                if let Some(id) = self.revision.gist_id.clone() {
                     if !self.gist_is_owned(&id) {
                         return KeyOutcome::None;
                     }
@@ -637,7 +637,7 @@ impl AppState {
             KeyCode::Char('r') if entries_len <= 1 => {
                 self.set_status("only one revision — nothing to restore");
             }
-            KeyCode::Char('r') if self.revision_index == 0 => {
+            KeyCode::Char('r') if self.revision.index == 0 => {
                 self.set_status("already at current revision");
             }
             KeyCode::Char('F') if !self.cycle_revision_target_file() => {
@@ -756,10 +756,10 @@ impl AppState {
             Screen::Revisions => {
                 if let Some(hit) = layout.list {
                     if point_in(hit.rect, col, row) {
-                        let count = self.revision_entries.as_ref().map_or(0, |e| e.len());
+                        let count = self.revision.entries.as_ref().map_or(0, |e| e.len());
                         if let Some(idx) = hit.index_at(row, count) {
-                            self.revision_index = idx;
-                            self.revision_hscroll = 0;
+                            self.revision.index = idx;
+                            self.revision.hscroll = 0;
                             return true;
                         }
                     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -18,8 +18,9 @@ pub enum FocusPane {
     Gist,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Screen {
+    #[default]
     List,
     Diff,
     Confirm,
@@ -446,6 +447,25 @@ pub struct UploadState {
     pub gist_label: Option<String>,
 }
 
+/// Per-screen revision-history state (`Screen::Revisions`). Data only — the revision
+/// methods stay on `AppState`.
+#[derive(Debug, Clone, Default)]
+pub struct RevisionState {
+    /// Gist whose revisions are shown.
+    pub gist_id: Option<String>,
+    /// Fetched revision rows (`None` while the initial list fetch is in flight).
+    pub entries: Option<Vec<GistRevision>>,
+    /// Cursor into `entries` (0 = current head).
+    pub index: usize,
+    pub hscroll: u16,
+    /// File within the gist that preview/diff/restore target.
+    pub target_file: String,
+    /// Where `q`/`Esc` returns from `Screen::Revisions`.
+    pub return_screen: Screen,
+    /// Error from the commits-list fetch, if any.
+    pub fetch_error: Option<String>,
+}
+
 #[derive(Debug, Clone)]
 pub struct AppState {
     pub locals: Vec<LocalCandidate>,
@@ -601,19 +621,7 @@ pub struct AppState {
     pub theme_choice: crate::config::ThemeChoice,
     /// Resolved colour palette for the current theme choice (from config).
     pub theme: Theme,
-    /// Gist whose revisions are shown on `Screen::Revisions`.
-    pub revision_gist_id: Option<String>,
-    /// Fetched revision rows (`None` while the initial list fetch is in flight).
-    pub revision_entries: Option<Vec<GistRevision>>,
-    /// Cursor into `revision_entries` (0 = current head).
-    pub revision_index: usize,
-    pub revision_hscroll: u16,
-    /// File within the gist that preview/diff/restore target.
-    pub revision_target_file: String,
-    /// Where `q`/`Esc` returns from `Screen::Revisions`.
-    pub revision_return_screen: Screen,
-    /// Error from the commits-list fetch, if any.
-    pub revision_fetch_error: Option<String>,
+    pub revision: RevisionState,
 }
 
 fn unranked_gists(gists: Vec<GistFile>) -> Vec<RankedGistFile> {
@@ -1090,26 +1098,26 @@ impl AppState {
         let Some(target_file) = target_file else {
             return false;
         };
-        self.revision_gist_id = Some(gist_id);
-        self.revision_target_file = target_file;
-        self.revision_return_screen = return_screen;
-        self.revision_index = 0;
-        self.revision_hscroll = 0;
-        self.revision_entries = None;
-        self.revision_fetch_error = None;
+        self.revision.gist_id = Some(gist_id);
+        self.revision.target_file = target_file;
+        self.revision.return_screen = return_screen;
+        self.revision.index = 0;
+        self.revision.hscroll = 0;
+        self.revision.entries = None;
+        self.revision.fetch_error = None;
         self.screen = Screen::Revisions;
         true
     }
 
     pub fn selected_revision(&self) -> Option<&GistRevision> {
-        let entries = self.revision_entries.as_ref()?;
-        entries.get(self.revision_index)
+        let entries = self.revision.entries.as_ref()?;
+        entries.get(self.revision.index)
     }
 
     /// Advance `revision_target_file` to the next filename in this gist (wraps). Returns
     /// false when the gist has at most one file.
     pub fn cycle_revision_target_file(&mut self) -> bool {
-        let Some(gist_id) = self.revision_gist_id.clone() else {
+        let Some(gist_id) = self.revision.gist_id.clone() else {
             return false;
         };
         let files = self.gist_filenames(&gist_id);
@@ -1118,9 +1126,9 @@ impl AppState {
         }
         let current = files
             .iter()
-            .position(|f| f == &self.revision_target_file)
+            .position(|f| f == &self.revision.target_file)
             .unwrap_or(0);
-        self.revision_target_file = files[(current + 1) % files.len()].clone();
+        self.revision.target_file = files[(current + 1) % files.len()].clone();
         true
     }
 
@@ -1132,19 +1140,19 @@ impl AppState {
 
     /// Footer label for the revision-history target file, including `(n/total)` when multi-file.
     pub fn revision_target_file_label(&self) -> String {
-        let Some(gist_id) = self.revision_gist_id.as_deref() else {
-            return self.revision_target_file.clone();
+        let Some(gist_id) = self.revision.gist_id.as_deref() else {
+            return self.revision.target_file.clone();
         };
         let files = self.gist_filenames(gist_id);
         if files.len() <= 1 {
-            return self.revision_target_file.clone();
+            return self.revision.target_file.clone();
         }
         let pos = files
             .iter()
-            .position(|f| f == &self.revision_target_file)
+            .position(|f| f == &self.revision.target_file)
             .map(|i| i + 1)
             .unwrap_or(1);
-        format!("{} ({pos}/{})", self.revision_target_file, files.len())
+        format!("{} ({pos}/{})", self.revision.target_file, files.len())
     }
 
     pub fn group_by_id(&self, gist_id: &str) -> Option<GistGroup> {
@@ -1484,13 +1492,10 @@ pub fn initial_state() -> AppState {
         gist_star_counts: std::collections::HashMap::new(),
         theme_choice: crate::config::ThemeChoice::Dark,
         theme: Theme::DARK,
-        revision_gist_id: None,
-        revision_entries: None,
-        revision_index: 0,
-        revision_hscroll: 0,
-        revision_target_file: String::new(),
-        revision_return_screen: Screen::GistDetail,
-        revision_fetch_error: None,
+        revision: RevisionState {
+            return_screen: Screen::GistDetail,
+            ..Default::default()
+        },
     }
 }
 

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -759,9 +759,9 @@ pub(super) fn render_revisions(frame: &mut Frame, state: &AppState, layout: &mut
     let area = frame.area();
     let (ftitle, footer, colored) = if let Some(message) = &state.status {
         (String::new(), message.clone(), false)
-    } else if state.revision_entries.is_none() {
+    } else if state.revision.entries.is_none() {
         (String::new(), "Loading revisions…".to_string(), false)
-    } else if let Some(err) = &state.revision_fetch_error {
+    } else if let Some(err) = &state.revision.fetch_error {
         (String::new(), err.clone(), false)
     } else {
         (
@@ -769,7 +769,8 @@ pub(super) fn render_revisions(frame: &mut Frame, state: &AppState, layout: &mut
             {
                 let file = state.revision_target_file_label();
                 let file_key = if state
-                    .revision_gist_id
+                    .revision
+                    .gist_id
                     .as_ref()
                     .is_some_and(|id| state.gist_filenames(id).len() > 1)
                 {
@@ -790,7 +791,7 @@ pub(super) fn render_revisions(frame: &mut Frame, state: &AppState, layout: &mut
         .constraints([Constraint::Min(3), Constraint::Length(footer_lines + 1)])
         .split(area);
 
-    let gist_id = state.revision_gist_id.as_deref().unwrap_or("");
+    let gist_id = state.revision.gist_id.as_deref().unwrap_or("");
     let label = state
         .group_by_id(gist_id)
         .map(|g| {
@@ -802,14 +803,15 @@ pub(super) fn render_revisions(frame: &mut Frame, state: &AppState, layout: &mut
         })
         .unwrap_or_else(|| gist_id.to_string());
     let count = state
-        .revision_entries
+        .revision
+        .entries
         .as_ref()
         .map(|e| e.len())
         .unwrap_or(0);
     let now = unix_now();
 
     let items: Vec<ListItem> =
-        match &state.revision_entries {
+        match &state.revision.entries {
             None => vec![ListItem::new("  ⏳ Loading revisions…")
                 .style(Style::default().fg(state.theme.dim))],
             Some(entries) if entries.is_empty() => {
@@ -822,13 +824,13 @@ pub(super) fn render_revisions(frame: &mut Frame, state: &AppState, layout: &mut
                 .map(|(i, rev)| {
                     ListItem::new(hscroll_str(
                         &revision_row_label(rev, i, now),
-                        state.revision_hscroll,
+                        state.revision.hscroll,
                     ))
                 })
                 .collect(),
         };
 
-    let selected = (count > 0).then_some(state.revision_index);
+    let selected = (count > 0).then_some(state.revision.index);
     let title = format!("Revisions: {label} {}", count_label(count, count));
     let list = List::new(items)
         .block(

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -489,15 +489,16 @@ pub(super) fn run_loop(
                         state.apply_older_comments(&gist_id, result);
                     }
                     BgTaskOutcome::RevisionsFetched { gist_id, result } => {
-                        if state.revision_gist_id.as_deref() != Some(gist_id.as_str()) {
+                        if state.revision.gist_id.as_deref() != Some(gist_id.as_str()) {
                             continue;
                         }
                         match result {
                             Ok(entries) => {
-                                state.revision_fetch_error = None;
-                                state.revision_entries = Some(entries);
+                                state.revision.fetch_error = None;
+                                state.revision.entries = Some(entries);
                                 if state
-                                    .revision_entries
+                                    .revision
+                                    .entries
                                     .as_ref()
                                     .is_some_and(|e| e.len() <= 1)
                                 {
@@ -505,8 +506,8 @@ pub(super) fn run_loop(
                                 }
                             }
                             Err(error) => {
-                                state.revision_entries = Some(Vec::new());
-                                state.revision_fetch_error = Some(error);
+                                state.revision.entries = Some(Vec::new());
+                                state.revision.fetch_error = Some(error);
                             }
                         }
                     }
@@ -609,11 +610,11 @@ pub(super) fn run_loop(
                             ));
                             state.pending_action = None;
                             state.screen = Screen::Revisions;
-                            state.revision_index = 0;
-                            state.revision_entries = None;
+                            state.revision.index = 0;
+                            state.revision.entries = None;
                             state.loading = true;
                             gist_rx = Some(spawn_gist_fetch());
-                            if let Some(gist_id) = state.revision_gist_id.clone() {
+                            if let Some(gist_id) = state.revision.gist_id.clone() {
                                 spawn_bg(
                                     &mut state,
                                     &mut bg_rx,
@@ -1234,7 +1235,7 @@ pub(super) fn run_loop(
             KeyOutcome::PersistDiffContext => persist_diff_context(&mut state),
             KeyOutcome::ThemeToggle => persist_theme(&mut state),
             KeyOutcome::FetchRevisions => {
-                let Some(gist_id) = state.revision_gist_id.clone() else {
+                let Some(gist_id) = state.revision.gist_id.clone() else {
                     continue;
                 };
                 spawn_bg(&mut state, &mut bg_rx, "Loading revisions…", move || {
@@ -1247,19 +1248,20 @@ pub(super) fn run_loop(
                 });
             }
             KeyOutcome::RevisionDiffIncremental => {
-                let Some(gist_id) = state.revision_gist_id.clone() else {
+                let Some(gist_id) = state.revision.gist_id.clone() else {
                     continue;
                 };
                 let Some(child) = state.selected_revision().cloned() else {
                     continue;
                 };
-                let filename = state.revision_target_file.clone();
+                let filename = state.revision.target_file.clone();
                 let child_version = child.version.clone();
                 let child_label = revision_version_label(&child);
                 let parent = state
-                    .revision_entries
+                    .revision
+                    .entries
                     .as_ref()
-                    .and_then(|entries| entries.get(state.revision_index + 1).cloned());
+                    .and_then(|entries| entries.get(state.revision.index + 1).cloned());
                 let (parent_version, old_label) = match parent {
                     Some(parent) => {
                         let label = revision_version_label(&parent);
@@ -1285,13 +1287,13 @@ pub(super) fn run_loop(
                 });
             }
             KeyOutcome::RevisionDiff => {
-                let Some(gist_id) = state.revision_gist_id.clone() else {
+                let Some(gist_id) = state.revision.gist_id.clone() else {
                     continue;
                 };
                 let Some(revision) = state.selected_revision().cloned() else {
                     continue;
                 };
-                let filename = state.revision_target_file.clone();
+                let filename = state.revision.target_file.clone();
                 let version = revision.version.clone();
                 let version_label = revision_version_label(&revision);
                 let old_label = format!("revision {version_label}");
@@ -1316,13 +1318,13 @@ pub(super) fn run_loop(
                 });
             }
             KeyOutcome::RestoreRevisionPreview => {
-                let Some(gist_id) = state.revision_gist_id.clone() else {
+                let Some(gist_id) = state.revision.gist_id.clone() else {
                     continue;
                 };
                 let Some(revision) = state.selected_revision().cloned() else {
                     continue;
                 };
-                let filename = state.revision_target_file.clone();
+                let filename = state.revision.target_file.clone();
                 let version = revision.version.clone();
                 let version_label = revision_version_label(&revision);
                 let raw_url = state.gist_file_raw_url(&gist_id, &filename);

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -3477,9 +3477,9 @@ fn capital_h_from_list_opens_revisions_for_selected_gist_file() {
     let outcome = state.handle_key(KeyCode::Char('H'));
     assert_eq!(outcome, KeyOutcome::FetchRevisions);
     assert_eq!(state.screen, Screen::Revisions);
-    assert_eq!(state.revision_gist_id.as_deref(), Some("a"));
-    assert_eq!(state.revision_target_file, "settings.json");
-    assert_eq!(state.revision_return_screen, Screen::List);
+    assert_eq!(state.revision.gist_id.as_deref(), Some("a"));
+    assert_eq!(state.revision.target_file, "settings.json");
+    assert_eq!(state.revision.return_screen, Screen::List);
 }
 
 #[test]
@@ -3491,17 +3491,17 @@ fn capital_h_from_gist_detail_opens_revisions_and_fetches() {
     let outcome = state.handle_key(KeyCode::Char('H'));
     assert_eq!(outcome, KeyOutcome::FetchRevisions);
     assert_eq!(state.screen, Screen::Revisions);
-    assert_eq!(state.revision_gist_id.as_deref(), Some("g1"));
-    assert_eq!(state.revision_target_file, "b.txt");
-    assert_eq!(state.revision_return_screen, Screen::GistDetail);
-    assert!(state.revision_entries.is_none());
+    assert_eq!(state.revision.gist_id.as_deref(), Some("g1"));
+    assert_eq!(state.revision.target_file, "b.txt");
+    assert_eq!(state.revision.return_screen, Screen::GistDetail);
+    assert!(state.revision.entries.is_none());
 }
 
 #[test]
 fn revisions_r_on_head_is_blocked() {
     let mut state = state_with_gists();
     state.screen = Screen::Revisions;
-    state.revision_entries = Some(vec![crate::domain::GistRevision {
+    state.revision.entries = Some(vec![crate::domain::GistRevision {
         version: "abc".into(),
         committed_at: "2026-06-10T00:00:00Z".into(),
         user: "u".into(),
@@ -3522,8 +3522,8 @@ fn revisions_r_on_head_is_blocked() {
 fn revisions_capital_d_on_current_shows_status() {
     let mut state = state_with_gists();
     state.screen = Screen::Revisions;
-    state.revision_index = 0;
-    state.revision_entries = Some(vec![
+    state.revision.index = 0;
+    state.revision.entries = Some(vec![
         crate::domain::GistRevision {
             version: "v2".into(),
             committed_at: "2026-06-10T00:00:00Z".into(),
@@ -3547,7 +3547,7 @@ fn revisions_capital_d_on_current_shows_status() {
     ]);
     assert_eq!(state.handle_key(KeyCode::Char('D')), KeyOutcome::None);
     assert_eq!(state.status.as_deref(), Some("already at current revision"));
-    state.revision_index = 1;
+    state.revision.index = 1;
     assert_eq!(
         state.handle_key(KeyCode::Char('D')),
         KeyOutcome::RevisionDiff
@@ -3558,8 +3558,8 @@ fn revisions_capital_d_on_current_shows_status() {
 fn revisions_enter_triggers_incremental_diff() {
     let mut state = state_with_gists();
     state.screen = Screen::Revisions;
-    state.revision_index = 0;
-    state.revision_entries = Some(vec![
+    state.revision.index = 0;
+    state.revision.entries = Some(vec![
         crate::domain::GistRevision {
             version: "v2".into(),
             committed_at: "2026-06-10T00:00:00Z".into(),
@@ -3585,7 +3585,7 @@ fn revisions_enter_triggers_incremental_diff() {
         state.handle_key(KeyCode::Enter),
         KeyOutcome::RevisionDiffIncremental
     );
-    state.revision_index = 1;
+    state.revision.index = 1;
     assert_eq!(
         state.handle_key(KeyCode::Enter),
         KeyOutcome::RevisionDiffIncremental
@@ -3609,13 +3609,13 @@ fn revision_diff_omits_download_upload() {
 fn revisions_capital_f_cycles_target_file() {
     let mut state = state_with_gists();
     state.screen = Screen::Revisions;
-    state.revision_gist_id = Some("g1".into());
-    state.revision_target_file = "a.txt".into();
-    state.revision_entries = Some(vec![]);
+    state.revision.gist_id = Some("g1".into());
+    state.revision.target_file = "a.txt".into();
+    state.revision.entries = Some(vec![]);
     state.handle_key(KeyCode::Char('F'));
-    assert_eq!(state.revision_target_file, "b.txt");
+    assert_eq!(state.revision.target_file, "b.txt");
     state.handle_key(KeyCode::Char('F'));
-    assert_eq!(state.revision_target_file, "a.txt");
+    assert_eq!(state.revision.target_file, "a.txt");
     assert_eq!(state.revision_target_file_label(), "a.txt (1/2)");
 }
 
@@ -3639,9 +3639,9 @@ fn revisions_capital_f_on_single_file_gist_shows_status() {
         node_id: None,
     }];
     state.screen = Screen::Revisions;
-    state.revision_gist_id = Some("g1".into());
-    state.revision_target_file = "only.txt".into();
-    state.revision_entries = Some(vec![]);
+    state.revision.gist_id = Some("g1".into());
+    state.revision.target_file = "only.txt".into();
+    state.revision.entries = Some(vec![]);
     state.handle_key(KeyCode::Char('F'));
     assert_eq!(state.status.as_deref(), Some("only one file in this gist"));
 }
@@ -4546,8 +4546,8 @@ fn pins_click_selects_and_double_click_matches_enter() {
 fn revisions_click_selects_and_double_click_matches_enter() {
     let mut state = state_with_gists();
     state.screen = Screen::Revisions;
-    state.revision_index = 0;
-    state.revision_entries = Some(vec![
+    state.revision.index = 0;
+    state.revision.entries = Some(vec![
         crate::domain::GistRevision {
             version: "v2".into(),
             committed_at: "2026-06-10T00:00:00Z".into(),
@@ -4579,7 +4579,7 @@ fn revisions_click_selects_and_double_click_matches_enter() {
     };
     let out = state.handle_mouse(MouseInput::Click { col: 5, row: 2 }, &layout);
     assert_eq!(out, KeyOutcome::None);
-    assert_eq!(state.revision_index, 1);
+    assert_eq!(state.revision.index, 1);
     let mut by_key = state.clone();
     let key_out = by_key.handle_key(KeyCode::Enter);
     let by_mouse = state.handle_mouse(MouseInput::DoubleClick { col: 5, row: 2 }, &layout);


### PR DESCRIPTION
Increment 2 of the incremental `AppState` decomposition (#163).

The seven `revision_*` fields move into a data-only `RevisionState` (prefix dropped), accessed as `self.revision.<field>`. Methods stay on `AppState`; no semantic change.

**One enabling change:** `Screen` now derives `Default` with `#[default] List` (its natural startup screen, already `initial_state`'s value). This lets `RevisionState` derive `Default` while `initial_state` overrides only the non-default `return_screen: Screen::GistDetail` via struct-update — and unblocks the later `*_return_screen`-bearing groups (Help, Detail) the same way.

Rename was done with `perl` anchored on `.revision_X` (BSD `sed` lacks `\b`; precise anchor avoids touching the doc-comment/method-name mentions among the 111 sites).

Pure refactor → **no new tests**; **441 tests, baseline-identical**, fmt/clippy `-D warnings`/check green. `skip-changelog`.

Refs #163