### PR TITLE
refactor(tui): group detail_* + comments_* into DetailState (AppState decomp 6/N)

### DIFF
--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -507,7 +507,7 @@ impl AppState {
                 }
             }
             KeyCode::Char('e') => {
-                let Some(id) = self.detail_gist_id.clone() else {
+                let Some(id) = self.detail.gist_id.clone() else {
                     return KeyOutcome::None;
                 };
                 if !self.gist_is_owned(&id) {
@@ -519,13 +519,13 @@ impl AppState {
                 }
             }
             KeyCode::Char('c') => {
-                let Some(id) = self.detail_gist_id.clone() else {
+                let Some(id) = self.detail.gist_id.clone() else {
                     return KeyOutcome::None;
                 };
                 if !self.gist_is_owned(&id) {
                     return KeyOutcome::None;
                 }
-                self.compact_return_screen = Screen::GistDetail;
+                self.detail.compact_return_screen = Screen::GistDetail;
                 return KeyOutcome::CompactGist;
             }
             KeyCode::Char('*') => return self.star_toggle_intent(),
@@ -535,13 +535,13 @@ impl AppState {
                 return self.preview_detail_file((c as u8 - b'1') as usize);
             }
             KeyCode::Tab => {
-                self.detail_focus = match self.detail_focus {
+                self.detail.focus = match self.detail.focus {
                     DetailFocus::Comments => DetailFocus::Files,
                     DetailFocus::Files => DetailFocus::Comments,
                 };
-                if self.detail_focus == DetailFocus::Comments
-                    && self.detail_comments.is_none()
-                    && !self.detail_comments_loading
+                if self.detail.focus == DetailFocus::Comments
+                    && self.detail.comments.is_none()
+                    && !self.detail.comments_loading
                 {
                     return KeyOutcome::FetchComments;
                 }
@@ -550,7 +550,8 @@ impl AppState {
             // which lands on the list once the gist is gone. Owned gists only (no-op otherwise).
             KeyCode::Char('X') => {
                 if let Some(group) = self
-                    .detail_gist_id
+                    .detail
+                    .gist_id
                     .clone()
                     .filter(|id| self.gist_is_owned(id))
                     .and_then(|id| self.group_by_id(&id))
@@ -573,9 +574,9 @@ impl AppState {
                     self.screen = Screen::Confirm;
                 }
             }
-            KeyCode::Enter if self.detail_focus == DetailFocus::Files => {
-                if let Some(gist_id) = self.detail_gist_id.clone() {
-                    let cursor = self.detail_file_cursor;
+            KeyCode::Enter if self.detail.focus == DetailFocus::Files => {
+                if let Some(gist_id) = self.detail.gist_id.clone() {
+                    let cursor = self.detail.file_cursor;
                     if let Some(filename) = self.gist_filenames(&gist_id).into_iter().nth(cursor) {
                         if self.block_if_non_previewable_gist_file(&gist_id, &filename) {
                             return KeyOutcome::None;
@@ -586,7 +587,7 @@ impl AppState {
                     }
                 }
             }
-            KeyCode::Char('m') if self.detail_focus == DetailFocus::Comments => {
+            KeyCode::Char('m') if self.detail.focus == DetailFocus::Comments => {
                 if self.can_load_older_comments() {
                     return KeyOutcome::LoadOlderComments;
                 }
@@ -655,17 +656,18 @@ impl AppState {
     /// Move within the focused detail pane: scroll comments, or move the file cursor
     /// (clamped to the gist's file count). `delta` is signed rows.
     fn detail_nav(&mut self, delta: i32) {
-        match self.detail_focus {
+        match self.detail.focus {
             DetailFocus::Comments => {
-                self.detail_scroll = if delta < 0 {
-                    self.detail_scroll.saturating_sub((-delta) as u16)
+                self.detail.scroll = if delta < 0 {
+                    self.detail.scroll.saturating_sub((-delta) as u16)
                 } else {
-                    self.detail_scroll.saturating_add(delta as u16)
+                    self.detail.scroll.saturating_add(delta as u16)
                 };
             }
             DetailFocus::Files => {
                 let count = self
-                    .detail_gist_id
+                    .detail
+                    .gist_id
                     .as_deref()
                     .map(|id| self.gist_filenames(id).len())
                     .unwrap_or(0);
@@ -673,8 +675,8 @@ impl AppState {
                     return;
                 }
                 let max = count - 1;
-                let next = self.detail_file_cursor as i64 + delta as i64;
-                self.detail_file_cursor = next.clamp(0, max as i64) as usize;
+                let next = self.detail.file_cursor as i64 + delta as i64;
+                self.detail.file_cursor = next.clamp(0, max as i64) as usize;
             }
         }
     }
@@ -687,7 +689,7 @@ impl AppState {
             Screen::Diff | Screen::Preview | Screen::Confirm => 3,
             // GistDetail: the comments body scrolls like content (3 lines); the file list
             // steps one file at a time.
-            Screen::GistDetail if self.detail_focus == DetailFocus::Comments => 3,
+            Screen::GistDetail if self.detail.focus == DetailFocus::Comments => 3,
             Screen::Help if !self.help.index_open => 3, // help body scrolls; topic index is a list
             _ => 1, // List/Pins/Gists/Revisions/Help index/GistDetail Files
         }
@@ -773,13 +775,14 @@ impl AppState {
                 if let Some(hit) = layout.detail_files {
                     if point_in(hit.rect, col, row) {
                         // Clicking the file list focuses the Files tab; a row also moves the cursor.
-                        self.detail_focus = DetailFocus::Files;
+                        self.detail.focus = DetailFocus::Files;
                         let count = self
-                            .detail_gist_id
+                            .detail
+                            .gist_id
                             .as_deref()
                             .map_or(0, |id| self.gist_filenames(id).len());
                         if let Some(idx) = hit.index_at(row, count) {
-                            self.detail_file_cursor = idx;
+                            self.detail.file_cursor = idx;
                             return true;
                         }
                     }
@@ -796,7 +799,7 @@ impl AppState {
         match self.screen {
             // GistDetail files have no `Enter`; they preview via number keys, so a
             // double-click previews the file under the cursor.
-            Screen::GistDetail => self.preview_detail_file(self.detail_file_cursor),
+            Screen::GistDetail => self.preview_detail_file(self.detail.file_cursor),
             _ => self.handle_key_with(KeyCode::Enter, KeyModifiers::NONE),
         }
     }
@@ -804,7 +807,7 @@ impl AppState {
     /// Preview the `index`-th file of the gist shown on `Screen::GistDetail` (full-screen),
     /// the action behind the `1`–`9` keys and a file double-click.
     fn preview_detail_file(&mut self, index: usize) -> KeyOutcome {
-        if let Some(gist_id) = self.detail_gist_id.clone() {
+        if let Some(gist_id) = self.detail.gist_id.clone() {
             if let Some(filename) = self.gist_filenames(&gist_id).into_iter().nth(index) {
                 if self.block_if_non_previewable_gist_file(&gist_id, &filename) {
                     return KeyOutcome::None;
@@ -825,14 +828,14 @@ impl AppState {
         }
         if let Some(rect) = layout.detail_tab_files {
             if point_in(rect, col, row) {
-                self.detail_focus = DetailFocus::Files;
+                self.detail.focus = DetailFocus::Files;
                 return Some(KeyOutcome::None);
             }
         }
         if let Some(rect) = layout.detail_tab_comments {
             if point_in(rect, col, row) {
-                self.detail_focus = DetailFocus::Comments;
-                if self.detail_comments.is_none() && !self.detail_comments_loading {
+                self.detail.focus = DetailFocus::Comments;
+                if self.detail.comments.is_none() && !self.detail.comments_loading {
                     return Some(KeyOutcome::FetchComments);
                 }
                 return Some(KeyOutcome::None);
@@ -848,7 +851,7 @@ impl AppState {
         row: u16,
         layout: &MouseLayout,
     ) -> Option<KeyOutcome> {
-        if self.screen != Screen::GistDetail || self.detail_focus != DetailFocus::Comments {
+        if self.screen != Screen::GistDetail || self.detail.focus != DetailFocus::Comments {
             return None;
         }
         let rect = layout.comments_load_older?;
@@ -1471,7 +1474,7 @@ impl AppState {
                 KeyCode::Char('n') | KeyCode::Char('q') | KeyCode::Esc => {
                     // Return to whichever screen launched the compaction (Gists or GistDetail).
                     self.pending_action = None;
-                    self.screen = self.compact_return_screen;
+                    self.screen = self.detail.compact_return_screen;
                 }
                 _ => {}
             },

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -97,9 +97,10 @@ impl HelpTopic {
 /// Which tab `Screen::GistDetail` shows, and which the navigation keys drive: the file list
 /// or the comments (only one is visible at a time). Defaults to `Files` — the gist's primary
 /// content — with the comments one `Tab` away.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum DetailFocus {
     Comments,
+    #[default]
     Files,
 }
 
@@ -518,6 +519,37 @@ pub struct GistsManagerState {
     pub filter_query: TextInput,
 }
 
+/// Gist-detail screen state (`Screen::GistDetail`), including its Comments tab. Data only —
+/// the detail/comment methods stay on `AppState`. The `comments_*` count/paging fields keep
+/// their prefix so they don't collide with the `comments` Vec.
+#[derive(Debug, Clone, Default)]
+pub struct DetailState {
+    /// The gist currently shown; also guards stale comment responses.
+    pub gist_id: Option<String>,
+    /// Comments: `None` until the Comments tab is opened; `Some` is the fetched result.
+    pub comments: Option<Vec<GistComment>>,
+    /// True while a comment fetch is in flight (after the user opens the Comments tab).
+    pub comments_loading: bool,
+    /// Comment-fetch error message, if any.
+    pub comments_error: Option<String>,
+    /// Exact total comment count (from the per_page=1 probe); for the title only.
+    pub comments_total: Option<u32>,
+    /// Smallest 1-based page index currently loaded. 0 = none loaded yet.
+    pub comments_loaded_oldest_page: u32,
+    /// A "load older" request is in flight (distinct from the initial load).
+    pub comments_loading_more: bool,
+    /// One-shot: run_loop scrolls the comments pane to the bottom on the next draw.
+    pub comments_scroll_to_bottom: bool,
+    /// Comment-pane scroll offset.
+    pub scroll: u16,
+    /// Which detail-view pane Tab/arrows currently drive (Comments vs Files).
+    pub focus: DetailFocus,
+    /// Cursor index into the detail gist's files when `focus == Files`.
+    pub file_cursor: usize,
+    /// Screen to return to after a compaction confirm is cancelled/finished (Gists or GistDetail).
+    pub compact_return_screen: Screen,
+}
+
 #[derive(Debug, Clone)]
 pub struct AppState {
     pub locals: Vec<LocalCandidate>,
@@ -617,30 +649,7 @@ pub struct AppState {
     pub download_gist_filename: Option<String>,
     /// Screen to return to when leaving the diff (default: List; set to Pins for pin diffs).
     pub diff_return: Screen,
-    /// The gist currently shown in `Screen::GistDetail`; also guards stale comment responses.
-    pub detail_gist_id: Option<String>,
-    /// Comments: `None` until the Comments tab is opened; `Some` is the fetched result.
-    pub detail_comments: Option<Vec<GistComment>>,
-    /// True while a comment fetch is in flight (after the user opens the Comments tab).
-    pub detail_comments_loading: bool,
-    /// Comment-fetch error message, if any.
-    pub detail_comments_error: Option<String>,
-    /// Exact total comment count (from the per_page=1 probe); for the title only.
-    pub comments_total: Option<u32>,
-    /// Smallest 1-based page index currently loaded. 0 = none loaded yet.
-    pub comments_loaded_oldest_page: u32,
-    /// A "load older" request is in flight (distinct from the initial load).
-    pub comments_loading_more: bool,
-    /// One-shot: run_loop scrolls the comments pane to the bottom on the next draw.
-    pub comments_scroll_to_bottom: bool,
-    /// Comment-pane scroll offset.
-    pub detail_scroll: u16,
-    /// Which detail-view pane Tab/arrows currently drive (Comments vs Files).
-    pub detail_focus: DetailFocus,
-    /// Cursor index into the detail gist's files when `detail_focus == Files`.
-    pub detail_file_cursor: usize,
-    /// Screen to return to after a compaction confirm is cancelled/finished (Gists or GistDetail).
-    pub compact_return_screen: Screen,
+    pub detail: DetailState,
     /// Monotonic tick advanced once per event-loop iteration (~150ms); drives the in-progress
     /// spinner animation. Wraps freely — only its value modulo the frame count is observed.
     pub spinner_frame: usize,
@@ -1112,7 +1121,7 @@ impl AppState {
     pub fn open_revisions(&mut self, return_screen: Screen) -> bool {
         let gist_id = match return_screen {
             Screen::List => self.selected_gist().map(|g| g.file.gist_id.clone()),
-            Screen::GistDetail => self.detail_gist_id.clone(),
+            Screen::GistDetail => self.detail.gist_id.clone(),
             Screen::Gists => self.selected_group().map(|g| g.id.clone()),
             _ => None,
         };
@@ -1127,7 +1136,7 @@ impl AppState {
                 .filter(|f| filenames.iter().any(|name| name == f)),
             Screen::GistDetail => filenames
                 .into_iter()
-                .nth(self.detail_file_cursor)
+                .nth(self.detail.file_cursor)
                 .or_else(|| self.gist_filenames(&gist_id).first().cloned()),
             Screen::Gists => filenames.first().cloned(),
             _ => None,
@@ -1207,7 +1216,7 @@ impl AppState {
     pub fn context_gist_id(&self) -> Option<String> {
         match self.screen {
             Screen::Gists => self.selected_group().map(|g| g.id),
-            Screen::GistDetail => self.detail_gist_id.clone(),
+            Screen::GistDetail => self.detail.gist_id.clone(),
             _ => self.selected_gist().map(|g| g.file.gist_id),
         }
     }
@@ -1498,18 +1507,10 @@ pub fn initial_state() -> AppState {
         download_gist_id: None,
         download_gist_filename: None,
         diff_return: Screen::List,
-        detail_gist_id: None,
-        detail_comments: None,
-        detail_comments_loading: false,
-        detail_comments_error: None,
-        comments_total: None,
-        comments_loaded_oldest_page: 0,
-        comments_loading_more: false,
-        comments_scroll_to_bottom: false,
-        detail_scroll: 0,
-        detail_focus: DetailFocus::Files,
-        detail_file_cursor: 0,
-        compact_return_screen: Screen::Gists,
+        detail: DetailState {
+            compact_return_screen: Screen::Gists,
+            ..Default::default()
+        },
         spinner_frame: 0,
         gist_comment_counts: std::collections::HashMap::new(),
         gist_fork_counts: std::collections::HashMap::new(),
@@ -1661,13 +1662,13 @@ impl AppState {
     /// Reset comment-pagination state (called when (re)opening a gist detail or switching
     /// the loaded gist), so a fresh Tab re-fetches from the newest page.
     pub fn reset_comment_pagination(&mut self) {
-        self.detail_comments = None;
-        self.detail_comments_loading = false;
-        self.detail_comments_error = None;
-        self.comments_total = None;
-        self.comments_loaded_oldest_page = 0;
-        self.comments_loading_more = false;
-        self.comments_scroll_to_bottom = false;
+        self.detail.comments = None;
+        self.detail.comments_loading = false;
+        self.detail.comments_error = None;
+        self.detail.comments_total = None;
+        self.detail.comments_loaded_oldest_page = 0;
+        self.detail.comments_loading_more = false;
+        self.detail.comments_scroll_to_bottom = false;
     }
 
     /// Apply the initial newest-page load. Ignored if the user navigated to another gist
@@ -1678,19 +1679,19 @@ impl AppState {
         gist_id: &str,
         result: Result<InitialComments, String>,
     ) {
-        if self.detail_gist_id.as_deref() != Some(gist_id) {
+        if self.detail.gist_id.as_deref() != Some(gist_id) {
             return;
         }
-        self.detail_comments_loading = false;
+        self.detail.comments_loading = false;
         match result {
             Ok(init) => {
-                self.comments_total = Some(init.total);
-                self.comments_loaded_oldest_page = init.oldest_page;
-                self.detail_comments = Some(init.comments);
-                self.comments_scroll_to_bottom = true;
+                self.detail.comments_total = Some(init.total);
+                self.detail.comments_loaded_oldest_page = init.oldest_page;
+                self.detail.comments = Some(init.comments);
+                self.detail.comments_scroll_to_bottom = true;
             }
             Err(error) => {
-                self.detail_comments_error = Some(error);
+                self.detail.comments_error = Some(error);
             }
         }
     }
@@ -1703,25 +1704,28 @@ impl AppState {
         gist_id: &str,
         result: Result<Vec<GistComment>, String>,
     ) {
-        if self.detail_gist_id.as_deref() != Some(gist_id) {
+        if self.detail.gist_id.as_deref() != Some(gist_id) {
             return;
         }
-        self.comments_loading_more = false;
+        self.detail.comments_loading_more = false;
         match result {
             Ok(mut older) => {
                 let added = crate::tui::render::comment_lines_count(&older);
-                if let Some(existing) = self.detail_comments.as_mut() {
+                if let Some(existing) = self.detail.comments.as_mut() {
                     older.append(existing);
                     *existing = older;
                 } else {
-                    self.detail_comments = Some(older);
+                    self.detail.comments = Some(older);
                 }
-                self.comments_loaded_oldest_page =
-                    self.comments_loaded_oldest_page.saturating_sub(1).max(1);
-                self.detail_scroll = self.detail_scroll.saturating_add(added);
+                self.detail.comments_loaded_oldest_page = self
+                    .detail
+                    .comments_loaded_oldest_page
+                    .saturating_sub(1)
+                    .max(1);
+                self.detail.scroll = self.detail.scroll.saturating_add(added);
             }
             Err(error) => {
-                self.detail_comments_error = Some(error);
+                self.detail.comments_error = Some(error);
             }
         }
     }
@@ -1729,10 +1733,10 @@ impl AppState {
     /// Whether a "load older" action should be offered: comments are loaded, an older page
     /// exists, and no load is already in flight.
     pub fn can_load_older_comments(&self) -> bool {
-        self.detail_comments.is_some()
-            && self.comments_loaded_oldest_page > 1
-            && !self.comments_loading_more
-            && !self.detail_comments_loading
+        self.detail.comments.is_some()
+            && self.detail.comments_loaded_oldest_page > 1
+            && !self.detail.comments_loading_more
+            && !self.detail.comments_loading
     }
 }
 

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -959,7 +959,7 @@ pub(super) fn render_gist_info_and_files(
             Style::default().add_modifier(Modifier::BOLD),
         )),
     ];
-    let cursor = state.detail_file_cursor.min(files.len().saturating_sub(1));
+    let cursor = state.detail.file_cursor.min(files.len().saturating_sub(1));
     // Visible file rows = area height minus borders(2), info line, blank, "Files (n)" header (3).
     let visible_rows = (area.height as usize).saturating_sub(5);
     let offset = file_list_scroll(cursor, visible_rows, files.len());
@@ -1005,7 +1005,7 @@ fn render_detail_header(
             state.gist_is_starred(gist_id),
             state.gist_counts(gist_id),
         )),
-        detail_focus_tabs_line(state.detail_focus, &state.theme),
+        detail_focus_tabs_line(state.detail.focus, &state.theme),
     ];
     frame.render_widget(
         Paragraph::new(lines).style(state.theme.base_style()).block(
@@ -1040,7 +1040,7 @@ fn render_gist_file_list(
     layout: &mut MouseLayout,
 ) {
     let files = state.gist_file_display_names(gist_id);
-    let cursor = state.detail_file_cursor.min(files.len().saturating_sub(1));
+    let cursor = state.detail.file_cursor.min(files.len().saturating_sub(1));
     let visible_rows = (area.height as usize).saturating_sub(2);
     let offset = file_list_scroll(cursor, visible_rows, files.len());
     if state.mouse_enabled {
@@ -1102,8 +1102,8 @@ fn dim_line<'a>(text: &'a str, state: &AppState) -> Line<'a> {
 
 /// Title for the comments block: shows the loaded range out of the total when known.
 fn comments_title(state: &AppState) -> String {
-    match (&state.detail_comments, state.comments_total) {
-        (Some(c), _) if state.detail_comments_error.is_some() => format!("Comments ({})", c.len()),
+    match (&state.detail.comments, state.detail.comments_total) {
+        (Some(c), _) if state.detail.comments_error.is_some() => format!("Comments ({})", c.len()),
         (Some(c), Some(total)) if !c.is_empty() => {
             let loaded = c.len() as u32;
             let first = total.saturating_sub(loaded) + 1;
@@ -1128,9 +1128,9 @@ pub(super) fn render_gist_comments(
     let mut affordance_present = false;
 
     match (
-        &state.detail_comments,
-        state.detail_comments_loading,
-        &state.detail_comments_error,
+        &state.detail.comments,
+        state.detail.comments_loading,
+        &state.detail.comments_error,
     ) {
         (None, true, _) => body.push(dim_line("Loading comments…", state)),
         (None, false, _) => body.push(dim_line("Tab here to load comments", state)),
@@ -1143,9 +1143,9 @@ pub(super) fn render_gist_comments(
         }
         (Some(comments), _, None) => {
             // Top affordance line: load-older / loading / start-of-thread.
-            let label = if state.comments_loading_more {
+            let label = if state.detail.comments_loading_more {
                 "Loading…"
-            } else if state.comments_loaded_oldest_page > 1 {
+            } else if state.detail.comments_loaded_oldest_page > 1 {
                 affordance_present = true;
                 "↑ Load 30 older comments"
             } else {
@@ -1179,7 +1179,7 @@ pub(super) fn render_gist_comments(
     frame.render_widget(
         Paragraph::new(body)
             .style(state.theme.base_style())
-            .scroll((state.detail_scroll, 0))
+            .scroll((state.detail.scroll, 0))
             .wrap(Wrap { trim: false })
             .block(
                 Block::default()
@@ -1190,7 +1190,7 @@ pub(super) fn render_gist_comments(
             ),
         area,
     );
-    render_text_scrollbar(frame, area, total_lines, state.detail_scroll as usize);
+    render_text_scrollbar(frame, area, total_lines, state.detail.scroll as usize);
 }
 
 /// Footer text + whether to colourise it: a one-shot `state.status` message (shown plain) when
@@ -1264,10 +1264,11 @@ pub(super) fn detail_focus_tabs_line(focus: DetailFocus, theme: &Theme) -> Line<
 pub(super) fn render_gist_detail(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout) {
     let area = frame.area();
     let owned = state
-        .detail_gist_id
+        .detail
+        .gist_id
         .as_deref()
         .is_some_and(|id| state.gist_is_owned(id));
-    let (footer, colored) = detail_footer(state.status.as_deref(), state.detail_focus, owned);
+    let (footer, colored) = detail_footer(state.status.as_deref(), state.detail.focus, owned);
     let footer_lines = wrap_line_count(&footer, area.width.saturating_sub(2)).max(1);
     // Fixed 4-row header (borders + basic-info line + focus tabs); the active tab — the file
     // list or the comments, never both — fills the rest above the footer.
@@ -1279,9 +1280,9 @@ pub(super) fn render_gist_detail(frame: &mut Frame, state: &AppState, layout: &m
             Constraint::Length(footer_lines + 1),
         ])
         .split(area);
-    if let Some(id) = state.detail_gist_id.as_deref() {
+    if let Some(id) = state.detail.gist_id.as_deref() {
         render_detail_header(frame, chunks[0], state, id, layout);
-        match state.detail_focus {
+        match state.detail.focus {
             DetailFocus::Files => render_gist_file_list(frame, chunks[1], state, id, layout),
             DetailFocus::Comments => render_gist_comments(frame, chunks[1], state, layout),
         }

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -46,11 +46,11 @@ pub(super) fn run_loop(
 
     loop {
         terminal.draw(|frame| render(frame, &state, &mut mouse_layout))?;
-        if state.comments_scroll_to_bottom {
+        if state.detail.comments_scroll_to_bottom {
             if let Some(max) = mouse_layout.comments_max_scroll {
-                state.detail_scroll = max;
+                state.detail.scroll = max;
             }
-            state.comments_scroll_to_bottom = false;
+            state.detail.comments_scroll_to_bottom = false;
         }
         // Advance the spinner once per iteration; the poll below caps the loop at ~150ms, so
         // in-progress states (scanning/loading/working) animate even with no input.
@@ -748,20 +748,20 @@ pub(super) fn run_loop(
                 };
                 let gist_id = group.id.clone();
                 state.screen = Screen::GistDetail;
-                state.detail_gist_id = Some(gist_id);
+                state.detail.gist_id = Some(gist_id);
                 state.reset_comment_pagination();
-                state.detail_scroll = 0;
-                state.detail_focus = DetailFocus::Files;
-                state.detail_file_cursor = 0;
+                state.detail.scroll = 0;
+                state.detail.focus = DetailFocus::Files;
+                state.detail.file_cursor = 0;
             }
             KeyOutcome::FetchComments => {
-                let Some(gist_id) = state.detail_gist_id.clone() else {
+                let Some(gist_id) = state.detail.gist_id.clone() else {
                     continue;
                 };
-                if state.detail_comments.is_some() || state.detail_comments_loading {
+                if state.detail.comments.is_some() || state.detail.comments_loading {
                     continue;
                 }
-                state.detail_comments_loading = true;
+                state.detail.comments_loading = true;
                 let fetch_id = gist_id.clone();
                 spawn_bg(&mut state, &mut bg_rx, "Loading comments…", move || {
                     let result = load_initial_comments(&fetch_id);
@@ -772,17 +772,17 @@ pub(super) fn run_loop(
                 });
             }
             KeyOutcome::LoadOlderComments => {
-                let Some(gist_id) = state.detail_gist_id.clone() else {
+                let Some(gist_id) = state.detail.gist_id.clone() else {
                     continue;
                 };
                 if !state.can_load_older_comments() {
                     continue;
                 }
-                let page = state.comments_loaded_oldest_page.saturating_sub(1);
+                let page = state.detail.comments_loaded_oldest_page.saturating_sub(1);
                 if page == 0 {
                     continue;
                 }
-                state.comments_loading_more = true;
+                state.detail.comments_loading_more = true;
                 let fetch_id = gist_id.clone();
                 spawn_bg(
                     &mut state,
@@ -1104,7 +1104,7 @@ pub(super) fn run_loop(
                     continue;
                 };
                 state.pending_action = None;
-                state.screen = state.compact_return_screen;
+                state.screen = state.detail.compact_return_screen;
 
                 spawn_bg(
                     &mut state,
@@ -1123,7 +1123,8 @@ pub(super) fn run_loop(
             }
             KeyOutcome::ApplyDescription => {
                 let gist_id = state
-                    .detail_gist_id
+                    .detail
+                    .gist_id
                     .clone()
                     .or_else(|| state.selected_group().map(|g| g.id.clone()));
                 let Some(gist_id) = gist_id else {

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -256,73 +256,73 @@ fn enter_on_gist_opens_detail() {
 #[test]
 fn detail_focus_and_cursor_default_to_files_and_zero() {
     let state = initial_state();
-    assert_eq!(state.detail_focus, DetailFocus::Files);
-    assert_eq!(state.detail_file_cursor, 0);
+    assert_eq!(state.detail.focus, DetailFocus::Files);
+    assert_eq!(state.detail.file_cursor, 0);
 }
 
 #[test]
 fn detail_tab_toggles_focus() {
     let mut state = state_with_gists();
     state.screen = Screen::GistDetail;
-    state.detail_gist_id = Some("g1".into());
-    assert_eq!(state.detail_focus, DetailFocus::Files);
+    state.detail.gist_id = Some("g1".into());
+    assert_eq!(state.detail.focus, DetailFocus::Files);
     let outcome = state.handle_key(KeyCode::Tab);
     assert!(matches!(outcome, KeyOutcome::FetchComments));
-    assert_eq!(state.detail_focus, DetailFocus::Comments);
+    assert_eq!(state.detail.focus, DetailFocus::Comments);
     let outcome = state.handle_key(KeyCode::Tab);
     assert!(matches!(outcome, KeyOutcome::None));
-    assert_eq!(state.detail_focus, DetailFocus::Files);
+    assert_eq!(state.detail.focus, DetailFocus::Files);
 }
 
 #[test]
 fn detail_tab_to_comments_skips_fetch_when_already_loaded() {
     let mut state = state_with_gists();
     state.screen = Screen::GistDetail;
-    state.detail_gist_id = Some("g1".into());
-    state.detail_comments = Some(Vec::new());
+    state.detail.gist_id = Some("g1".into());
+    state.detail.comments = Some(Vec::new());
     let outcome = state.handle_key(KeyCode::Tab);
     assert!(matches!(outcome, KeyOutcome::None));
-    assert_eq!(state.detail_focus, DetailFocus::Comments);
+    assert_eq!(state.detail.focus, DetailFocus::Comments);
 }
 
 #[test]
 fn detail_files_focus_arrows_move_cursor_and_clamp() {
     let mut state = state_with_gists(); // g1 has 2 files: a.txt, b.txt
     state.screen = Screen::GistDetail;
-    state.detail_gist_id = Some("g1".into());
-    state.detail_focus = DetailFocus::Files;
+    state.detail.gist_id = Some("g1".into());
+    state.detail.focus = DetailFocus::Files;
 
     state.handle_key(KeyCode::Up); // already at 0, clamps
-    assert_eq!(state.detail_file_cursor, 0);
+    assert_eq!(state.detail.file_cursor, 0);
     state.handle_key(KeyCode::Down);
-    assert_eq!(state.detail_file_cursor, 1);
+    assert_eq!(state.detail.file_cursor, 1);
     state.handle_key(KeyCode::Down); // only 2 files, clamps at index 1
-    assert_eq!(state.detail_file_cursor, 1);
+    assert_eq!(state.detail.file_cursor, 1);
     state.handle_key(KeyCode::PageUp); // jumps to 0
-    assert_eq!(state.detail_file_cursor, 0);
+    assert_eq!(state.detail.file_cursor, 0);
     state.handle_key(KeyCode::PageDown); // +10 clamps to last (1)
-    assert_eq!(state.detail_file_cursor, 1);
+    assert_eq!(state.detail.file_cursor, 1);
     // Comment scroll is untouched while files-focused.
-    assert_eq!(state.detail_scroll, 0);
+    assert_eq!(state.detail.scroll, 0);
 }
 
 #[test]
 fn detail_comments_focus_arrows_still_scroll_comments() {
     let mut state = state_with_gists();
     state.screen = Screen::GistDetail;
-    state.detail_focus = DetailFocus::Comments;
+    state.detail.focus = DetailFocus::Comments;
     state.handle_key(KeyCode::Down);
-    assert_eq!(state.detail_scroll, 1);
-    assert_eq!(state.detail_file_cursor, 0); // cursor untouched
+    assert_eq!(state.detail.scroll, 1);
+    assert_eq!(state.detail.file_cursor, 0); // cursor untouched
 }
 
 #[test]
 fn detail_enter_previews_cursor_file_including_tenth() {
     let mut state = state_with_many_files(12);
     state.screen = Screen::GistDetail;
-    state.detail_gist_id = Some("g1".into());
-    state.detail_focus = DetailFocus::Files;
-    state.detail_file_cursor = 9; // the 10th file — unreachable via 1-9
+    state.detail.gist_id = Some("g1".into());
+    state.detail.focus = DetailFocus::Files;
+    state.detail.file_cursor = 9; // the 10th file — unreachable via 1-9
     let outcome = state.handle_key(KeyCode::Enter);
     assert!(matches!(outcome, KeyOutcome::PreviewContent));
     assert_eq!(state.preview_request, Some(("g1".into(), "f9.txt".into())));
@@ -333,8 +333,8 @@ fn detail_enter_previews_cursor_file_including_tenth() {
 fn detail_enter_in_comments_focus_is_noop() {
     let mut state = state_with_gists();
     state.screen = Screen::GistDetail;
-    state.detail_gist_id = Some("g1".into());
-    state.detail_focus = DetailFocus::Comments;
+    state.detail.gist_id = Some("g1".into());
+    state.detail.focus = DetailFocus::Comments;
     let outcome = state.handle_key(KeyCode::Enter);
     assert!(matches!(outcome, KeyOutcome::None));
     assert_eq!(state.preview_request, None);
@@ -352,29 +352,29 @@ fn detail_q_returns_to_gists() {
 fn detail_scroll_saturates_at_zero() {
     let mut state = state_with_gists();
     state.screen = Screen::GistDetail;
-    state.detail_focus = DetailFocus::Comments;
-    state.detail_scroll = 0;
+    state.detail.focus = DetailFocus::Comments;
+    state.detail.scroll = 0;
     state.handle_key(KeyCode::Up);
-    assert_eq!(state.detail_scroll, 0);
+    assert_eq!(state.detail.scroll, 0);
     state.handle_key(KeyCode::Down);
-    assert_eq!(state.detail_scroll, 1);
+    assert_eq!(state.detail.scroll, 1);
 }
 
 #[test]
 fn detail_c_triggers_compaction_and_records_origin() {
     let mut state = state_with_gists();
     state.screen = Screen::GistDetail;
-    state.detail_gist_id = Some("g1".into());
+    state.detail.gist_id = Some("g1".into());
     let outcome = state.handle_key(KeyCode::Char('c'));
     assert!(matches!(outcome, KeyOutcome::CompactGist));
-    assert_eq!(state.compact_return_screen, Screen::GistDetail);
+    assert_eq!(state.detail.compact_return_screen, Screen::GistDetail);
 }
 
 #[test]
 fn detail_number_key_requests_file_preview() {
     let mut state = state_with_gists();
     state.screen = Screen::GistDetail;
-    state.detail_gist_id = Some("g1".into());
+    state.detail.gist_id = Some("g1".into());
     let outcome = state.handle_key(KeyCode::Char('1'));
     assert!(matches!(outcome, KeyOutcome::PreviewContent));
     assert_eq!(state.preview_request, Some(("g1".into(), "a.txt".into())));
@@ -385,7 +385,7 @@ fn detail_number_key_requests_file_preview() {
 fn detail_number_key_out_of_range_is_ignored() {
     let mut state = state_with_gists();
     state.screen = Screen::GistDetail;
-    state.detail_gist_id = Some("g1".into());
+    state.detail.gist_id = Some("g1".into());
     // Only two files exist; pressing 5 must do nothing (no fetch requested).
     let outcome = state.handle_key(KeyCode::Char('5'));
     assert!(matches!(outcome, KeyOutcome::None));
@@ -433,7 +433,7 @@ fn diff_footer_reflects_wrap_toggle() {
 fn detail_x_requests_gist_delete_confirm() {
     let mut state = state_with_gists();
     state.screen = Screen::GistDetail;
-    state.detail_gist_id = Some("g1".into());
+    state.detail.gist_id = Some("g1".into());
     let outcome = state.handle_key(KeyCode::Char('X'));
     assert!(matches!(outcome, KeyOutcome::None));
     assert_eq!(state.screen, Screen::Confirm);
@@ -534,7 +534,7 @@ fn detail_footer_shows_manage_keys_for_owned_and_fork_for_foreign() {
 fn star_key_in_detail_returns_toggle_intent() {
     let mut state = state_with_gists();
     state.screen = Screen::GistDetail;
-    state.detail_gist_id = Some("g1".into());
+    state.detail.gist_id = Some("g1".into());
     assert_eq!(
         state.handle_key(KeyCode::Char('*')),
         KeyOutcome::ToggleGistStar
@@ -570,7 +570,7 @@ fn spinner_glyph_cycles_through_frames_and_wraps() {
 fn context_gist_id_uses_detail_id_on_detail_screen() {
     let mut state = state_with_gists();
     state.screen = Screen::GistDetail;
-    state.detail_gist_id = Some("g1".into());
+    state.detail.gist_id = Some("g1".into());
     assert_eq!(state.context_gist_id().as_deref(), Some("g1"));
 }
 
@@ -2184,7 +2184,7 @@ fn y_copies_gist_url_on_list_gists_and_detail() {
 
     let mut detail = state_with_gists();
     detail.screen = Screen::GistDetail;
-    detail.detail_gist_id = Some("g1".into());
+    detail.detail.gist_id = Some("g1".into());
     assert_eq!(
         detail.handle_key(KeyCode::Char('y')),
         KeyOutcome::CopyGistUrl
@@ -2211,7 +2211,7 @@ fn c_in_detail_requests_compaction_not_gist_manager() {
     state.screen = Screen::Gists;
     assert_eq!(state.handle_key(KeyCode::Char('c')), KeyOutcome::None);
     state.screen = Screen::GistDetail;
-    state.detail_gist_id = Some("a".into());
+    state.detail.gist_id = Some("a".into());
     assert_eq!(
         state.handle_key(KeyCode::Char('c')),
         KeyOutcome::CompactGist
@@ -2512,7 +2512,7 @@ fn g_with_no_gists_is_blocked() {
 fn detail_e_edits_description_with_prefill_and_enter_applies() {
     let mut state = state_with_two_gists();
     state.screen = Screen::GistDetail;
-    state.detail_gist_id = Some("a".into());
+    state.detail.gist_id = Some("a".into());
     state.handle_key(KeyCode::Char('e'));
     assert!(state.editing_description);
     // Prefilled with the current description.
@@ -2559,7 +2559,7 @@ fn input_line_cursor_at_end_reverses_trailing_space() {
 fn detail_description_edits_mid_string_with_cursor_keys() {
     let mut state = state_with_two_gists();
     state.screen = Screen::GistDetail;
-    state.detail_gist_id = Some("a".into());
+    state.detail.gist_id = Some("a".into());
     state.handle_key(KeyCode::Char('e'));
     assert_eq!(state.description_input, "My Ghostty config");
     // Jump to the start, step right past "My", and insert without retyping the rest.
@@ -2601,7 +2601,7 @@ fn create_description_edits_mid_string_with_cursor_keys() {
 fn detail_esc_cancels_description_edit() {
     let mut state = state_with_two_gists();
     state.screen = Screen::GistDetail;
-    state.detail_gist_id = Some("a".into());
+    state.detail.gist_id = Some("a".into());
     state.handle_key(KeyCode::Char('e'));
     assert!(state.editing_description);
     state.handle_key(KeyCode::Esc);
@@ -2613,7 +2613,7 @@ fn detail_esc_cancels_description_edit() {
 fn detail_x_stages_whole_gist_delete() {
     let mut state = state_with_two_gists();
     state.screen = Screen::GistDetail;
-    state.detail_gist_id = Some("b".into());
+    state.detail.gist_id = Some("b".into());
     assert_eq!(state.handle_key(KeyCode::Char('X')), KeyOutcome::None);
     assert_eq!(state.screen, Screen::Confirm);
     assert_eq!(
@@ -3486,8 +3486,8 @@ fn capital_h_from_list_opens_revisions_for_selected_gist_file() {
 fn capital_h_from_gist_detail_opens_revisions_and_fetches() {
     let mut state = state_with_gists();
     state.screen = Screen::GistDetail;
-    state.detail_gist_id = Some("g1".into());
-    state.detail_file_cursor = 1;
+    state.detail.gist_id = Some("g1".into());
+    state.detail.file_cursor = 1;
     let outcome = state.handle_key(KeyCode::Char('H'));
     assert_eq!(outcome, KeyOutcome::FetchRevisions);
     assert_eq!(state.screen, Screen::Revisions);
@@ -3671,10 +3671,10 @@ fn ctrl_f_pages_gist_detail_files() {
     use crossterm::event::KeyModifiers;
     let mut state = state_with_gists();
     state.screen = Screen::GistDetail;
-    state.detail_gist_id = Some("g1".into());
-    state.detail_file_cursor = 0;
+    state.detail.gist_id = Some("g1".into());
+    state.detail.file_cursor = 0;
     state.handle_key_with(KeyCode::Char('f'), KeyModifiers::CONTROL);
-    assert_eq!(state.detail_file_cursor, 1);
+    assert_eq!(state.detail.file_cursor, 1);
 }
 
 #[test]
@@ -4041,7 +4041,7 @@ fn fork_key_returns_fork_intent_for_foreign_gist_in_detail() {
     let mut state = initial_state();
     state.current_user_login = Some("me".into());
     state.screen = Screen::GistDetail;
-    state.detail_gist_id = Some("foreign".into());
+    state.detail.gist_id = Some("foreign".into());
     state.starred_gists = vec![GistFile {
         gist_id: "foreign".into(),
         description: "x".into(),
@@ -4066,7 +4066,7 @@ fn fork_key_blocked_for_owned_gist_in_detail() {
     let mut state = initial_state();
     state.current_user_login = Some("me".into());
     state.screen = Screen::GistDetail;
-    state.detail_gist_id = Some("mine".into());
+    state.detail.gist_id = Some("mine".into());
     state.gists = vec![GistFile {
         gist_id: "mine".into(),
         description: "x".into(),
@@ -4092,7 +4092,7 @@ fn foreign_detail_mutate_keys_are_silent_noop() {
     let mut state = initial_state();
     state.current_user_login = Some("me".into());
     state.screen = Screen::GistDetail;
-    state.detail_gist_id = Some("foreign".into());
+    state.detail.gist_id = Some("foreign".into());
     state.starred_gists = vec![GistFile {
         gist_id: "foreign".into(),
         description: "x".into(),
@@ -4467,13 +4467,13 @@ fn wheel_step_gist_detail_moves_three() {
     // GistDetail content pane: one scroll-down tick must advance detail_scroll by 3.
     let mut state = state_with_gists();
     state.screen = Screen::GistDetail;
-    state.detail_gist_id = Some("g1".into());
+    state.detail.gist_id = Some("g1".into());
     // Use Comments focus so detail_nav moves detail_scroll (not the file cursor).
-    state.detail_focus = DetailFocus::Comments;
-    state.detail_comments = Some(Vec::new());
-    assert_eq!(state.detail_scroll, 0);
+    state.detail.focus = DetailFocus::Comments;
+    state.detail.comments = Some(Vec::new());
+    assert_eq!(state.detail.scroll, 0);
     state.handle_mouse(MouseInput::ScrollDown, &MouseLayout::default());
-    assert_eq!(state.detail_scroll, 3);
+    assert_eq!(state.detail.scroll, 3);
 }
 
 #[test]
@@ -4591,8 +4591,8 @@ fn revisions_click_selects_and_double_click_matches_enter() {
 fn gist_detail_file_click_selects_and_double_previews() {
     let mut state = state_with_gists(); // g1: a.txt (0), b.txt (1)
     state.screen = Screen::GistDetail;
-    state.detail_gist_id = Some("g1".into());
-    state.detail_focus = DetailFocus::Comments; // start elsewhere to prove the focus switch
+    state.detail.gist_id = Some("g1".into());
+    state.detail.focus = DetailFocus::Comments; // start elsewhere to prove the focus switch
     let hit = PaneHit {
         rect: Rect::new(0, 0, 40, 10),
         offset: 0,
@@ -4604,8 +4604,8 @@ fn gist_detail_file_click_selects_and_double_previews() {
     // Click the 2nd file row -> Files focus + cursor 1, but no open yet.
     let out = state.handle_mouse(MouseInput::Click { col: 5, row: 2 }, &layout);
     assert_eq!(out, KeyOutcome::None);
-    assert_eq!(state.detail_focus, DetailFocus::Files);
-    assert_eq!(state.detail_file_cursor, 1);
+    assert_eq!(state.detail.focus, DetailFocus::Files);
+    assert_eq!(state.detail.file_cursor, 1);
     // Double-click previews that file (there is no Enter for files).
     let out = state.handle_mouse(MouseInput::DoubleClick { col: 5, row: 2 }, &layout);
     assert_eq!(out, KeyOutcome::PreviewContent);
@@ -4616,8 +4616,8 @@ fn gist_detail_file_click_selects_and_double_previews() {
 fn gist_detail_tab_click_switches_focus() {
     let mut state = state_with_gists();
     state.screen = Screen::GistDetail;
-    state.detail_gist_id = Some("g1".into());
-    state.detail_focus = DetailFocus::Files;
+    state.detail.gist_id = Some("g1".into());
+    state.detail.focus = DetailFocus::Files;
     // Header at chunks[0] y=0: content_x = 2, tabs_y = 2; " Files " (7), " Comments " (10 @ +10).
     let layout = MouseLayout {
         detail_tab_files: Some(Rect::new(2, 2, 7, 1)),
@@ -4626,11 +4626,11 @@ fn gist_detail_tab_click_switches_focus() {
     };
     // Click the Comments tab: switches focus and (comments unloaded) requests a fetch.
     let out = state.handle_mouse(MouseInput::Click { col: 14, row: 2 }, &layout);
-    assert_eq!(state.detail_focus, DetailFocus::Comments);
+    assert_eq!(state.detail.focus, DetailFocus::Comments);
     assert_eq!(out, KeyOutcome::FetchComments);
     // Click the Files tab back.
     let out = state.handle_mouse(MouseInput::Click { col: 4, row: 2 }, &layout);
-    assert_eq!(state.detail_focus, DetailFocus::Files);
+    assert_eq!(state.detail.focus, DetailFocus::Files);
     assert_eq!(out, KeyOutcome::None);
 }
 
@@ -4639,11 +4639,11 @@ fn wheel_step_gist_detail_files_moves_one() {
     // The file list (Files tab) steps one file per wheel tick, not 3.
     let mut state = state_with_gists();
     state.screen = Screen::GistDetail;
-    state.detail_gist_id = Some("g1".into());
-    state.detail_focus = DetailFocus::Files;
-    state.detail_file_cursor = 0;
+    state.detail.gist_id = Some("g1".into());
+    state.detail.focus = DetailFocus::Files;
+    state.detail.file_cursor = 0;
     state.handle_mouse(MouseInput::ScrollDown, &MouseLayout::default());
-    assert_eq!(state.detail_file_cursor, 1);
+    assert_eq!(state.detail.file_cursor, 1);
 }
 
 #[test]
@@ -4681,7 +4681,7 @@ fn sample_comment(author: &str, body: &str) -> crate::domain::GistComment {
 fn apply_initial_comments_sets_window_and_requests_bottom_scroll() {
     use crate::tui::InitialComments;
     let mut s = crate::tui::initial_state();
-    s.detail_gist_id = Some("g1".into());
+    s.detail.gist_id = Some("g1".into());
     s.apply_initial_comments(
         "g1",
         Ok(InitialComments {
@@ -4690,18 +4690,18 @@ fn apply_initial_comments_sets_window_and_requests_bottom_scroll() {
             oldest_page: 31,
         }),
     );
-    assert_eq!(s.comments_total, Some(910));
-    assert_eq!(s.comments_loaded_oldest_page, 31);
-    assert!(s.comments_scroll_to_bottom);
+    assert_eq!(s.detail.comments_total, Some(910));
+    assert_eq!(s.detail.comments_loaded_oldest_page, 31);
+    assert!(s.detail.comments_scroll_to_bottom);
     assert!(s.can_load_older_comments()); // page 31 > 1
-    assert_eq!(s.detail_comments.as_ref().unwrap().len(), 1);
+    assert_eq!(s.detail.comments.as_ref().unwrap().len(), 1);
 }
 
 #[test]
 fn apply_initial_comments_ignored_when_gist_changed() {
     use crate::tui::InitialComments;
     let mut s = crate::tui::initial_state();
-    s.detail_gist_id = Some("g2".into());
+    s.detail.gist_id = Some("g2".into());
     s.apply_initial_comments(
         "g1",
         Ok(InitialComments {
@@ -4710,14 +4710,14 @@ fn apply_initial_comments_ignored_when_gist_changed() {
             oldest_page: 1,
         }),
     );
-    assert!(s.detail_comments.is_none()); // stale response dropped
+    assert!(s.detail.comments.is_none()); // stale response dropped
 }
 
 #[test]
 fn apply_older_comments_prepends_and_compensates_scroll() {
     use crate::tui::InitialComments;
     let mut s = crate::tui::initial_state();
-    s.detail_gist_id = Some("g1".into());
+    s.detail.gist_id = Some("g1".into());
     s.apply_initial_comments(
         "g1",
         Ok(InitialComments {
@@ -4726,21 +4726,21 @@ fn apply_older_comments_prepends_and_compensates_scroll() {
             oldest_page: 2,
         }),
     );
-    s.detail_scroll = 5;
+    s.detail.scroll = 5;
     // One older comment = 1 header + 1 body + 1 blank = 3 lines prepended.
     s.apply_older_comments("g1", Ok(vec![sample_comment("older", "o")]));
-    assert_eq!(s.comments_loaded_oldest_page, 1);
+    assert_eq!(s.detail.comments_loaded_oldest_page, 1);
     assert!(!s.can_load_older_comments()); // reached page 1
-    assert_eq!(s.detail_comments.as_ref().unwrap()[0].author, "older"); // prepended
-    assert_eq!(s.detail_scroll, 5 + 3); // viewport held in place
-    assert!(!s.comments_loading_more);
+    assert_eq!(s.detail.comments.as_ref().unwrap()[0].author, "older"); // prepended
+    assert_eq!(s.detail.scroll, 5 + 3); // viewport held in place
+    assert!(!s.detail.comments_loading_more);
 }
 
 #[test]
 fn can_load_older_false_while_loading_more() {
     use crate::tui::InitialComments;
     let mut s = crate::tui::initial_state();
-    s.detail_gist_id = Some("g1".into());
+    s.detail.gist_id = Some("g1".into());
     s.apply_initial_comments(
         "g1",
         Ok(InitialComments {
@@ -4749,7 +4749,7 @@ fn can_load_older_false_while_loading_more() {
             oldest_page: 3,
         }),
     );
-    s.comments_loading_more = true;
+    s.detail.comments_loading_more = true;
     assert!(!s.can_load_older_comments());
 }
 
@@ -4758,8 +4758,8 @@ fn m_key_loads_older_when_available() {
     use crate::tui::InitialComments;
     let mut s = crate::tui::initial_state();
     s.screen = Screen::GistDetail;
-    s.detail_focus = DetailFocus::Comments;
-    s.detail_gist_id = Some("g1".into());
+    s.detail.focus = DetailFocus::Comments;
+    s.detail.gist_id = Some("g1".into());
     s.apply_initial_comments(
         "g1",
         Ok(InitialComments {
@@ -4777,8 +4777,8 @@ fn m_key_noop_when_at_oldest_page() {
     use crate::tui::InitialComments;
     let mut s = crate::tui::initial_state();
     s.screen = Screen::GistDetail;
-    s.detail_focus = DetailFocus::Comments;
-    s.detail_gist_id = Some("g1".into());
+    s.detail.focus = DetailFocus::Comments;
+    s.detail.gist_id = Some("g1".into());
     s.apply_initial_comments(
         "g1",
         Ok(InitialComments {


### PR DESCRIPTION
Increment 6 (the largest) of the incremental `AppState` decomposition (#163).

The twelve gist-detail + comments fields move into a data-only `DetailState`, accessed as `self.detail.<field>`. The count/paging fields **keep their `comments_` prefix** (`detail.comments_total`, `detail.comments_loading`, …) so they don't collide with the comments `Vec` (`detail.comments`).

- `DetailFocus` derives `Default` (`#[default] Files`, its documented default); `initial_state` overrides only the non-default `compact_return_screen: Screen::Gists` via struct-update.
- The rename used three precise `perl` passes anchored on the exact field names, so `MouseLayout.detail_tab_files`/`detail_tab_comments` are **untouched** (verified: 6 accesses preserved).

Methods stay on `AppState`; no semantic change. Pure refactor → **no new tests**; **441 tests, baseline-identical**, fmt/clippy `-D warnings`/check green. `skip-changelog`.

One left after this: increment 7 (Diff/Preview), the most entangled — to be re-evaluated.

Refs #163