### PR TITLE
refactor(tui): group gists_* fields into GistsManagerState (AppState decomp 5/N)

### DIFF
--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -53,7 +53,7 @@ impl AppState {
             && theme_toggle_modifiers_ok(modifiers)
             && !self.filtering
             && !self.pins.filtering
-            && !self.gists_filtering
+            && !self.gist_manager.filtering
             && !self.editing_description
         {
             self.theme_choice = match self.theme_choice {
@@ -101,7 +101,7 @@ impl AppState {
         }
         // While filtering, arrows/hjkl are typed or handled in the filter branches; page keys
         // still jump the live selection by PAGE_SCROLL.
-        if (self.filtering || self.pins.filtering || self.gists_filtering)
+        if (self.filtering || self.pins.filtering || self.gist_manager.filtering)
             && !matches!(action, NavAction::PageUp | NavAction::PageDown)
         {
             return false;
@@ -179,34 +179,37 @@ impl AppState {
                 let groups = self.visible_gist_groups();
                 match action {
                     NavAction::Down => {
-                        if self.gists_index + 1 < groups.len() {
-                            self.gists_index += 1;
-                            self.gists_hscroll = 0;
+                        if self.gist_manager.index + 1 < groups.len() {
+                            self.gist_manager.index += 1;
+                            self.gist_manager.hscroll = 0;
                         }
                     }
                     NavAction::Up => {
-                        if self.gists_index > 0 {
-                            self.gists_index -= 1;
-                            self.gists_hscroll = 0;
+                        if self.gist_manager.index > 0 {
+                            self.gist_manager.index -= 1;
+                            self.gist_manager.hscroll = 0;
                         }
                     }
                     NavAction::Right => {
-                        self.gists_hscroll = (self.gists_hscroll + 1).min(self.gists_hscroll_max());
+                        self.gist_manager.hscroll =
+                            (self.gist_manager.hscroll + 1).min(self.gists_hscroll_max());
                     }
                     NavAction::Left => {
-                        self.gists_hscroll = self.gists_hscroll.saturating_sub(1);
+                        self.gist_manager.hscroll = self.gist_manager.hscroll.saturating_sub(1);
                     }
                     NavAction::PageDown => {
                         let len = groups.len();
                         if len > 0 {
                             let max = len - 1;
-                            self.gists_index = (self.gists_index + PAGE_SCROLL as usize).min(max);
-                            self.gists_hscroll = 0;
+                            self.gist_manager.index =
+                                (self.gist_manager.index + PAGE_SCROLL as usize).min(max);
+                            self.gist_manager.hscroll = 0;
                         }
                     }
                     NavAction::PageUp => {
-                        self.gists_index = self.gists_index.saturating_sub(PAGE_SCROLL as usize);
-                        self.gists_hscroll = 0;
+                        self.gist_manager.index =
+                            self.gist_manager.index.saturating_sub(PAGE_SCROLL as usize);
+                        self.gist_manager.hscroll = 0;
                     }
                 }
                 true
@@ -412,30 +415,30 @@ impl AppState {
     fn handle_key_gists(&mut self, code: KeyCode) -> KeyOutcome {
         self.status = None;
         // Inline text filter: live-navigate with arrows; Tab is a no-op (single pane).
-        if self.gists_filtering {
+        if self.gist_manager.filtering {
             match code {
-                KeyCode::Up if self.gists_index > 0 => {
-                    self.gists_index -= 1;
-                    self.gists_hscroll = 0;
+                KeyCode::Up if self.gist_manager.index > 0 => {
+                    self.gist_manager.index -= 1;
+                    self.gist_manager.hscroll = 0;
                 }
                 KeyCode::Up => {}
                 KeyCode::Down => {
-                    if self.gists_index + 1 < self.visible_gist_groups().len() {
-                        self.gists_index += 1;
-                        self.gists_hscroll = 0;
+                    if self.gist_manager.index + 1 < self.visible_gist_groups().len() {
+                        self.gist_manager.index += 1;
+                        self.gist_manager.hscroll = 0;
                     }
                 }
-                _ => match apply_filter_edit(code, &mut self.gists_filter_query) {
+                _ => match apply_filter_edit(code, &mut self.gist_manager.filter_query) {
                     FilterKey::Edited => {
-                        self.gists_index = 0;
-                        self.gists_hscroll = 0;
+                        self.gist_manager.index = 0;
+                        self.gist_manager.hscroll = 0;
                     }
                     FilterKey::Cleared => {
-                        self.gists_filtering = false;
-                        self.gists_index = 0;
-                        self.gists_hscroll = 0;
+                        self.gist_manager.filtering = false;
+                        self.gist_manager.index = 0;
+                        self.gist_manager.hscroll = 0;
                     }
-                    FilterKey::Exited => self.gists_filtering = false,
+                    FilterKey::Exited => self.gist_manager.filtering = false,
                     FilterKey::Moved | FilterKey::Pass => {}
                 },
             }
@@ -444,28 +447,28 @@ impl AppState {
         let groups = self.visible_gist_groups();
         match code {
             KeyCode::Char('q') | KeyCode::Esc => self.screen = Screen::List,
-            KeyCode::Char('/') => self.gists_filtering = true,
+            KeyCode::Char('/') => self.gist_manager.filtering = true,
             KeyCode::Char('s') => {
-                self.gists_sort = self.gists_sort.next();
-                self.gists_index = 0;
-                self.gists_hscroll = 0;
+                self.gist_manager.sort = self.gist_manager.sort.next();
+                self.gist_manager.index = 0;
+                self.gist_manager.hscroll = 0;
             }
             KeyCode::Char('v') => {
-                self.gists_type_filter = self.gists_type_filter.next();
-                self.gists_index = 0;
-                self.gists_hscroll = 0;
+                self.gist_manager.type_filter = self.gist_manager.type_filter.next();
+                self.gist_manager.index = 0;
+                self.gist_manager.hscroll = 0;
             }
             KeyCode::Char('*') => return self.star_toggle_intent(),
-            KeyCode::Enter if self.gists_index < groups.len() => {
+            KeyCode::Enter if self.gist_manager.index < groups.len() => {
                 return KeyOutcome::OpenGistDetail;
             }
-            KeyCode::Char('o') if self.gists_index < groups.len() => {
+            KeyCode::Char('o') if self.gist_manager.index < groups.len() => {
                 return KeyOutcome::OpenBrowser
             }
-            KeyCode::Char('y') if self.gists_index < groups.len() => {
+            KeyCode::Char('y') if self.gist_manager.index < groups.len() => {
                 return KeyOutcome::CopyGistUrl
             }
-            KeyCode::Char('H') if self.gists_index < groups.len() => {
+            KeyCode::Char('H') if self.gist_manager.index < groups.len() => {
                 if self.open_revisions(Screen::Gists) {
                     return KeyOutcome::FetchRevisions;
                 }
@@ -733,8 +736,8 @@ impl AppState {
                 if let Some(hit) = layout.list {
                     if point_in(hit.rect, col, row) {
                         if let Some(idx) = hit.index_at(row, self.visible_gist_groups().len()) {
-                            self.gists_index = idx;
-                            self.gists_hscroll = 0;
+                            self.gist_manager.index = idx;
+                            self.gist_manager.hscroll = 0;
                             return true;
                         }
                     }
@@ -1240,15 +1243,15 @@ impl AppState {
             self.status = Some("no gists to manage".into());
             return;
         }
-        self.gists_filtering = false;
-        self.gists_filter_query.clear();
-        self.gists_type_filter = GistTypeFilter::All;
-        self.gists_hscroll = 0;
+        self.gist_manager.filtering = false;
+        self.gist_manager.filter_query.clear();
+        self.gist_manager.type_filter = GistTypeFilter::All;
+        self.gist_manager.hscroll = 0;
         self.editing_description = false;
         self.description_input.clear();
         let target = self.selected_gist().map(|g| g.file.gist_id);
         let groups = self.visible_gist_groups();
-        self.gists_index = target
+        self.gist_manager.index = target
             .and_then(|id| groups.iter().position(|g| g.id == id))
             .unwrap_or(0);
         self.screen = Screen::Gists;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -143,8 +143,9 @@ pub enum GistView {
     Id,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum GistTypeFilter {
+    #[default]
     All,
     Public,
     Secret,
@@ -201,6 +202,13 @@ cycling_enum! {
     pub enum GistGroupSort {
         Updated => "updated",
         Created => "created",
+    }
+}
+
+impl Default for GistGroupSort {
+    /// `Updated` mirrors the gh list's default updated-first order.
+    fn default() -> Self {
+        GistGroupSort::Updated
     }
 }
 
@@ -498,6 +506,18 @@ pub struct PinsState {
     pub sort: PinSort,
 }
 
+/// Gist-manager screen state (`Screen::Gists`). Named `gist_manager` on `AppState` because
+/// the `gists` field name is taken by the gist list `Vec`. Data only — methods stay on `AppState`.
+#[derive(Debug, Clone, Default)]
+pub struct GistsManagerState {
+    pub index: usize,
+    pub hscroll: u16,
+    pub sort: GistGroupSort,
+    pub type_filter: GistTypeFilter,
+    pub filtering: bool,
+    pub filter_query: TextInput,
+}
+
 #[derive(Debug, Clone)]
 pub struct AppState {
     pub locals: Vec<LocalCandidate>,
@@ -582,12 +602,7 @@ pub struct AppState {
     pub scan_depth: u32,
     pub local_scanning: bool,
     pub pins: PinsState,
-    pub gists_index: usize,
-    pub gists_hscroll: u16,
-    pub gists_sort: GistGroupSort,
-    pub gists_type_filter: GistTypeFilter,
-    pub gists_filtering: bool,
-    pub gists_filter_query: TextInput,
+    pub gist_manager: GistsManagerState,
     pub editing_description: bool,
     pub description_input: TextInput,
     pub bg_task_msg: Option<String>,
@@ -747,7 +762,7 @@ impl AppState {
     }
 
     fn manager_gist_source(&self) -> &[GistFile] {
-        if self.gists_type_filter.uses_starred_source() {
+        if self.gist_manager.type_filter.uses_starred_source() {
             &self.starred_gists
         } else {
             &self.gists
@@ -906,17 +921,17 @@ impl AppState {
     /// are applied. This is the single source of truth for navigation, selection, and
     /// rendering in `Screen::Gists`.
     pub fn visible_gist_groups(&self) -> Vec<GistGroup> {
-        let query = self.gists_filter_query.to_lowercase();
+        let query = self.gist_manager.filter_query.to_lowercase();
         let mut groups: Vec<GistGroup> = group_gists(self.manager_gist_source())
             .into_iter()
-            .filter(|g| self.gists_type_filter.matches_group(g))
+            .filter(|g| self.gist_manager.type_filter.matches_group(g))
             .filter(|g| {
                 query.is_empty()
                     || g.description.to_lowercase().contains(&query)
                     || g.id.to_lowercase().contains(&query)
             })
             .collect();
-        match self.gists_sort {
+        match self.gist_manager.sort {
             GistGroupSort::Updated => groups.sort_by(|a, b| b.updated_at.cmp(&a.updated_at)),
             GistGroupSort::Created => groups.sort_by(|a, b| b.created_at.cmp(&a.created_at)),
         }
@@ -925,7 +940,9 @@ impl AppState {
 
     /// The gist highlighted in the gist-level view.
     pub fn selected_group(&self) -> Option<GistGroup> {
-        self.visible_gist_groups().into_iter().nth(self.gists_index)
+        self.visible_gist_groups()
+            .into_iter()
+            .nth(self.gist_manager.index)
     }
 
     /// Highest horizontal-scroll offset for the gist-level view, based on its longest
@@ -937,7 +954,7 @@ impl AppState {
                 gist_group_row_label(
                     g,
                     unix_now(),
-                    self.gists_sort,
+                    self.gist_manager.sort,
                     (
                         self.gist_comment_counts.get(&g.id).copied().unwrap_or(0),
                         self.gist_star_counts.get(&g.id).copied().unwrap_or(0),
@@ -1471,12 +1488,7 @@ pub fn initial_state() -> AppState {
         scan_depth: crate::config::AppConfig::default().scan_depth,
         local_scanning: false,
         pins: PinsState::default(),
-        gists_index: 0,
-        gists_hscroll: 0,
-        gists_sort: GistGroupSort::Updated,
-        gists_type_filter: GistTypeFilter::All,
-        gists_filtering: false,
-        gists_filter_query: TextInput::default(),
+        gist_manager: GistsManagerState::default(),
         editing_description: false,
         description_input: TextInput::default(),
         bg_task_msg: None,

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -568,10 +568,10 @@ pub(super) fn render_gists(frame: &mut Frame, state: &AppState, layout: &mut Mou
     let area = frame.area();
     // Footer: filter input while filtering, else a one-shot status message (e.g. the compaction
     // result) when present, else the command hints. Only the hints get key colouring.
-    let (ftitle, footer, colored) = if state.gists_filtering {
+    let (ftitle, footer, colored) = if state.gist_manager.filtering {
         (
             "Filter (↑↓ move · Enter apply · Esc clear)".to_string(),
-            format!("/{}_", state.gists_filter_query),
+            format!("/{}_", state.gist_manager.filter_query),
             false,
         )
     } else if let Some(message) = &state.status {
@@ -608,7 +608,7 @@ pub(super) fn render_gists(frame: &mut Frame, state: &AppState, layout: &mut Mou
                     &gist_group_row_label(
                         g,
                         now,
-                        state.gists_sort,
+                        state.gist_manager.sort,
                         (
                             state.gist_comment_counts.get(&g.id).copied().unwrap_or(0),
                             state.gist_star_counts.get(&g.id).copied().unwrap_or(0),
@@ -617,23 +617,23 @@ pub(super) fn render_gists(frame: &mut Frame, state: &AppState, layout: &mut Mou
                         state.gist_is_starred(&g.id),
                         state.current_user_login.as_deref(),
                     ),
-                    state.gists_hscroll,
+                    state.gist_manager.hscroll,
                 ))
             })
             .collect()
     };
 
-    let selected = (!groups.is_empty()).then_some(state.gists_index);
+    let selected = (!groups.is_empty()).then_some(state.gist_manager.index);
     let mut title = format!(
         "Gists {}  ·  sort:{}  ·  type:{}  ·  ★ {}  ·  ⑂ {}",
         count_label(groups.len(), state.gist_groups().len()),
-        state.gists_sort.label(),
-        state.gists_type_filter.label(),
+        state.gist_manager.sort.label(),
+        state.gist_manager.type_filter.label(),
         state.starred_gist_count(),
         state.owned_fork_gist_count()
     );
-    if !state.gists_filter_query.is_empty() {
-        title.push_str(&format!("  ·  /{}", state.gists_filter_query));
+    if !state.gist_manager.filter_query.is_empty() {
+        title.push_str(&format!("  ·  /{}", state.gist_manager.filter_query));
     }
     let list = List::new(items)
         .block(
@@ -664,12 +664,12 @@ pub(super) fn render_gists(frame: &mut Frame, state: &AppState, layout: &mut Mou
         });
     }
 
-    if state.gists_filtering {
+    if state.gist_manager.filtering {
         render_footer_line(
             frame,
             chunks[1],
             &ftitle,
-            input_line("/", &state.gists_filter_query, ""),
+            input_line("/", &state.gist_manager.filter_query, ""),
             &state.theme,
         );
     } else {

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -88,8 +88,8 @@ pub(super) fn run_loop(
                         state.gist_index = 0;
                     }
                     let count = state.visible_gist_groups().len();
-                    if count > 0 && state.gists_index >= count {
-                        state.gists_index = count - 1;
+                    if count > 0 && state.gist_manager.index >= count {
+                        state.gist_manager.index = count - 1;
                     }
                     gist_rx = None;
                     let gist_ids: std::collections::HashSet<String> = state

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -40,7 +40,7 @@ fn state_with_gists() -> AppState {
             node_id: None,
         },
     ];
-    state.gists_index = 0;
+    state.gist_manager.index = 0;
     state
 }
 
@@ -578,7 +578,7 @@ fn context_gist_id_uses_detail_id_on_detail_screen() {
 fn context_gist_id_uses_group_cursor_on_gists_screen() {
     let mut state = state_with_gists();
     state.screen = Screen::Gists;
-    state.gists_index = 0;
+    state.gist_manager.index = 0;
     assert_eq!(
         state.context_gist_id(),
         state.selected_group().map(|g| g.id)
@@ -2497,7 +2497,7 @@ fn g_opens_gist_view_landing_on_the_selected_files_gist() {
     state.gist_index = 1;
     assert_eq!(state.handle_key(KeyCode::Char('g')), KeyOutcome::None);
     assert_eq!(state.screen, Screen::Gists);
-    assert_eq!(state.gists_index, 1);
+    assert_eq!(state.gist_manager.index, 1);
     assert_eq!(state.selected_group().unwrap().id, "b");
 }
 
@@ -2665,7 +2665,7 @@ fn gist_view_filter_narrows_then_esc_clears() {
     let mut state = state_with_two_gists();
     state.screen = Screen::Gists;
     state.handle_key(KeyCode::Char('/'));
-    assert!(state.gists_filtering);
+    assert!(state.gist_manager.filtering);
     for c in "ssh".chars() {
         state.handle_key(KeyCode::Char(c));
     }
@@ -2674,8 +2674,8 @@ fn gist_view_filter_narrows_then_esc_clears() {
     assert_eq!(vis[0].id, "b"); // "SSH config"
 
     state.handle_key(KeyCode::Esc);
-    assert!(!state.gists_filtering);
-    assert!(state.gists_filter_query.is_empty());
+    assert!(!state.gist_manager.filtering);
+    assert!(state.gist_manager.filter_query.is_empty());
     assert_eq!(state.visible_gist_groups().len(), 2);
 }
 
@@ -2718,11 +2718,11 @@ fn gist_view_s_cycles_sort_updated_then_created() {
         },
     ];
     // Default: sort by updated (newest first).
-    assert_eq!(state.gists_sort, GistGroupSort::Updated);
+    assert_eq!(state.gist_manager.sort, GistGroupSort::Updated);
     assert_eq!(state.visible_gist_groups()[0].id, "new-upd");
     // s -> sort by created (newest created first).
     state.handle_key(KeyCode::Char('s'));
-    assert_eq!(state.gists_sort, GistGroupSort::Created);
+    assert_eq!(state.gist_manager.sort, GistGroupSort::Created);
     assert_eq!(state.visible_gist_groups()[0].id, "old-upd");
 }
 
@@ -2730,14 +2730,14 @@ fn gist_view_s_cycles_sort_updated_then_created() {
 fn gist_view_left_right_scrolls_horizontally() {
     let mut state = state_with_two_gists();
     state.screen = Screen::Gists;
-    assert_eq!(state.gists_hscroll, 0);
+    assert_eq!(state.gist_manager.hscroll, 0);
     state.handle_key(KeyCode::Right);
-    assert_eq!(state.gists_hscroll, 1);
+    assert_eq!(state.gist_manager.hscroll, 1);
     state.handle_key(KeyCode::Left);
-    assert_eq!(state.gists_hscroll, 0);
+    assert_eq!(state.gist_manager.hscroll, 0);
     // Left at the origin saturates at 0.
     state.handle_key(KeyCode::Left);
-    assert_eq!(state.gists_hscroll, 0);
+    assert_eq!(state.gist_manager.hscroll, 0);
 }
 
 #[test]
@@ -3318,36 +3318,36 @@ fn gists_screen_state() -> AppState {
 #[test]
 fn gists_filter_navigates_while_typing() {
     let mut state = gists_screen_state();
-    state.gists_filtering = true;
+    state.gist_manager.filtering = true;
 
     state.handle_key(KeyCode::Down);
-    assert_eq!(state.gists_index, 1);
-    assert!(state.gists_filtering);
+    assert_eq!(state.gist_manager.index, 1);
+    assert!(state.gist_manager.filtering);
     state.handle_key(KeyCode::Up);
-    assert_eq!(state.gists_index, 0);
+    assert_eq!(state.gist_manager.index, 0);
 }
 
 #[test]
 fn gists_filter_empty_backspace_exits() {
     let mut state = gists_screen_state();
-    state.gists_filtering = true;
+    state.gist_manager.filtering = true;
 
     state.handle_key(KeyCode::Char('a'));
     state.handle_key(KeyCode::Backspace); // empty again, still filtering
-    assert!(state.gists_filtering);
+    assert!(state.gist_manager.filtering);
     state.handle_key(KeyCode::Backspace); // empty -> exit
-    assert!(!state.gists_filtering);
+    assert!(!state.gist_manager.filtering);
 }
 
 #[test]
 fn gists_filter_tab_is_noop() {
     let mut state = gists_screen_state();
-    state.gists_filtering = true;
+    state.gist_manager.filtering = true;
     state.handle_key(KeyCode::Char('a'));
 
     state.handle_key(KeyCode::Tab);
-    assert!(state.gists_filtering); // still typing
-    assert_eq!(state.gists_filter_query, "a"); // unchanged
+    assert!(state.gist_manager.filtering); // still typing
+    assert_eq!(state.gist_manager.filter_query, "a"); // unchanged
 }
 
 // ── Pins screen filter ────────────────────────────────────────────────────────
@@ -3741,9 +3741,9 @@ fn gists_page_keys_jump_selection() {
         })
         .collect();
     state.handle_key(KeyCode::PageDown);
-    assert_eq!(state.gists_index, 10);
+    assert_eq!(state.gist_manager.index, 10);
     state.handle_key(KeyCode::PageDown);
-    assert_eq!(state.gists_index, 11);
+    assert_eq!(state.gist_manager.index, 11);
 }
 
 #[test]
@@ -4137,8 +4137,8 @@ fn fork_key_ignored_on_list_and_gist_manager() {
     assert_eq!(state.handle_key(KeyCode::Char('F')), KeyOutcome::None);
 
     state.screen = Screen::Gists;
-    state.gists_type_filter = GistTypeFilter::Starred;
-    state.gists_index = 0;
+    state.gist_manager.type_filter = GistTypeFilter::Starred;
+    state.gist_manager.index = 0;
     assert_eq!(state.handle_key(KeyCode::Char('F')), KeyOutcome::None);
 }
 
@@ -4501,7 +4501,7 @@ fn wheel_step_help_index_moves_one() {
 #[test]
 fn gists_click_selects_and_double_click_matches_enter() {
     let mut state = gists_screen_state(); // 2 groups, Screen::Gists
-    state.gists_index = 0;
+    state.gist_manager.index = 0;
     let hit = PaneHit {
         rect: Rect::new(0, 0, 40, 10),
         offset: 0,
@@ -4513,7 +4513,7 @@ fn gists_click_selects_and_double_click_matches_enter() {
     // Row 2 is the 2nd content row (border at row 0) -> idx 1.
     let out = state.handle_mouse(MouseInput::Click { col: 5, row: 2 }, &layout);
     assert_eq!(out, KeyOutcome::None);
-    assert_eq!(state.gists_index, 1);
+    assert_eq!(state.gist_manager.index, 1);
     // Double-click activates the same row, exactly as Enter would.
     let mut by_key = state.clone();
     let key_out = by_key.handle_key(KeyCode::Enter);


### PR DESCRIPTION
Increment 5 of the incremental `AppState` decomposition (#163).

The six `gists_*` (gist-manager screen) fields move into a data-only `GistsManagerState`, accessed as **`self.gist_manager.<field>`** — the field is `gist_manager`, **not** `gists`, because `gists` is already the gist-list `Vec` (a name collision). The rename was anchored on `.gists_X` so the shared `.gists` Vec accesses are untouched.

`GistTypeFilter` now derives `Default` (`#[default] All`); `GistGroupSort` gains a manual `impl Default` (`Updated`, the gh list's order) — so the struct derives `Default` and `initial_state` is `GistsManagerState::default()`.

Methods stay on `AppState`; no semantic change. Pure refactor → **no new tests**; **441 tests, baseline-identical**, fmt/clippy `-D warnings`/check green. `skip-changelog`.

Refs #163