### PR TITLE
refactor(tui): extract pure helpers into tui::text (decouple state from render) — arch-3

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -890,7 +890,7 @@ impl AppState {
         let query = self.local_filter_query.to_lowercase();
         if !query.is_empty() {
             ranked.retain(|r| {
-                render::local_row_label(&r.candidate.path, &self.cwd)
+                local_row_label(&r.candidate.path, &self.cwd)
                     .to_lowercase()
                     .contains(&query)
             });
@@ -1699,7 +1699,7 @@ impl AppState {
         self.detail.comments_loading_more = false;
         match result {
             Ok(mut older) => {
-                let added = crate::tui::render::comment_lines_count(&older);
+                let added = comment_lines_count(&older);
                 if let Some(existing) = self.detail.comments.as_mut() {
                     older.append(existing);
                     *existing = older;
@@ -1736,6 +1736,8 @@ impl AppState {
 mod highlight;
 mod render;
 use render::*;
+mod text;
+use text::{comment_lines_count, local_row_label};
 mod keys;
 mod run_loop;
 use run_loop::run_loop;

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1085,16 +1085,6 @@ pub(super) fn comment_lines<'a>(
     lines
 }
 
-/// Logical line count of `comment_lines(comments, …)` — the amount to add to
-/// `detail_scroll` when older comments are prepended, so the viewport does not jump.
-pub(super) fn comment_lines_count(comments: &[GistComment]) -> u16 {
-    comments
-        .iter()
-        .map(|c| 2 + c.body.lines().count())
-        .sum::<usize>()
-        .min(u16::MAX as usize) as u16
-}
-
 /// Dim helper line (matches the existing dim placeholder styling).
 fn dim_line<'a>(text: &'a str, state: &AppState) -> Line<'a> {
     Line::from(Span::styled(text, Style::default().fg(state.theme.dim)))
@@ -1317,10 +1307,6 @@ pub(super) fn render_gist_detail(frame: &mut Frame, state: &AppState, layout: &m
             &state.theme,
         ));
     }
-}
-
-pub(super) fn local_row_label(path: &std::path::Path, cwd: &std::path::Path) -> String {
-    path.strip_prefix(cwd).unwrap_or(path).display().to_string()
 }
 
 pub(super) fn hscroll_str(text: &str, offset: u16) -> String {
@@ -1654,7 +1640,7 @@ pub(super) fn render_list(frame: &mut Frame, state: &AppState, layout: &mut Mous
         visible_locals
             .iter()
             .map(|r| {
-                let base = local_row_label(&r.candidate.path, &state.cwd);
+                let base = super::text::local_row_label(&r.candidate.path, &state.cwd);
                 marked_item(base, row_mark(&r.reasons), state.local_hscroll)
             })
             .collect()

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -4649,7 +4649,8 @@ fn wheel_step_gist_detail_files_moves_one() {
 #[test]
 fn comment_lines_count_matches_built_lines() {
     use crate::domain::GistComment;
-    use crate::tui::render::{comment_lines, comment_lines_count};
+    use crate::tui::render::comment_lines;
+    use crate::tui::text::comment_lines_count;
     let theme = crate::tui::theme::Theme::for_choice(crate::config::ThemeChoice::Dark);
     let comments = vec![
         GistComment {

--- a/src/tui/text.rs
+++ b/src/tui/text.rs
@@ -1,0 +1,21 @@
+//! Pure display/format helpers shared by the state layer (`AppState`) and the render layer,
+//! kept out of `render` so `AppState` logic does not depend on the presentation module.
+
+use crate::domain::GistComment;
+use std::path::Path;
+
+/// A local file path shortened relative to `cwd` for list-row display.
+pub(super) fn local_row_label(path: &Path, cwd: &Path) -> String {
+    path.strip_prefix(cwd).unwrap_or(path).display().to_string()
+}
+
+/// Logical line count of the rendered comment block — must mirror `render::comment_lines`
+/// (1 author header + body lines + 1 blank per comment). The amount to bump the comment
+/// scroll by when older comments are prepended.
+pub(super) fn comment_lines_count(comments: &[GistComment]) -> u16 {
+    comments
+        .iter()
+        .map(|c| 2 + c.body.lines().count())
+        .sum::<usize>()
+        .min(u16::MAX as usize) as u16
+}


### PR DESCRIPTION
First slice of #164 (arch-3).

The pure `AppState` layer depended on the presentation module `render` for two pure helpers. (The audit listed four, but `gist_group_row_label`/`unix_now` are only used *within* render — the actual coupling is just these two.)

- New pure module **`src/tui/text.rs`** holds `local_row_label` (cwd-relative path label) and `comment_lines_count` (comment-block line count for scroll compensation). No ratatui types.
- `mod.rs` and `render.rs` import from `text`; the state→render dependency for these is gone.
- `comment_lines` (returns a ratatui `Line`, genuinely presentation) stays in `render`; the existing `comment_lines_count_matches_built_lines` test still guards that the count mirrors the builder.

Pure move, behaviour-preserving → **no new tests**; **441 tests, baseline-identical**, fmt/clippy `-D warnings`/check green. `skip-changelog`.

Next in #164: arch-2 (split the ~1430-line `run_loop()`) — to be brainstormed; deps-3 likely deferred (YAGNI).

Refs #164