### PR TITLE
refactor: finish DRY cleanups (IMAGE_EXTENSIONS + cycling_enum for GistTypeFilter)

### DIFF
--- a/src/domain.rs
+++ b/src/domain.rs
@@ -89,11 +89,17 @@ pub struct GistFile {
     pub node_id: Option<String>,
 }
 
-/// File extensions that are treated as non-text for preview/diff (images, archives, media, …).
+/// Image file extensions — the single source of truth for the "image file" classification,
+/// referenced by both [`extension_looks_binary`] and [`gist_file_non_previewable_reason`].
+const IMAGE_EXTENSIONS: &[&str] = &[
+    "avif", "bmp", "gif", "heic", "heif", "ico", "jpeg", "jpg", "png", "tif", "tiff", "webp",
+];
+
+/// Non-image binary extensions (archives, media, executables, fonts, …). Images live in
+/// [`IMAGE_EXTENSIONS`]; the binary check below treats both lists as non-text.
 const BINARY_EXTENSIONS: &[&str] = &[
-    "avif", "bmp", "bz2", "deb", "dll", "dmg", "dylib", "eot", "exe", "flac", "gif", "gz", "heic",
-    "heif", "ico", "iso", "jpeg", "jpg", "mkv", "mov", "mp3", "mp4", "ogg", "otf", "pdf", "png",
-    "rar", "rpm", "so", "tar", "tif", "tiff", "ttf", "wav", "wasm", "webm", "webp", "woff",
+    "bz2", "deb", "dll", "dmg", "dylib", "eot", "exe", "flac", "gz", "iso", "mkv", "mov", "mp3",
+    "mp4", "ogg", "otf", "pdf", "rar", "rpm", "so", "tar", "ttf", "wav", "wasm", "webm", "woff",
     "woff2", "xz", "zip", "7z",
 ];
 
@@ -150,6 +156,7 @@ pub fn extension_looks_binary(filename: &str) -> bool {
         .is_some_and(|e| {
             BINARY_EXTENSIONS
                 .iter()
+                .chain(IMAGE_EXTENSIONS)
                 .any(|&deny| e.eq_ignore_ascii_case(deny))
         })
 }
@@ -184,23 +191,10 @@ pub fn gist_file_non_previewable_reason(
             .extension()
             .and_then(|e| e.to_str())
             .map(str::to_ascii_lowercase);
-        if matches!(
-            ext.as_deref(),
-            Some(
-                "png"
-                    | "jpg"
-                    | "jpeg"
-                    | "gif"
-                    | "webp"
-                    | "ico"
-                    | "bmp"
-                    | "tif"
-                    | "tiff"
-                    | "heic"
-                    | "heif"
-                    | "avif"
-            )
-        ) {
+        if ext
+            .as_deref()
+            .is_some_and(|e| IMAGE_EXTENSIONS.contains(&e))
+        {
             return "image file";
         }
         return "binary file";

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -144,16 +144,6 @@ pub enum GistView {
     Id,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum GistTypeFilter {
-    #[default]
-    All,
-    Public,
-    Secret,
-    Starred,
-    Forked,
-}
-
 /// Generates a small enum whose variants cycle in declaration order. `next()` advances to the
 /// following variant (wrapping past the last) and `label()` returns each variant's short
 /// status-footer label. Keeping the variant↔label pairing in one place lets the sort enums
@@ -241,6 +231,25 @@ impl Default for PinSort {
     }
 }
 
+cycling_enum! {
+    /// Visibility/type filter for the gist panes, cycled with `v`. `next`/`label` come from
+    /// the macro; the filtering helpers live in a separate `impl` block below.
+    pub enum GistTypeFilter {
+        All => "all",
+        Public => "public",
+        Secret => "secret",
+        Starred => "starred",
+        Forked => "forked",
+    }
+}
+
+impl Default for GistTypeFilter {
+    /// `All` (no filtering) is the natural default.
+    fn default() -> Self {
+        GistTypeFilter::All
+    }
+}
+
 impl GistSort {
     /// Re-orders ranked gists. `Match` keeps the incoming order; the others override it.
     fn apply(self, gists: &mut [RankedGistFile]) {
@@ -290,26 +299,6 @@ impl GistTypeFilter {
             GistTypeFilter::Public => group.public,
             GistTypeFilter::Secret => !group.public,
             GistTypeFilter::Forked => group.fork_of_id.is_some(),
-        }
-    }
-
-    fn next(self) -> Self {
-        match self {
-            GistTypeFilter::All => GistTypeFilter::Public,
-            GistTypeFilter::Public => GistTypeFilter::Secret,
-            GistTypeFilter::Secret => GistTypeFilter::Starred,
-            GistTypeFilter::Starred => GistTypeFilter::Forked,
-            GistTypeFilter::Forked => GistTypeFilter::All,
-        }
-    }
-
-    fn label(self) -> &'static str {
-        match self {
-            GistTypeFilter::All => "all",
-            GistTypeFilter::Public => "public",
-            GistTypeFilter::Secret => "secret",
-            GistTypeFilter::Starred => "starred",
-            GistTypeFilter::Forked => "forked",
         }
     }
 }


### PR DESCRIPTION
Completes #160 (after #169's simp-1/2/7 and #174's simp-4/5).

- **simp-3** — extract `IMAGE_EXTENSIONS` (12 entries). It was duplicated inside `BINARY_EXTENSIONS` *and* as a `matches!` arm in `gist_file_non_previewable_reason`. Now: `BINARY_EXTENSIONS` holds non-image binaries only, `extension_looks_binary` chains both lists (same union → same behaviour), the image check is `IMAGE_EXTENSIONS.contains`.
- **simp-6** — `GistTypeFilter` now gets `next()`/`label()` from the `cycling_enum!` macro (its old hand-rolled `next` already cycled in declaration order; labels unchanged). The filtering helpers (`uses_starred_source`/`matches_file`/`matches_group`) stay in a separate `impl`; a 3-line manual `impl Default` (`All`) replaces the derive (the macro doesn't derive `Default`).

Behaviour-preserving → **no new tests**; **441 tests, baseline-identical**, fmt/clippy `-D warnings`/check green. `skip-changelog`.

Closes #160