### PR TITLE
refactor(tui): group pins_* fields into PinsState (AppState decomp 4/N)

### DIFF
--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -52,7 +52,7 @@ impl AppState {
         if code == KeyCode::Char('T')
             && theme_toggle_modifiers_ok(modifiers)
             && !self.filtering
-            && !self.pins_filtering
+            && !self.pins.filtering
             && !self.gists_filtering
             && !self.editing_description
         {
@@ -101,7 +101,7 @@ impl AppState {
         }
         // While filtering, arrows/hjkl are typed or handled in the filter branches; page keys
         // still jump the live selection by PAGE_SCROLL.
-        if (self.filtering || self.pins_filtering || self.gists_filtering)
+        if (self.filtering || self.pins.filtering || self.gists_filtering)
             && !matches!(action, NavAction::PageUp | NavAction::PageDown)
         {
             return false;
@@ -144,33 +144,33 @@ impl AppState {
                 let len = self.visible_pin_indices().len();
                 match action {
                     NavAction::Down => {
-                        if self.pins_index + 1 < len {
-                            self.pins_index += 1;
-                            self.pins_hscroll = 0;
+                        if self.pins.index + 1 < len {
+                            self.pins.index += 1;
+                            self.pins.hscroll = 0;
                         }
                     }
                     NavAction::Up => {
-                        if self.pins_index > 0 {
-                            self.pins_index -= 1;
-                            self.pins_hscroll = 0;
+                        if self.pins.index > 0 {
+                            self.pins.index -= 1;
+                            self.pins.hscroll = 0;
                         }
                     }
                     NavAction::Right => {
-                        self.pins_hscroll = (self.pins_hscroll + 1).min(self.pins_hscroll_max());
+                        self.pins.hscroll = (self.pins.hscroll + 1).min(self.pins_hscroll_max());
                     }
                     NavAction::Left => {
-                        self.pins_hscroll = self.pins_hscroll.saturating_sub(1);
+                        self.pins.hscroll = self.pins.hscroll.saturating_sub(1);
                     }
                     NavAction::PageDown => {
                         if len > 0 {
                             let max = len - 1;
-                            self.pins_index = (self.pins_index + PAGE_SCROLL as usize).min(max);
-                            self.pins_hscroll = 0;
+                            self.pins.index = (self.pins.index + PAGE_SCROLL as usize).min(max);
+                            self.pins.hscroll = 0;
                         }
                     }
                     NavAction::PageUp => {
-                        self.pins_index = self.pins_index.saturating_sub(PAGE_SCROLL as usize);
-                        self.pins_hscroll = 0;
+                        self.pins.index = self.pins.index.saturating_sub(PAGE_SCROLL as usize);
+                        self.pins.hscroll = 0;
                     }
                 }
                 true
@@ -342,30 +342,30 @@ impl AppState {
         // key may set a fresh one afterwards (e.g. "already in sync").
         self.status = None;
         // Inline text filter: live-navigate with arrows; Tab is a no-op (single pane).
-        if self.pins_filtering {
+        if self.pins.filtering {
             match code {
-                KeyCode::Up if self.pins_index > 0 => {
-                    self.pins_index -= 1;
-                    self.pins_hscroll = 0;
+                KeyCode::Up if self.pins.index > 0 => {
+                    self.pins.index -= 1;
+                    self.pins.hscroll = 0;
                 }
                 KeyCode::Up => {}
                 KeyCode::Down => {
-                    if self.pins_index + 1 < self.visible_pin_indices().len() {
-                        self.pins_index += 1;
-                        self.pins_hscroll = 0;
+                    if self.pins.index + 1 < self.visible_pin_indices().len() {
+                        self.pins.index += 1;
+                        self.pins.hscroll = 0;
                     }
                 }
-                _ => match apply_filter_edit(code, &mut self.pins_filter_query) {
+                _ => match apply_filter_edit(code, &mut self.pins.filter_query) {
                     FilterKey::Edited => {
-                        self.pins_index = 0;
-                        self.pins_hscroll = 0;
+                        self.pins.index = 0;
+                        self.pins.hscroll = 0;
                     }
                     FilterKey::Cleared => {
-                        self.pins_filtering = false;
-                        self.pins_index = 0;
-                        self.pins_hscroll = 0;
+                        self.pins.filtering = false;
+                        self.pins.index = 0;
+                        self.pins.hscroll = 0;
                     }
-                    FilterKey::Exited => self.pins_filtering = false,
+                    FilterKey::Exited => self.pins.filtering = false,
                     FilterKey::Moved | FilterKey::Pass => {}
                 },
             }
@@ -373,7 +373,7 @@ impl AppState {
         }
         match code {
             KeyCode::Char('q') | KeyCode::Esc => self.screen = Screen::List,
-            KeyCode::Char('/') => self.pins_filtering = true,
+            KeyCode::Char('/') => self.pins.filtering = true,
             KeyCode::Enter if !self.pinned.is_empty() => {
                 if let Some(idx) = self.selected_pin_index() {
                     let (gist_id, gist_filename, local_path) = {
@@ -399,9 +399,9 @@ impl AppState {
             KeyCode::Char('u') if !self.pinned.is_empty() => return KeyOutcome::SyncPinPush,
             KeyCode::Char('d') if !self.pinned.is_empty() => return KeyOutcome::SyncPinPull,
             KeyCode::Char('o') => {
-                self.pins_sort = self.pins_sort.next();
-                self.pins_index = 0;
-                self.pins_hscroll = 0;
+                self.pins.sort = self.pins.sort.next();
+                self.pins.index = 0;
+                self.pins.hscroll = 0;
             }
             KeyCode::Char('?') => self.open_help(),
             _ => {}
@@ -745,8 +745,8 @@ impl AppState {
                 if let Some(hit) = layout.list {
                     if point_in(hit.rect, col, row) {
                         if let Some(idx) = hit.index_at(row, self.visible_pin_indices().len()) {
-                            self.pins_index = idx;
-                            self.pins_hscroll = 0;
+                            self.pins.index = idx;
+                            self.pins.hscroll = 0;
                             return true;
                         }
                     }
@@ -1061,8 +1061,8 @@ impl AppState {
             KeyCode::Char('y') => return KeyOutcome::CopyGistUrl,
             KeyCode::Char('?') => self.open_help(),
             KeyCode::Char('P') => {
-                self.pins_index = 0;
-                self.pins_hscroll = 0;
+                self.pins.index = 0;
+                self.pins.hscroll = 0;
                 self.screen = Screen::Pins;
             }
             KeyCode::Char('S') => return KeyOutcome::SyncSelectedPair,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -225,6 +225,13 @@ cycling_enum! {
     }
 }
 
+impl Default for PinSort {
+    /// The `Default` variant (config/insertion order) is the natural default.
+    fn default() -> Self {
+        PinSort::Default
+    }
+}
+
 impl GistSort {
     /// Re-orders ranked gists. `Match` keeps the incoming order; the others override it.
     fn apply(self, gists: &mut [RankedGistFile]) {
@@ -481,6 +488,16 @@ pub struct HelpState {
     pub index_sel: usize,
 }
 
+/// Pins-screen state (`Screen::Pins`). Data only — the pins methods stay on `AppState`.
+#[derive(Debug, Clone, Default)]
+pub struct PinsState {
+    pub index: usize,
+    pub hscroll: u16,
+    pub filtering: bool,
+    pub filter_query: TextInput,
+    pub sort: PinSort,
+}
+
 #[derive(Debug, Clone)]
 pub struct AppState {
     pub locals: Vec<LocalCandidate>,
@@ -564,11 +581,7 @@ pub struct AppState {
     pub skip_dirs: Vec<String>,
     pub scan_depth: u32,
     pub local_scanning: bool,
-    pub pins_index: usize,
-    pub pins_hscroll: u16,
-    pub pins_filtering: bool,
-    pub pins_filter_query: TextInput,
-    pub pins_sort: PinSort,
+    pub pins: PinsState,
     pub gists_index: usize,
     pub gists_hscroll: u16,
     pub gists_sort: GistGroupSort,
@@ -959,7 +972,7 @@ impl AppState {
     /// Empty query → every index. Matched against the cwd/home-shortened local path plus
     /// the gist filename (the meaningful, visible parts of the row).
     pub fn visible_pin_indices(&self) -> Vec<usize> {
-        let query = self.pins_filter_query.to_lowercase();
+        let query = self.pins.filter_query.to_lowercase();
         let mut indices: Vec<usize> = self
             .pinned
             .iter()
@@ -978,7 +991,7 @@ impl AppState {
             })
             .map(|(i, _)| i)
             .collect();
-        match self.pins_sort {
+        match self.pins.sort {
             PinSort::Default => {}
             PinSort::Local => indices.sort_by(|&a, &b| {
                 crate::config::display_path(&self.pinned[a].local_path)
@@ -996,7 +1009,7 @@ impl AppState {
     /// The true `self.pinned` index of the currently selected Pins row (selection is a
     /// position within the filtered view).
     pub fn selected_pin_index(&self) -> Option<usize> {
-        self.visible_pin_indices().get(self.pins_index).copied()
+        self.visible_pin_indices().get(self.pins.index).copied()
     }
 
     /// Number of files the given gist holds in the current in-memory list. Used to guard
@@ -1457,11 +1470,7 @@ pub fn initial_state() -> AppState {
         skip_dirs: crate::config::AppConfig::default().skip_dirs,
         scan_depth: crate::config::AppConfig::default().scan_depth,
         local_scanning: false,
-        pins_index: 0,
-        pins_hscroll: 0,
-        pins_filtering: false,
-        pins_filter_query: TextInput::default(),
-        pins_sort: PinSort::Default,
+        pins: PinsState::default(),
         gists_index: 0,
         gists_hscroll: 0,
         gists_sort: GistGroupSort::Updated,

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -376,10 +376,10 @@ pub(super) fn render_pins(frame: &mut Frame, state: &AppState, layout: &mut Mous
     } else {
         "↑↓ move · ←→ scroll · / filter · o sort · Enter diff · s sync · u push · d pull · x unpin · ? help  ·  ✓ synced ↑ local-newer ↓ remote-newer ? n/a  ·  Esc/q back"
     };
-    let (ftitle, footer, colored) = if state.pins_filtering {
+    let (ftitle, footer, colored) = if state.pins.filtering {
         (
             "Filter (↑↓ move · Enter apply · Esc clear)".to_string(),
-            format!("/{}_", state.pins_filter_query),
+            format!("/{}_", state.pins.filter_query),
             false,
         )
     } else {
@@ -424,22 +424,22 @@ pub(super) fn render_pins(frame: &mut Frame, state: &AppState, layout: &mut Mous
                         &age(lts),
                         &age(rts),
                     ),
-                    state.pins_hscroll,
+                    state.pins.hscroll,
                 ))
             })
             .collect()
     };
 
-    let selected = (!visible.is_empty()).then_some(state.pins_index);
+    let selected = (!visible.is_empty()).then_some(state.pins.index);
     let mut title = format!(
         "Pinned Mappings {}",
         count_label(visible.len(), state.pinned.len())
     );
-    if !state.pins_filter_query.is_empty() {
-        title.push_str(&format!(" · /{}", state.pins_filter_query));
+    if !state.pins.filter_query.is_empty() {
+        title.push_str(&format!(" · /{}", state.pins.filter_query));
     }
-    if state.pins_sort != crate::tui::PinSort::Default {
-        title.push_str(&format!(" · sort:{}", state.pins_sort.label()));
+    if state.pins.sort != crate::tui::PinSort::Default {
+        title.push_str(&format!(" · sort:{}", state.pins.sort.label()));
     }
     let list = List::new(items)
         .block(
@@ -470,12 +470,12 @@ pub(super) fn render_pins(frame: &mut Frame, state: &AppState, layout: &mut Mous
         });
     }
 
-    if state.pins_filtering {
+    if state.pins.filtering {
         render_footer_line(
             frame,
             chunks[1],
             &ftitle,
-            input_line("/", &state.pins_filter_query, ""),
+            input_line("/", &state.pins.filter_query, ""),
             &state.theme,
         );
     } else {

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -2270,8 +2270,9 @@ fn unpin_at_pin_index(state: &mut AppState) {
             state.pinned = config.pinned;
             state.skip_dirs = config.skip_dirs;
             state.scan_depth = config.scan_depth;
-            state.pins_index = state
-                .pins_index
+            state.pins.index = state
+                .pins
+                .index
                 .min(state.visible_pin_indices().len().saturating_sub(1));
             refresh_locals(state);
             state.set_status(format!("Unpinned {label}"));

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -2878,13 +2878,13 @@ fn pins_state_with_long_home_path() -> AppState {
         direction: None,
         last_seen_hash: None,
     }];
-    state.pins_index = 0;
+    state.pins.index = 0;
     state
 }
 
 #[test]
 fn pins_hscroll_starts_at_zero() {
-    assert_eq!(initial_state().pins_hscroll, 0);
+    assert_eq!(initial_state().pins.hscroll, 0);
 }
 
 #[test]
@@ -2953,14 +2953,14 @@ fn pin_row_label_shows_home_as_tilde() {
 fn pins_right_scrolls_then_clamps_at_a_bound() {
     let mut state = pins_state_with_long_home_path();
     state.handle_key(KeyCode::Right);
-    assert_eq!(state.pins_hscroll, 1, "Right should advance the scroll");
+    assert_eq!(state.pins.hscroll, 1, "Right should advance the scroll");
     // Far past the end clamps to a stable maximum (does not run away).
     for _ in 0..500 {
         state.handle_key(KeyCode::Right);
     }
-    let clamped = state.pins_hscroll;
+    let clamped = state.pins.hscroll;
     state.handle_key(KeyCode::Right);
-    assert_eq!(state.pins_hscroll, clamped, "scroll must clamp at its max");
+    assert_eq!(state.pins.hscroll, clamped, "scroll must clamp at its max");
     assert!(clamped > 0, "a long path must be scrollable");
 }
 
@@ -2970,7 +2970,7 @@ fn pins_left_clamps_at_zero() {
     state.handle_key(KeyCode::Right);
     state.handle_key(KeyCode::Left);
     state.handle_key(KeyCode::Left);
-    assert_eq!(state.pins_hscroll, 0);
+    assert_eq!(state.pins.hscroll, 0);
 }
 
 #[test]
@@ -2984,20 +2984,20 @@ fn pins_hscroll_resets_when_selection_moves() {
         last_seen_hash: None,
     });
     state.handle_key(KeyCode::Right);
-    assert!(state.pins_hscroll > 0);
+    assert!(state.pins.hscroll > 0);
     state.handle_key(KeyCode::Down);
-    assert_eq!(state.pins_hscroll, 0, "moving selection resets hscroll");
+    assert_eq!(state.pins.hscroll, 0, "moving selection resets hscroll");
 }
 
 #[test]
 fn entering_pins_screen_resets_hscroll() {
     let mut state = pins_state_with_long_home_path();
     state.handle_key(KeyCode::Right);
-    assert!(state.pins_hscroll > 0);
+    assert!(state.pins.hscroll > 0);
     state.screen = Screen::List;
     state.handle_key(KeyCode::Char('P'));
     assert_eq!(state.screen, Screen::Pins);
-    assert_eq!(state.pins_hscroll, 0);
+    assert_eq!(state.pins.hscroll, 0);
 }
 
 #[test]
@@ -3378,10 +3378,10 @@ fn visible_pin_indices_filters_by_path_and_filename() {
     ]);
     assert_eq!(state.visible_pin_indices(), vec![0, 1, 2]);
 
-    state.pins_filter_query = "lua".into(); // matches filename of row 1
+    state.pins.filter_query = "lua".into(); // matches filename of row 1
     assert_eq!(state.visible_pin_indices(), vec![1]);
 
-    state.pins_filter_query = "ZSH".into(); // case-insensitive, matches path of row 0
+    state.pins.filter_query = "ZSH".into(); // case-insensitive, matches path of row 0
     assert_eq!(state.visible_pin_indices(), vec![0]);
 }
 
@@ -3392,8 +3392,8 @@ fn selected_pin_index_maps_through_filter() {
         ("/cwd/beta", "g2", "beta"),
         ("/cwd/gamma", "g3", "gamma"),
     ]);
-    state.pins_filter_query = "gamma".into(); // only row 2 visible
-    state.pins_index = 0; // first (and only) visible row
+    state.pins.filter_query = "gamma".into(); // only row 2 visible
+    state.pins.index = 0; // first (and only) visible row
     assert_eq!(state.selected_pin_index(), Some(2)); // TRUE index, not 0
 }
 
@@ -3404,43 +3404,43 @@ fn pins_down_clamps_to_filtered_count() {
         ("/cwd/blua", "g2", "blua"),
         ("/cwd/c", "g3", "c"),
     ]);
-    state.pins_filter_query = "lua".into(); // 1 visible
+    state.pins.filter_query = "lua".into(); // 1 visible
     state.handle_key(KeyCode::Down);
-    assert_eq!(state.pins_index, 0); // clamped to the single filtered row
+    assert_eq!(state.pins.index, 0); // clamped to the single filtered row
 }
 
 #[test]
 fn pins_filter_input_behaviors() {
     let mut state = state_with_pins(&[("/cwd/a", "g1", "a"), ("/cwd/b", "g2", "b")]);
-    state.pins_filtering = true;
+    state.pins.filtering = true;
 
     // live nav while typing
     state.handle_key(KeyCode::Down);
-    assert_eq!(state.pins_index, 1);
-    assert!(state.pins_filtering);
+    assert_eq!(state.pins.index, 1);
+    assert!(state.pins.filtering);
 
     // Tab is a no-op (single pane)
     state.handle_key(KeyCode::Char('a'));
     state.handle_key(KeyCode::Tab);
-    assert!(state.pins_filtering);
-    assert_eq!(state.pins_filter_query, "a");
+    assert!(state.pins.filtering);
+    assert_eq!(state.pins.filter_query, "a");
 
     // Esc clears + exits
     state.handle_key(KeyCode::Esc);
-    assert!(!state.pins_filtering);
-    assert_eq!(state.pins_filter_query, "");
+    assert!(!state.pins.filtering);
+    assert_eq!(state.pins.filter_query, "");
 
     // Backspace on empty exits
-    state.pins_filtering = true;
+    state.pins.filtering = true;
     state.handle_key(KeyCode::Backspace);
-    assert!(!state.pins_filtering);
+    assert!(!state.pins.filtering);
 
     // Enter keeps query + exits
-    state.pins_filtering = true;
+    state.pins.filtering = true;
     state.handle_key(KeyCode::Char('b'));
     state.handle_key(KeyCode::Enter);
-    assert!(!state.pins_filtering);
-    assert_eq!(state.pins_filter_query, "b");
+    assert!(!state.pins.filtering);
+    assert_eq!(state.pins.filter_query, "b");
 }
 
 #[test]
@@ -3716,9 +3716,9 @@ fn pins_page_keys_jump_selection() {
         })
         .collect();
     state.handle_key_with(KeyCode::Char('f'), KeyModifiers::CONTROL);
-    assert_eq!(state.pins_index, 10);
+    assert_eq!(state.pins.index, 10);
     state.handle_key(KeyCode::PageUp);
-    assert_eq!(state.pins_index, 0);
+    assert_eq!(state.pins.index, 0);
 }
 
 #[test]
@@ -4535,7 +4535,7 @@ fn pins_click_selects_and_double_click_matches_enter() {
     };
     let out = state.handle_mouse(MouseInput::Click { col: 5, row: 2 }, &layout);
     assert_eq!(out, KeyOutcome::None);
-    assert_eq!(state.pins_index, 1);
+    assert_eq!(state.pins.index, 1);
     let mut by_key = state.clone();
     let key_out = by_key.handle_key(KeyCode::Enter);
     let by_mouse = state.handle_mouse(MouseInput::DoubleClick { col: 5, row: 2 }, &layout);


### PR DESCRIPTION
Increment 4 of the incremental `AppState` decomposition (#163).

The five `pins_*` fields move into a data-only `PinsState`, accessed as `self.pins.<field>`. `PinSort` gains a small manual `impl Default` (its `Default` variant — config/insertion order — is the natural default) so `PinsState` derives `Default` and `initial_state` is just `PinsState::default()`. Kept as a 3-line manual impl rather than touching the shared `cycling_enum!` macro.

Methods stay on `AppState`; no semantic change. Pure refactor → **no new tests**; **441 tests, baseline-identical**, fmt/clippy `-D warnings`/check green. `skip-changelog`.

Refs #163