### PR TITLE
refactor(tui): group help_* fields into HelpState (AppState decomp 3/N)

### DIFF
--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -85,10 +85,10 @@ impl AppState {
 
     /// Open the Help screen on the topic for the current screen, remembering where to return.
     fn open_help(&mut self) {
-        self.help_return = self.screen;
-        self.help_topic = HelpTopic::for_screen(self.screen);
-        self.help_index_open = false;
-        self.help_scroll = 0;
+        self.help.return_screen = self.screen;
+        self.help.topic = HelpTopic::for_screen(self.screen);
+        self.help.index_open = false;
+        self.help.scroll = 0;
         self.screen = Screen::Help;
     }
 
@@ -109,14 +109,14 @@ impl AppState {
         match self.screen {
             Screen::Help => {
                 let topics = HelpTopic::all();
-                if self.help_index_open {
+                if self.help.index_open {
                     match action {
                         NavAction::Up => {
-                            self.help_index_sel = self.help_index_sel.saturating_sub(1)
+                            self.help.index_sel = self.help.index_sel.saturating_sub(1)
                         }
                         NavAction::Down => {
-                            if self.help_index_sel + 1 < topics.len() {
-                                self.help_index_sel += 1;
+                            if self.help.index_sel + 1 < topics.len() {
+                                self.help.index_sel += 1;
                             }
                         }
                         _ => return false,
@@ -124,16 +124,16 @@ impl AppState {
                 } else {
                     match action {
                         NavAction::Up => {
-                            self.help_scroll = self.help_scroll.saturating_sub(1);
+                            self.help.scroll = self.help.scroll.saturating_sub(1);
                         }
                         NavAction::Down => {
-                            self.help_scroll = self.help_scroll.saturating_add(1);
+                            self.help.scroll = self.help.scroll.saturating_add(1);
                         }
                         NavAction::PageUp => {
-                            self.help_scroll = self.help_scroll.saturating_sub(PAGE_SCROLL);
+                            self.help.scroll = self.help.scroll.saturating_sub(PAGE_SCROLL);
                         }
                         NavAction::PageDown => {
-                            self.help_scroll = self.help_scroll.saturating_add(PAGE_SCROLL);
+                            self.help.scroll = self.help.scroll.saturating_add(PAGE_SCROLL);
                         }
                         _ => return false,
                     }
@@ -295,41 +295,41 @@ impl AppState {
 
     fn handle_key_help(&mut self, code: KeyCode) -> KeyOutcome {
         let topics = HelpTopic::all();
-        if self.help_index_open {
+        if self.help.index_open {
             match code {
                 KeyCode::Enter => {
-                    self.help_topic = topics[self.help_index_sel];
-                    self.help_index_open = false;
-                    self.help_scroll = 0;
+                    self.help.topic = topics[self.help.index_sel];
+                    self.help.index_open = false;
+                    self.help.scroll = 0;
                 }
                 KeyCode::Char(c @ '1'..='9') if (c as u8 - b'1') < topics.len() as u8 => {
-                    self.help_topic = topics[(c as u8 - b'1') as usize];
-                    self.help_index_open = false;
-                    self.help_scroll = 0;
+                    self.help.topic = topics[(c as u8 - b'1') as usize];
+                    self.help.index_open = false;
+                    self.help.scroll = 0;
                 }
                 KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => {
-                    self.screen = self.help_return;
-                    self.help_index_open = false;
-                    self.help_scroll = 0;
+                    self.screen = self.help.return_screen;
+                    self.help.index_open = false;
+                    self.help.scroll = 0;
                 }
                 _ => {}
             }
         } else {
             match code {
                 KeyCode::Tab => {
-                    self.help_index_sel = topics
+                    self.help.index_sel = topics
                         .iter()
-                        .position(|&t| t == self.help_topic)
+                        .position(|&t| t == self.help.topic)
                         .unwrap_or(0);
-                    self.help_index_open = true;
+                    self.help.index_open = true;
                 }
                 KeyCode::Char(c @ '1'..='9') if (c as u8 - b'1') < topics.len() as u8 => {
-                    self.help_topic = topics[(c as u8 - b'1') as usize];
-                    self.help_scroll = 0;
+                    self.help.topic = topics[(c as u8 - b'1') as usize];
+                    self.help.scroll = 0;
                 }
                 KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => {
-                    self.screen = self.help_return;
-                    self.help_scroll = 0;
+                    self.screen = self.help.return_screen;
+                    self.help.scroll = 0;
                 }
                 _ => {}
             }
@@ -685,7 +685,7 @@ impl AppState {
             // GistDetail: the comments body scrolls like content (3 lines); the file list
             // steps one file at a time.
             Screen::GistDetail if self.detail_focus == DetailFocus::Comments => 3,
-            Screen::Help if !self.help_index_open => 3, // help body scrolls; topic index is a list
+            Screen::Help if !self.help.index_open => 3, // help body scrolls; topic index is a list
             _ => 1, // List/Pins/Gists/Revisions/Help index/GistDetail Files
         }
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -35,8 +35,9 @@ pub enum Screen {
 }
 
 /// A help topic — one per key-dense area. Ordered for the index list and `1`-`8` quick-jump.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum HelpTopic {
+    #[default]
     List,
     Pins,
     GistManager,
@@ -466,6 +467,20 @@ pub struct RevisionState {
     pub fetch_error: Option<String>,
 }
 
+/// Per-screen Help-view state (`Screen::Help`). Data only — the help methods stay on `AppState`.
+#[derive(Debug, Clone, Default)]
+pub struct HelpState {
+    pub scroll: u16,
+    /// Screen to return to when leaving Help (mirrors `preview_return` / `diff_return`).
+    pub return_screen: Screen,
+    /// The topic shown in the Help screen's topic view.
+    pub topic: HelpTopic,
+    /// When true the Help screen shows the topic index instead of a topic body.
+    pub index_open: bool,
+    /// Highlighted row in the Help topic index.
+    pub index_sel: usize,
+}
+
 #[derive(Debug, Clone)]
 pub struct AppState {
     pub locals: Vec<LocalCandidate>,
@@ -566,15 +581,7 @@ pub struct AppState {
     /// Set after the first `q`/`Esc` on the main list; a second press confirms the quit. Any
     /// other key clears it. Prevents an accidental single-key exit.
     pub quit_armed: bool,
-    pub help_scroll: u16,
-    /// Screen to return to when leaving Help (mirrors `preview_return` / `diff_return`).
-    pub help_return: Screen,
-    /// The topic shown in the Help screen's topic view.
-    pub help_topic: HelpTopic,
-    /// When true the Help screen shows the topic index instead of a topic body.
-    pub help_index_open: bool,
-    /// Highlighted row in the Help topic index.
-    pub help_index_sel: usize,
+    pub help: HelpState,
     pub upload: UploadState,
     /// gist_id of the active download (set when entering the diff Confirm for a pull).
     pub download_gist_id: Option<String>,
@@ -1465,11 +1472,7 @@ pub fn initial_state() -> AppState {
         description_input: TextInput::default(),
         bg_task_msg: None,
         quit_armed: false,
-        help_scroll: 0,
-        help_return: Screen::List,
-        help_topic: HelpTopic::List,
-        help_index_open: false,
-        help_index_sel: 0,
+        help: HelpState::default(),
         upload: UploadState::default(),
         download_gist_id: None,
         download_gist_filename: None,

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -223,7 +223,7 @@ Mouse (on by default; disable with mouse = false in config or --no-mouse)
 }
 
 pub(super) fn render_help(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout) {
-    if state.help_index_open {
+    if state.help.index_open {
         let items: Vec<ListItem> = HelpTopic::all()
             .iter()
             .enumerate()
@@ -247,17 +247,17 @@ pub(super) fn render_help(frame: &mut Frame, state: &AppState, layout: &mut Mous
             )
             .highlight_symbol("▶ ");
         let mut list_state = ListState::default();
-        list_state.select(Some(state.help_index_sel));
+        list_state.select(Some(state.help.index_sel));
         frame.render_stateful_widget(list, frame.area(), &mut list_state);
     } else {
         let title = format!(
             "Help · {} — Tab topics · ↑↓ scroll · Esc back",
-            state.help_topic.title()
+            state.help.topic.title()
         );
         frame.render_widget(
-            Paragraph::new(help_topic_body(state.help_topic))
+            Paragraph::new(help_topic_body(state.help.topic))
                 .style(state.theme.base_style())
-                .scroll((state.help_scroll, 0))
+                .scroll((state.help.scroll, 0))
                 .block(
                     Block::default()
                         .title(title)

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1174,21 +1174,21 @@ fn question_opens_contextual_help_from_list() {
     let mut state = initial_state();
     state.handle_key(KeyCode::Char('?'));
     assert_eq!(state.screen, Screen::Help);
-    assert_eq!(state.help_topic, HelpTopic::List);
-    assert_eq!(state.help_return, Screen::List);
-    assert!(!state.help_index_open);
+    assert_eq!(state.help.topic, HelpTopic::List);
+    assert_eq!(state.help.return_screen, Screen::List);
+    assert!(!state.help.index_open);
     // Arrow keys scroll help
     state.handle_key(KeyCode::Down);
     assert_eq!(state.screen, Screen::Help);
-    assert_eq!(state.help_scroll, 1);
+    assert_eq!(state.help.scroll, 1);
     state.handle_key(KeyCode::Up);
     assert_eq!(state.screen, Screen::Help);
-    assert_eq!(state.help_scroll, 0);
+    assert_eq!(state.help.scroll, 0);
     // Esc closes help and resets scroll
-    state.help_scroll = 5;
+    state.help.scroll = 5;
     state.handle_key(KeyCode::Esc);
     assert_eq!(state.screen, Screen::List);
-    assert_eq!(state.help_scroll, 0);
+    assert_eq!(state.help.scroll, 0);
 }
 
 #[test]
@@ -3797,38 +3797,38 @@ fn question_mark_opens_contextual_help_from_pins() {
     state.screen = Screen::Pins;
     state.handle_key(KeyCode::Char('?'));
     assert_eq!(state.screen, Screen::Help);
-    assert_eq!(state.help_topic, HelpTopic::Pins);
-    assert_eq!(state.help_return, Screen::Pins);
-    assert!(!state.help_index_open);
+    assert_eq!(state.help.topic, HelpTopic::Pins);
+    assert_eq!(state.help.return_screen, Screen::Pins);
+    assert!(!state.help.index_open);
 }
 
 #[test]
 fn help_topic_view_tab_opens_index_at_current_topic() {
     let mut state = initial_state();
     state.screen = Screen::Help;
-    state.help_topic = HelpTopic::GistManager; // index 2
+    state.help.topic = HelpTopic::GistManager; // index 2
     state.handle_key(KeyCode::Tab);
-    assert!(state.help_index_open);
-    assert_eq!(state.help_index_sel, 2);
+    assert!(state.help.index_open);
+    assert_eq!(state.help.index_sel, 2);
 }
 
 #[test]
 fn help_topic_view_number_switches_topic() {
     let mut state = initial_state();
     state.screen = Screen::Help;
-    state.help_topic = HelpTopic::List;
-    state.help_scroll = 5;
+    state.help.topic = HelpTopic::List;
+    state.help.scroll = 5;
     state.handle_key(KeyCode::Char('2')); // 2 -> Pins (index 1)
-    assert_eq!(state.help_topic, HelpTopic::Pins);
-    assert_eq!(state.help_scroll, 0);
-    assert!(!state.help_index_open);
+    assert_eq!(state.help.topic, HelpTopic::Pins);
+    assert_eq!(state.help.scroll, 0);
+    assert!(!state.help.index_open);
 }
 
 #[test]
 fn help_topic_view_esc_returns_to_origin() {
     let mut state = initial_state();
     state.screen = Screen::Help;
-    state.help_return = Screen::Gists;
+    state.help.return_screen = Screen::Gists;
     state.handle_key(KeyCode::Esc);
     assert_eq!(state.screen, Screen::Gists);
 }
@@ -3837,36 +3837,36 @@ fn help_topic_view_esc_returns_to_origin() {
 fn help_index_navigates_and_enter_opens_topic() {
     let mut state = initial_state();
     state.screen = Screen::Help;
-    state.help_index_open = true;
-    state.help_index_sel = 0;
+    state.help.index_open = true;
+    state.help.index_sel = 0;
     state.handle_key(KeyCode::Down); // -> 1
     state.handle_key(KeyCode::Down); // -> 2 (GistManager)
-    assert_eq!(state.help_index_sel, 2);
+    assert_eq!(state.help.index_sel, 2);
     state.handle_key(KeyCode::Enter);
-    assert!(!state.help_index_open);
-    assert_eq!(state.help_topic, HelpTopic::GistManager);
+    assert!(!state.help.index_open);
+    assert_eq!(state.help.topic, HelpTopic::GistManager);
 }
 
 #[test]
 fn help_index_esc_returns_to_origin() {
     let mut state = initial_state();
     state.screen = Screen::Help;
-    state.help_index_open = true;
-    state.help_return = Screen::List;
+    state.help.index_open = true;
+    state.help.return_screen = Screen::List;
     state.handle_key(KeyCode::Esc);
     assert_eq!(state.screen, Screen::List);
-    assert!(!state.help_index_open);
+    assert!(!state.help.index_open);
 }
 
 #[test]
 fn help_index_question_mark_exits_help() {
     let mut state = initial_state();
     state.screen = Screen::Help;
-    state.help_index_open = true;
-    state.help_return = Screen::Pins;
+    state.help.index_open = true;
+    state.help.return_screen = Screen::Pins;
     state.handle_key(KeyCode::Char('?'));
     assert_eq!(state.screen, Screen::Pins);
-    assert!(!state.help_index_open);
+    assert!(!state.help.index_open);
 }
 
 #[test]
@@ -4271,7 +4271,7 @@ fn scroll_up_moves_content_three_lines() {
 fn close_button_click_returns_from_help() {
     let mut state = state_with_gists();
     // Simulate entering Help (mirrors what open_help() does).
-    state.help_return = Screen::List;
+    state.help.return_screen = Screen::List;
     state.screen = Screen::Help;
     let layout = MouseLayout {
         close_button: Some(Rect::new(36, 0, 5, 1)),
@@ -4285,7 +4285,7 @@ fn close_button_click_returns_from_help() {
 #[test]
 fn close_button_click_outside_is_noop() {
     let mut state = state_with_gists();
-    state.help_return = Screen::List;
+    state.help.return_screen = Screen::List;
     state.screen = Screen::Help;
     let layout = MouseLayout {
         close_button: Some(Rect::new(36, 0, 5, 1)),
@@ -4386,7 +4386,7 @@ fn click_in_pane_blank_focuses_without_selecting() {
 #[test]
 fn click_off_list_screen_is_noop() {
     let mut state = state_with_gists();
-    state.help_return = Screen::List;
+    state.help.return_screen = Screen::List;
     state.screen = Screen::Help;
     let hit = PaneHit {
         rect: Rect::new(20, 0, 20, 10),
@@ -4481,10 +4481,10 @@ fn wheel_step_help_body_moves_three() {
     // Help body (help_index_open = false): one scroll-down tick must advance help_scroll by 3.
     let mut state = initial_state();
     state.screen = Screen::Help;
-    state.help_index_open = false;
-    state.help_scroll = 0;
+    state.help.index_open = false;
+    state.help.scroll = 0;
     state.handle_mouse(MouseInput::ScrollDown, &MouseLayout::default());
-    assert_eq!(state.help_scroll, 3);
+    assert_eq!(state.help.scroll, 3);
 }
 
 #[test]
@@ -4492,10 +4492,10 @@ fn wheel_step_help_index_moves_one() {
     // Help topic index (help_index_open = true): one scroll-down tick must move index by 1.
     let mut state = initial_state();
     state.screen = Screen::Help;
-    state.help_index_open = true;
-    state.help_index_sel = 0;
+    state.help.index_open = true;
+    state.help.index_sel = 0;
     state.handle_mouse(MouseInput::ScrollDown, &MouseLayout::default());
-    assert_eq!(state.help_index_sel, 1);
+    assert_eq!(state.help.index_sel, 1);
 }
 
 #[test]


### PR DESCRIPTION
Increment 3 of the incremental `AppState` decomposition (#163).

The five `help_*` fields move into a data-only `HelpState`, accessed as `self.help.<field>` (`help_return` → `help.return_screen`, since `return` is a Rust keyword). `HelpTopic` now derives `Default` (`#[default] List` — its natural default, first in `all()` and the `for_screen` fallback), so all five help initial values are type-defaults and `initial_state` is just `HelpState::default()`.

Methods stay on `AppState`; no semantic change. Pure refactor → **no new tests**; **441 tests, baseline-identical**, fmt/clippy `-D warnings`/check green. `skip-changelog`.

Refs #163