### PR TITLE
refactor(tui): split run_loop — extract absorb_background_results (arch-2, 1/2)

### DIFF
--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -57,588 +57,10 @@ pub(super) fn run_loop(
         // in-progress states (scanning/loading/working) animate even with no input.
         state.spinner_frame = state.spinner_frame.wrapping_add(1);
 
-        // Absorb the background gist list once it arrives.
-        if state.loading {
-            if let Some(ref rx) = channels.gist {
-                if let Ok((
-                    gists,
-                    starred,
-                    starred_ids,
-                    user_login,
-                    comment_counts,
-                    owned_raw,
-                    starred_raw,
-                )) = rx.try_recv()
-                {
-                    persist_gist_cache_from_state_fields(
-                        &gists,
-                        &starred,
-                        &starred_ids,
-                        &user_login,
-                        &comment_counts,
-                        &state.gist_fork_counts,
-                        &state.gist_star_counts,
-                    );
-                    state.gists = gists;
-                    state.starred_gists = starred;
-                    state.starred_gist_ids = starred_ids;
-                    state.current_user_login = user_login;
-                    state.gist_comment_counts = comment_counts;
-                    state.loading = false;
-                    if state.gist_index >= state.ranked_gists().len() {
-                        state.gist_index = 0;
-                    }
-                    let count = state.visible_gist_groups().len();
-                    if count > 0 && state.gist_manager.index >= count {
-                        state.gist_manager.index = count - 1;
-                    }
-                    channels.gist = None;
-                    let gist_ids: std::collections::HashSet<String> = state
-                        .gists
-                        .iter()
-                        .chain(state.starred_gists.iter())
-                        .map(|g| g.gist_id.clone())
-                        .collect();
-                    channels.fork = Some(spawn_fork_count_fetch(
-                        owned_raw,
-                        starred_raw,
-                        gist_ids.clone(),
-                    ));
-                    channels.fork_meta = Some(spawn_fork_metadata_fetch(
-                        state.gists.iter().map(|g| g.gist_id.clone()).collect(),
-                    ));
-                    let node_ids =
-                        crate::gh::merge_gist_node_id_maps(&state.gists, &state.starred_gists);
-                    channels.star = Some(spawn_star_count_fetch(node_ids));
-                }
-            }
-        }
-
-        if let Some(ref rx) = channels.fork {
-            if let Ok(fork_counts) = rx.try_recv() {
-                state.gist_fork_counts = fork_counts;
-                persist_gist_cache_from_state(&state);
-                channels.fork = None;
-            }
-        }
-
-        if let Some(ref rx) = channels.star {
-            if let Ok(star_counts) = rx.try_recv() {
-                state.gist_star_counts = star_counts;
-                persist_gist_cache_from_state(&state);
-                channels.star = None;
-            }
-        }
-
-        if let Some(ref rx) = channels.fork_meta {
-            if let Ok(result) = rx.try_recv() {
-                match result {
-                    Ok(fork_of) => {
-                        crate::gh::apply_fork_of_ids(&mut state.gists, &fork_of);
-                        persist_gist_cache_from_state(&state);
-                    }
-                    Err(error) => state.set_status(format!("fork detection unavailable: {error}")),
-                }
-                channels.fork_meta = None;
-            }
-        }
-
-        // Absorb a completed background local scan.
-        if state.local_scanning {
-            if let Some(ref rx) = channels.local {
-                if let Ok(locals) = rx.try_recv() {
-                    let selected = state.selected_local().map(|c| c.path.clone());
-                    state.locals = locals;
-                    state.local_index = selected
-                        .and_then(|path| state.locals.iter().position(|c| c.path == path))
-                        .unwrap_or(0)
-                        .min(state.locals.len().saturating_sub(1));
-                    if state.gist_index >= state.ranked_gists().len() {
-                        state.gist_index = 0;
-                    }
-                    state.local_scanning = false;
-                    state.status = None;
-                    channels.local = None;
-                }
-            }
-        }
-
-        // Absorb the background update-check result: show the hint and persist the throttle.
-        // Failed checks are silent and not recorded, so they retry on the next launch.
-        if let Some(ref rx) = channels.update {
-            if let Ok(outcome) = rx.try_recv() {
-                channels.update = None;
-                let now = crate::update_check::now_secs();
-                match outcome {
-                    crate::update_check::UpdateCheckOutcome::Newer(version) => {
-                        if let Some(ref path) = update_check_path {
-                            crate::update_check::save_state(
-                                path,
-                                &crate::update_check::UpdateCheckState {
-                                    last_check: now,
-                                    latest_seen: version.clone(),
-                                },
-                            );
-                        }
-                        state.update_available = Some(version);
-                    }
-                    crate::update_check::UpdateCheckOutcome::UpToDate => {
-                        if let Some(ref path) = update_check_path {
-                            crate::update_check::save_state(
-                                path,
-                                &crate::update_check::UpdateCheckState {
-                                    last_check: now,
-                                    latest_seen: String::new(),
-                                },
-                            );
-                        }
-                        state.update_available = None;
-                    }
-                    crate::update_check::UpdateCheckOutcome::Failed => {}
-                }
-            }
-        }
-
-        // Absorb a completed background per-action task.
-        if let Some(ref rx) = channels.bg {
-            if let Ok(outcome) = rx.try_recv() {
-                state.bg_task_msg = None;
-                channels.bg = None;
-                match outcome {
-                    BgTaskOutcome::PreviewDiff {
-                        result,
-                        local_path,
-                        local_label,
-                        gist_label,
-                        target,
-                        upload_orientation,
-                    } => match result {
-                        Ok(remote) => {
-                            match local_path.as_ref().map(std::fs::read_to_string).transpose() {
-                                Ok(local) => {
-                                    let local_content = local.unwrap_or_default();
-                                    let diff = preview_diff_text(
-                                        upload_orientation,
-                                        &local_label,
-                                        &local_content,
-                                        &gist_label,
-                                        &remote,
-                                        state.ignore_trailing_newline,
-                                    );
-                                    let identical = crate::diff::content_eq(
-                                        &local_content,
-                                        &remote,
-                                        state.ignore_trailing_newline,
-                                    );
-                                    state.enter_diff(
-                                        diff,
-                                        remote,
-                                        local_path.unwrap_or_default(),
-                                        target,
-                                    );
-                                    state.diff_identical = identical;
-                                }
-                                Err(error) => state.set_status(format!("read failed: {error}")),
-                            }
-                        }
-                        Err(error) => state.set_status(format!("fetch failed: {error}")),
-                    },
-                    BgTaskOutcome::DownloadSelected {
-                        result,
-                        target,
-                        local_label,
-                        gist_label,
-                        gist_id,
-                        filename,
-                    } => match result {
-                        Ok(remote) => {
-                            if target.exists() {
-                                match std::fs::read_to_string(&target) {
-                                    Ok(local_content) => {
-                                        let diff = crate::diff::unified_diff(
-                                            &local_label,
-                                            &local_content,
-                                            &gist_label,
-                                            &remote,
-                                            state.ignore_trailing_newline,
-                                        );
-                                        let identical = crate::diff::content_eq(
-                                            &local_content,
-                                            &remote,
-                                            state.ignore_trailing_newline,
-                                        );
-                                        state.download_gist_id = Some(gist_id);
-                                        state.download_gist_filename = Some(filename);
-                                        state.enter_diff(diff, remote, target.clone(), target);
-                                        state.diff_identical = identical;
-                                    }
-                                    Err(error) => state.set_status(format!("read failed: {error}")),
-                                }
-                            } else {
-                                match crate::actions::execute_download(&target, &remote, false) {
-                                    Ok(()) => {
-                                        state.set_status(format!(
-                                            "Downloaded {}",
-                                            target
-                                                .file_name()
-                                                .unwrap_or(target.as_os_str())
-                                                .to_string_lossy()
-                                        ));
-                                        record_pin_sync(
-                                            &mut state,
-                                            &target,
-                                            &gist_id,
-                                            &filename,
-                                            &remote,
-                                            crate::domain::SyncDirection::Download,
-                                        );
-                                        refresh_locals(&mut state);
-                                    }
-                                    Err(error) => {
-                                        state.set_status(format!("download failed: {error}"))
-                                    }
-                                }
-                            }
-                        }
-                        Err(error) => state.set_status(format!("fetch failed: {error}")),
-                    },
-                    BgTaskOutcome::UploadPreview {
-                        result,
-                        gist_id,
-                        filename,
-                        local_path,
-                        local_label,
-                        gist_label,
-                    } => match result {
-                        Ok(remote) => {
-                            state.pending_action = Some(PendingAction::Upload {
-                                gist_id,
-                                filename,
-                                local_path: local_path.clone(),
-                            });
-                            match state.init_upload_state(
-                                &local_path,
-                                Some(remote),
-                                local_label,
-                                gist_label,
-                            ) {
-                                Ok(()) => {
-                                    state.diff_scroll = 0;
-                                    state.diff_hscroll = 0;
-                                    state.status = None;
-                                    state.screen = Screen::Confirm;
-                                }
-                                Err(error) => {
-                                    state.pending_action = None;
-                                    state.set_status(format!(
-                                        "cannot read {}: {error}",
-                                        crate::config::display_path(&local_path)
-                                    ));
-                                }
-                            }
-                        }
-                        Err(error) => state.set_status(format!("fetch failed: {error}")),
-                    },
-                    BgTaskOutcome::UploadReplace {
-                        result,
-                        gist_id,
-                        filename,
-                    } => match result {
-                        Ok(_) => {
-                            state
-                                .gist_content_cache
-                                .remove(&(gist_id.clone(), filename.clone()));
-                            state.set_status(format!("Uploaded {} to gist {}", filename, gist_id));
-                            if let Some(local_path) = state.upload_local_path() {
-                                let content = state.content_to_upload();
-                                record_pin_sync(
-                                    &mut state,
-                                    &local_path,
-                                    &gist_id,
-                                    &filename,
-                                    &content,
-                                    crate::domain::SyncDirection::Upload,
-                                );
-                            }
-                            state.back_to_list();
-                            state.loading = true;
-                            channels.gist = Some(spawn_gist_fetch());
-                        }
-                        Err(error) => {
-                            state.set_status(format!("upload failed: {error}"));
-                            state.screen = Screen::Confirm;
-                        }
-                    },
-                    BgTaskOutcome::CreateGist {
-                        result,
-                        local_path,
-                        public,
-                    } => match result {
-                        Ok(_) => {
-                            let visibility = if public { "public" } else { "secret" };
-                            state.set_status(format!(
-                                "Created {} gist from {}",
-                                visibility,
-                                crate::config::display_path(&local_path)
-                            ));
-                            state.description_input.clear();
-                            state.back_to_list();
-                            state.loading = true;
-                            channels.gist = Some(spawn_gist_fetch());
-                        }
-                        Err(error) => {
-                            state.set_status(format!("create failed: {error}"));
-                            state.screen = Screen::List;
-                            state.pending_action = None;
-                            state.description_input.clear();
-                        }
-                    },
-                    BgTaskOutcome::PreviewContent {
-                        result,
-                        key,
-                        preview_title,
-                    } => match result {
-                        Ok(content) => {
-                            state
-                                .gist_content_cache
-                                .insert(key.clone(), content.clone());
-                            state.preview_title = preview_title;
-                            state.preview_gist_key = Some(key);
-                            state.diff_text = content;
-                            state.diff_scroll = 0;
-                            state.diff_hscroll = 0;
-                            state.status = None;
-                            state.screen = Screen::Preview;
-                        }
-                        Err(error) => state.set_status(format!("fetch failed: {error}")),
-                    },
-                    BgTaskOutcome::DeleteGist { result, gist_id } => match result {
-                        Ok(_) => {
-                            state.set_status(format!("Deleted gist {gist_id}"));
-                            state.loading = true;
-                            channels.gist = Some(spawn_gist_fetch());
-                        }
-                        Err(error) => state.set_status(format!("delete failed: {error}")),
-                    },
-                    BgTaskOutcome::RemoveFile {
-                        result,
-                        gist_id,
-                        filename,
-                    } => match result {
-                        Ok(_) => {
-                            state
-                                .gist_content_cache
-                                .remove(&(gist_id.clone(), filename.clone()));
-                            state.set_status(format!("Removed {filename} from gist {gist_id}"));
-                            state.loading = true;
-                            channels.gist = Some(spawn_gist_fetch());
-                        }
-                        Err(error) => state.set_status(format!("remove failed: {error}")),
-                    },
-                    BgTaskOutcome::ApplyDescription { result, gist_id } => match result {
-                        Ok(_) => {
-                            state.set_status(format!("Updated description for gist {gist_id}"));
-                            state.loading = true;
-                            channels.gist = Some(spawn_gist_fetch());
-                        }
-                        Err(error) => {
-                            state.set_status(format!("description update failed: {error}"))
-                        }
-                    },
-                    BgTaskOutcome::CompactAnalyze {
-                        result,
-                        gist_id,
-                        label,
-                    } => match result {
-                        Ok(count) if count <= 1 => state.set_status(format!(
-                            "\"{label}\" already has a single revision — nothing to compact"
-                        )),
-                        Ok(count) => {
-                            state.diff_text = format!(
-                                "Compact gist {gist_id} (\"{label}\").\n\nIt has {count} revisions. Compacting clones it to a temp dir, squashes the history to a single commit, and force-pushes — the {} older revisions are gone for good.",
-                                count - 1
-                            );
-                            state.diff_scroll = 0;
-                            state.diff_hscroll = 0;
-                            state.pending_action = Some(PendingAction::CompactGist {
-                                gist_id,
-                                label,
-                                count,
-                            });
-                            state.screen = Screen::Confirm;
-                        }
-                        Err(error) => state.set_status(format!("revision check failed: {error}")),
-                    },
-                    BgTaskOutcome::CompactGist {
-                        result,
-                        label,
-                        count,
-                    } => match result {
-                        Ok(_) => {
-                            state.set_status(format!(
-                                "Compacted \"{label}\" ({count} → 1 revision)"
-                            ));
-                            state.loading = true;
-                            channels.gist = Some(spawn_gist_fetch());
-                        }
-                        Err(error) => state.set_status(format!("compact failed: {error}")),
-                    },
-                    BgTaskOutcome::CommentsInitialLoaded { gist_id, result } => {
-                        state.apply_initial_comments(&gist_id, result);
-                    }
-                    BgTaskOutcome::CommentsOlderLoaded { gist_id, result } => {
-                        state.apply_older_comments(&gist_id, result);
-                    }
-                    BgTaskOutcome::RevisionsFetched { gist_id, result } => {
-                        if state.revision.gist_id.as_deref() != Some(gist_id.as_str()) {
-                            continue;
-                        }
-                        match result {
-                            Ok(entries) => {
-                                state.revision.fetch_error = None;
-                                state.revision.entries = Some(entries);
-                                if state
-                                    .revision
-                                    .entries
-                                    .as_ref()
-                                    .is_some_and(|e| e.len() <= 1)
-                                {
-                                    state.set_status("only one revision — nothing to restore");
-                                }
-                            }
-                            Err(error) => {
-                                state.revision.entries = Some(Vec::new());
-                                state.revision.fetch_error = Some(error);
-                            }
-                        }
-                    }
-                    BgTaskOutcome::RevisionDiff {
-                        result,
-                        old_label,
-                        new_label,
-                    } => match result {
-                        Ok((old_content, new_content)) => {
-                            let diff = crate::diff::unified_diff(
-                                &old_label,
-                                &old_content,
-                                &new_label,
-                                &new_content,
-                                state.ignore_trailing_newline,
-                            );
-                            state.diff_text = diff;
-                            state.diff_scroll = 0;
-                            state.diff_hscroll = 0;
-                            state.diff_identical = old_content == new_content;
-                            state.diff_return = Screen::Revisions;
-                            state.pending_action = None;
-                            state.screen = Screen::Diff;
-                        }
-                        Err(error) => state.set_status(error),
-                    },
-                    BgTaskOutcome::RestoreRevisionReady {
-                        result,
-                        gist_id,
-                        filename,
-                        version,
-                        version_label,
-                    } => match result {
-                        Ok((revision_content, current_content)) => {
-                            if revision_content == current_content {
-                                state.set_status("revision matches current — nothing to restore");
-                                continue;
-                            }
-                            let old_label = format!("revision {version_label}");
-                            let new_label = format!("current {filename}");
-                            let diff = crate::diff::unified_diff(
-                                &old_label,
-                                &revision_content,
-                                &new_label,
-                                &current_content,
-                                state.ignore_trailing_newline,
-                            );
-                            state.diff_text = diff;
-                            state.diff_scroll = 0;
-                            state.diff_hscroll = 0;
-                            state.diff_identical = false;
-                            state.pending_action = Some(PendingAction::RestoreRevision {
-                                gist_id,
-                                filename,
-                                version,
-                                version_label,
-                                content: revision_content,
-                            });
-                            state.screen = Screen::Confirm;
-                        }
-                        Err(error) => state.set_status(error),
-                    },
-                    BgTaskOutcome::GistStarToggle {
-                        result,
-                        gist_id,
-                        starred,
-                    } => match result {
-                        Ok(()) => {
-                            if starred {
-                                state.starred_gist_ids.insert(gist_id.clone());
-                                state.set_status(format!("starred {gist_id}"));
-                            } else {
-                                state.starred_gist_ids.remove(&gist_id);
-                                state.set_status(format!("unstarred {gist_id}"));
-                            }
-                            state.loading = true;
-                            channels.gist = Some(spawn_gist_fetch());
-                        }
-                        Err(error) => state.set_status(format!("star toggle failed: {error}")),
-                    },
-                    BgTaskOutcome::ForkGist { result, gist_id } => match result {
-                        Ok(()) => {
-                            state.set_status(format!("forked {gist_id} into your account"));
-                            state.loading = true;
-                            channels.gist = Some(spawn_gist_fetch());
-                        }
-                        Err(error) => state.set_status(format!("fork failed: {error}")),
-                    },
-                    BgTaskOutcome::RestoreRevisionDone {
-                        result,
-                        gist_id,
-                        filename,
-                    } => match result {
-                        Ok(_) => {
-                            state
-                                .gist_content_cache
-                                .remove(&(gist_id.clone(), filename.clone()));
-                            state.set_status(format!(
-                                "Restored {filename} from old revision (new revision created)"
-                            ));
-                            state.pending_action = None;
-                            state.screen = Screen::Revisions;
-                            state.revision.index = 0;
-                            state.revision.entries = None;
-                            state.loading = true;
-                            channels.gist = Some(spawn_gist_fetch());
-                            if let Some(gist_id) = state.revision.gist_id.clone() {
-                                spawn_bg(
-                                    &mut state,
-                                    &mut channels.bg,
-                                    "Loading revisions…",
-                                    move || {
-                                        let result = crate::gh::fetch_gist_commits_json(&gist_id)
-                                            .map_err(|e| e.to_string())
-                                            .and_then(|raw| {
-                                                crate::gh::parse_gist_commits_json(&raw)
-                                                    .map_err(|e| e.to_string())
-                                            });
-                                        BgTaskOutcome::RevisionsFetched { gist_id, result }
-                                    },
-                                );
-                            }
-                        }
-                        Err(error) => {
-                            state.set_status(format!("restore failed: {error}"));
-                            state.screen = Screen::Confirm;
-                        }
-                    },
-                }
-            }
+        match absorb_background_results(&mut state, &mut channels, &update_check_path)? {
+            LoopFlow::Quit => break,
+            LoopFlow::SkipIteration => continue,
+            LoopFlow::Proceed => {}
         }
 
         // Poll so the loop also wakes to check the background fetches, not only on input.
@@ -2355,4 +1777,593 @@ struct BgChannels {
     fork_meta: Option<std::sync::mpsc::Receiver<ForkMetaResult>>,
     local: Option<std::sync::mpsc::Receiver<Vec<LocalCandidate>>>,
     bg: BgRx,
+}
+
+/// `Quit` is constructed by `dispatch_outcome` (the next run_loop-split increment); the
+/// `#[allow]` keeps this increment warning-clean until then.
+#[allow(dead_code)]
+enum LoopFlow {
+    Proceed,
+    SkipIteration,
+    Quit,
+}
+
+fn absorb_background_results(
+    state: &mut AppState,
+    channels: &mut BgChannels,
+    update_check_path: &Option<std::path::PathBuf>,
+) -> Result<LoopFlow> {
+    // Absorb the background gist list once it arrives.
+    if state.loading {
+        if let Some(ref rx) = channels.gist {
+            if let Ok((
+                gists,
+                starred,
+                starred_ids,
+                user_login,
+                comment_counts,
+                owned_raw,
+                starred_raw,
+            )) = rx.try_recv()
+            {
+                persist_gist_cache_from_state_fields(
+                    &gists,
+                    &starred,
+                    &starred_ids,
+                    &user_login,
+                    &comment_counts,
+                    &state.gist_fork_counts,
+                    &state.gist_star_counts,
+                );
+                state.gists = gists;
+                state.starred_gists = starred;
+                state.starred_gist_ids = starred_ids;
+                state.current_user_login = user_login;
+                state.gist_comment_counts = comment_counts;
+                state.loading = false;
+                if state.gist_index >= state.ranked_gists().len() {
+                    state.gist_index = 0;
+                }
+                let count = state.visible_gist_groups().len();
+                if count > 0 && state.gist_manager.index >= count {
+                    state.gist_manager.index = count - 1;
+                }
+                channels.gist = None;
+                let gist_ids: std::collections::HashSet<String> = state
+                    .gists
+                    .iter()
+                    .chain(state.starred_gists.iter())
+                    .map(|g| g.gist_id.clone())
+                    .collect();
+                channels.fork = Some(spawn_fork_count_fetch(
+                    owned_raw,
+                    starred_raw,
+                    gist_ids.clone(),
+                ));
+                channels.fork_meta = Some(spawn_fork_metadata_fetch(
+                    state.gists.iter().map(|g| g.gist_id.clone()).collect(),
+                ));
+                let node_ids =
+                    crate::gh::merge_gist_node_id_maps(&state.gists, &state.starred_gists);
+                channels.star = Some(spawn_star_count_fetch(node_ids));
+            }
+        }
+    }
+
+    if let Some(ref rx) = channels.fork {
+        if let Ok(fork_counts) = rx.try_recv() {
+            state.gist_fork_counts = fork_counts;
+            persist_gist_cache_from_state(state);
+            channels.fork = None;
+        }
+    }
+
+    if let Some(ref rx) = channels.star {
+        if let Ok(star_counts) = rx.try_recv() {
+            state.gist_star_counts = star_counts;
+            persist_gist_cache_from_state(state);
+            channels.star = None;
+        }
+    }
+
+    if let Some(ref rx) = channels.fork_meta {
+        if let Ok(result) = rx.try_recv() {
+            match result {
+                Ok(fork_of) => {
+                    crate::gh::apply_fork_of_ids(&mut state.gists, &fork_of);
+                    persist_gist_cache_from_state(state);
+                }
+                Err(error) => state.set_status(format!("fork detection unavailable: {error}")),
+            }
+            channels.fork_meta = None;
+        }
+    }
+
+    // Absorb a completed background local scan.
+    if state.local_scanning {
+        if let Some(ref rx) = channels.local {
+            if let Ok(locals) = rx.try_recv() {
+                let selected = state.selected_local().map(|c| c.path.clone());
+                state.locals = locals;
+                state.local_index = selected
+                    .and_then(|path| state.locals.iter().position(|c| c.path == path))
+                    .unwrap_or(0)
+                    .min(state.locals.len().saturating_sub(1));
+                if state.gist_index >= state.ranked_gists().len() {
+                    state.gist_index = 0;
+                }
+                state.local_scanning = false;
+                state.status = None;
+                channels.local = None;
+            }
+        }
+    }
+
+    // Absorb the background update-check result: show the hint and persist the throttle.
+    // Failed checks are silent and not recorded, so they retry on the next launch.
+    if let Some(ref rx) = channels.update {
+        if let Ok(outcome) = rx.try_recv() {
+            channels.update = None;
+            let now = crate::update_check::now_secs();
+            match outcome {
+                crate::update_check::UpdateCheckOutcome::Newer(version) => {
+                    if let Some(ref path) = update_check_path {
+                        crate::update_check::save_state(
+                            path,
+                            &crate::update_check::UpdateCheckState {
+                                last_check: now,
+                                latest_seen: version.clone(),
+                            },
+                        );
+                    }
+                    state.update_available = Some(version);
+                }
+                crate::update_check::UpdateCheckOutcome::UpToDate => {
+                    if let Some(ref path) = update_check_path {
+                        crate::update_check::save_state(
+                            path,
+                            &crate::update_check::UpdateCheckState {
+                                last_check: now,
+                                latest_seen: String::new(),
+                            },
+                        );
+                    }
+                    state.update_available = None;
+                }
+                crate::update_check::UpdateCheckOutcome::Failed => {}
+            }
+        }
+    }
+
+    // Absorb a completed background per-action task.
+    if let Some(ref rx) = channels.bg {
+        if let Ok(outcome) = rx.try_recv() {
+            state.bg_task_msg = None;
+            channels.bg = None;
+            match outcome {
+                BgTaskOutcome::PreviewDiff {
+                    result,
+                    local_path,
+                    local_label,
+                    gist_label,
+                    target,
+                    upload_orientation,
+                } => match result {
+                    Ok(remote) => {
+                        match local_path.as_ref().map(std::fs::read_to_string).transpose() {
+                            Ok(local) => {
+                                let local_content = local.unwrap_or_default();
+                                let diff = preview_diff_text(
+                                    upload_orientation,
+                                    &local_label,
+                                    &local_content,
+                                    &gist_label,
+                                    &remote,
+                                    state.ignore_trailing_newline,
+                                );
+                                let identical = crate::diff::content_eq(
+                                    &local_content,
+                                    &remote,
+                                    state.ignore_trailing_newline,
+                                );
+                                state.enter_diff(
+                                    diff,
+                                    remote,
+                                    local_path.unwrap_or_default(),
+                                    target,
+                                );
+                                state.diff_identical = identical;
+                            }
+                            Err(error) => state.set_status(format!("read failed: {error}")),
+                        }
+                    }
+                    Err(error) => state.set_status(format!("fetch failed: {error}")),
+                },
+                BgTaskOutcome::DownloadSelected {
+                    result,
+                    target,
+                    local_label,
+                    gist_label,
+                    gist_id,
+                    filename,
+                } => match result {
+                    Ok(remote) => {
+                        if target.exists() {
+                            match std::fs::read_to_string(&target) {
+                                Ok(local_content) => {
+                                    let diff = crate::diff::unified_diff(
+                                        &local_label,
+                                        &local_content,
+                                        &gist_label,
+                                        &remote,
+                                        state.ignore_trailing_newline,
+                                    );
+                                    let identical = crate::diff::content_eq(
+                                        &local_content,
+                                        &remote,
+                                        state.ignore_trailing_newline,
+                                    );
+                                    state.download_gist_id = Some(gist_id);
+                                    state.download_gist_filename = Some(filename);
+                                    state.enter_diff(diff, remote, target.clone(), target);
+                                    state.diff_identical = identical;
+                                }
+                                Err(error) => state.set_status(format!("read failed: {error}")),
+                            }
+                        } else {
+                            match crate::actions::execute_download(&target, &remote, false) {
+                                Ok(()) => {
+                                    state.set_status(format!(
+                                        "Downloaded {}",
+                                        target
+                                            .file_name()
+                                            .unwrap_or(target.as_os_str())
+                                            .to_string_lossy()
+                                    ));
+                                    record_pin_sync(
+                                        state,
+                                        &target,
+                                        &gist_id,
+                                        &filename,
+                                        &remote,
+                                        crate::domain::SyncDirection::Download,
+                                    );
+                                    refresh_locals(state);
+                                }
+                                Err(error) => state.set_status(format!("download failed: {error}")),
+                            }
+                        }
+                    }
+                    Err(error) => state.set_status(format!("fetch failed: {error}")),
+                },
+                BgTaskOutcome::UploadPreview {
+                    result,
+                    gist_id,
+                    filename,
+                    local_path,
+                    local_label,
+                    gist_label,
+                } => match result {
+                    Ok(remote) => {
+                        state.pending_action = Some(PendingAction::Upload {
+                            gist_id,
+                            filename,
+                            local_path: local_path.clone(),
+                        });
+                        match state.init_upload_state(
+                            &local_path,
+                            Some(remote),
+                            local_label,
+                            gist_label,
+                        ) {
+                            Ok(()) => {
+                                state.diff_scroll = 0;
+                                state.diff_hscroll = 0;
+                                state.status = None;
+                                state.screen = Screen::Confirm;
+                            }
+                            Err(error) => {
+                                state.pending_action = None;
+                                state.set_status(format!(
+                                    "cannot read {}: {error}",
+                                    crate::config::display_path(&local_path)
+                                ));
+                            }
+                        }
+                    }
+                    Err(error) => state.set_status(format!("fetch failed: {error}")),
+                },
+                BgTaskOutcome::UploadReplace {
+                    result,
+                    gist_id,
+                    filename,
+                } => match result {
+                    Ok(_) => {
+                        state
+                            .gist_content_cache
+                            .remove(&(gist_id.clone(), filename.clone()));
+                        state.set_status(format!("Uploaded {} to gist {}", filename, gist_id));
+                        if let Some(local_path) = state.upload_local_path() {
+                            let content = state.content_to_upload();
+                            record_pin_sync(
+                                state,
+                                &local_path,
+                                &gist_id,
+                                &filename,
+                                &content,
+                                crate::domain::SyncDirection::Upload,
+                            );
+                        }
+                        state.back_to_list();
+                        state.loading = true;
+                        channels.gist = Some(spawn_gist_fetch());
+                    }
+                    Err(error) => {
+                        state.set_status(format!("upload failed: {error}"));
+                        state.screen = Screen::Confirm;
+                    }
+                },
+                BgTaskOutcome::CreateGist {
+                    result,
+                    local_path,
+                    public,
+                } => match result {
+                    Ok(_) => {
+                        let visibility = if public { "public" } else { "secret" };
+                        state.set_status(format!(
+                            "Created {} gist from {}",
+                            visibility,
+                            crate::config::display_path(&local_path)
+                        ));
+                        state.description_input.clear();
+                        state.back_to_list();
+                        state.loading = true;
+                        channels.gist = Some(spawn_gist_fetch());
+                    }
+                    Err(error) => {
+                        state.set_status(format!("create failed: {error}"));
+                        state.screen = Screen::List;
+                        state.pending_action = None;
+                        state.description_input.clear();
+                    }
+                },
+                BgTaskOutcome::PreviewContent {
+                    result,
+                    key,
+                    preview_title,
+                } => match result {
+                    Ok(content) => {
+                        state
+                            .gist_content_cache
+                            .insert(key.clone(), content.clone());
+                        state.preview_title = preview_title;
+                        state.preview_gist_key = Some(key);
+                        state.diff_text = content;
+                        state.diff_scroll = 0;
+                        state.diff_hscroll = 0;
+                        state.status = None;
+                        state.screen = Screen::Preview;
+                    }
+                    Err(error) => state.set_status(format!("fetch failed: {error}")),
+                },
+                BgTaskOutcome::DeleteGist { result, gist_id } => match result {
+                    Ok(_) => {
+                        state.set_status(format!("Deleted gist {gist_id}"));
+                        state.loading = true;
+                        channels.gist = Some(spawn_gist_fetch());
+                    }
+                    Err(error) => state.set_status(format!("delete failed: {error}")),
+                },
+                BgTaskOutcome::RemoveFile {
+                    result,
+                    gist_id,
+                    filename,
+                } => match result {
+                    Ok(_) => {
+                        state
+                            .gist_content_cache
+                            .remove(&(gist_id.clone(), filename.clone()));
+                        state.set_status(format!("Removed {filename} from gist {gist_id}"));
+                        state.loading = true;
+                        channels.gist = Some(spawn_gist_fetch());
+                    }
+                    Err(error) => state.set_status(format!("remove failed: {error}")),
+                },
+                BgTaskOutcome::ApplyDescription { result, gist_id } => match result {
+                    Ok(_) => {
+                        state.set_status(format!("Updated description for gist {gist_id}"));
+                        state.loading = true;
+                        channels.gist = Some(spawn_gist_fetch());
+                    }
+                    Err(error) => state.set_status(format!("description update failed: {error}")),
+                },
+                BgTaskOutcome::CompactAnalyze {
+                    result,
+                    gist_id,
+                    label,
+                } => match result {
+                    Ok(count) if count <= 1 => state.set_status(format!(
+                        "\"{label}\" already has a single revision — nothing to compact"
+                    )),
+                    Ok(count) => {
+                        state.diff_text = format!(
+                                "Compact gist {gist_id} (\"{label}\").\n\nIt has {count} revisions. Compacting clones it to a temp dir, squashes the history to a single commit, and force-pushes — the {} older revisions are gone for good.",
+                                count - 1
+                            );
+                        state.diff_scroll = 0;
+                        state.diff_hscroll = 0;
+                        state.pending_action = Some(PendingAction::CompactGist {
+                            gist_id,
+                            label,
+                            count,
+                        });
+                        state.screen = Screen::Confirm;
+                    }
+                    Err(error) => state.set_status(format!("revision check failed: {error}")),
+                },
+                BgTaskOutcome::CompactGist {
+                    result,
+                    label,
+                    count,
+                } => match result {
+                    Ok(_) => {
+                        state.set_status(format!("Compacted \"{label}\" ({count} → 1 revision)"));
+                        state.loading = true;
+                        channels.gist = Some(spawn_gist_fetch());
+                    }
+                    Err(error) => state.set_status(format!("compact failed: {error}")),
+                },
+                BgTaskOutcome::CommentsInitialLoaded { gist_id, result } => {
+                    state.apply_initial_comments(&gist_id, result);
+                }
+                BgTaskOutcome::CommentsOlderLoaded { gist_id, result } => {
+                    state.apply_older_comments(&gist_id, result);
+                }
+                BgTaskOutcome::RevisionsFetched { gist_id, result } => {
+                    if state.revision.gist_id.as_deref() != Some(gist_id.as_str()) {
+                        return Ok(LoopFlow::SkipIteration);
+                    }
+                    match result {
+                        Ok(entries) => {
+                            state.revision.fetch_error = None;
+                            state.revision.entries = Some(entries);
+                            if state
+                                .revision
+                                .entries
+                                .as_ref()
+                                .is_some_and(|e| e.len() <= 1)
+                            {
+                                state.set_status("only one revision — nothing to restore");
+                            }
+                        }
+                        Err(error) => {
+                            state.revision.entries = Some(Vec::new());
+                            state.revision.fetch_error = Some(error);
+                        }
+                    }
+                }
+                BgTaskOutcome::RevisionDiff {
+                    result,
+                    old_label,
+                    new_label,
+                } => match result {
+                    Ok((old_content, new_content)) => {
+                        let diff = crate::diff::unified_diff(
+                            &old_label,
+                            &old_content,
+                            &new_label,
+                            &new_content,
+                            state.ignore_trailing_newline,
+                        );
+                        state.diff_text = diff;
+                        state.diff_scroll = 0;
+                        state.diff_hscroll = 0;
+                        state.diff_identical = old_content == new_content;
+                        state.diff_return = Screen::Revisions;
+                        state.pending_action = None;
+                        state.screen = Screen::Diff;
+                    }
+                    Err(error) => state.set_status(error),
+                },
+                BgTaskOutcome::RestoreRevisionReady {
+                    result,
+                    gist_id,
+                    filename,
+                    version,
+                    version_label,
+                } => match result {
+                    Ok((revision_content, current_content)) => {
+                        if revision_content == current_content {
+                            state.set_status("revision matches current — nothing to restore");
+                            return Ok(LoopFlow::SkipIteration);
+                        }
+                        let old_label = format!("revision {version_label}");
+                        let new_label = format!("current {filename}");
+                        let diff = crate::diff::unified_diff(
+                            &old_label,
+                            &revision_content,
+                            &new_label,
+                            &current_content,
+                            state.ignore_trailing_newline,
+                        );
+                        state.diff_text = diff;
+                        state.diff_scroll = 0;
+                        state.diff_hscroll = 0;
+                        state.diff_identical = false;
+                        state.pending_action = Some(PendingAction::RestoreRevision {
+                            gist_id,
+                            filename,
+                            version,
+                            version_label,
+                            content: revision_content,
+                        });
+                        state.screen = Screen::Confirm;
+                    }
+                    Err(error) => state.set_status(error),
+                },
+                BgTaskOutcome::GistStarToggle {
+                    result,
+                    gist_id,
+                    starred,
+                } => match result {
+                    Ok(()) => {
+                        if starred {
+                            state.starred_gist_ids.insert(gist_id.clone());
+                            state.set_status(format!("starred {gist_id}"));
+                        } else {
+                            state.starred_gist_ids.remove(&gist_id);
+                            state.set_status(format!("unstarred {gist_id}"));
+                        }
+                        state.loading = true;
+                        channels.gist = Some(spawn_gist_fetch());
+                    }
+                    Err(error) => state.set_status(format!("star toggle failed: {error}")),
+                },
+                BgTaskOutcome::ForkGist { result, gist_id } => match result {
+                    Ok(()) => {
+                        state.set_status(format!("forked {gist_id} into your account"));
+                        state.loading = true;
+                        channels.gist = Some(spawn_gist_fetch());
+                    }
+                    Err(error) => state.set_status(format!("fork failed: {error}")),
+                },
+                BgTaskOutcome::RestoreRevisionDone {
+                    result,
+                    gist_id,
+                    filename,
+                } => match result {
+                    Ok(_) => {
+                        state
+                            .gist_content_cache
+                            .remove(&(gist_id.clone(), filename.clone()));
+                        state.set_status(format!(
+                            "Restored {filename} from old revision (new revision created)"
+                        ));
+                        state.pending_action = None;
+                        state.screen = Screen::Revisions;
+                        state.revision.index = 0;
+                        state.revision.entries = None;
+                        state.loading = true;
+                        channels.gist = Some(spawn_gist_fetch());
+                        if let Some(gist_id) = state.revision.gist_id.clone() {
+                            spawn_bg(state, &mut channels.bg, "Loading revisions…", move || {
+                                let result = crate::gh::fetch_gist_commits_json(&gist_id)
+                                    .map_err(|e| e.to_string())
+                                    .and_then(|raw| {
+                                        crate::gh::parse_gist_commits_json(&raw)
+                                            .map_err(|e| e.to_string())
+                                    });
+                                BgTaskOutcome::RevisionsFetched { gist_id, result }
+                            });
+                        }
+                    }
+                    Err(error) => {
+                        state.set_status(format!("restore failed: {error}"));
+                        state.screen = Screen::Confirm;
+                    }
+                },
+            }
+        }
+    }
+    Ok(LoopFlow::Proceed)
 }

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -35,14 +35,15 @@ pub(super) fn run_loop(
             update_rx = Some(spawn_update_check());
         }
     }
-    let mut gist_rx = Some(spawn_gist_fetch());
-    let mut fork_rx: Option<std::sync::mpsc::Receiver<std::collections::HashMap<String, u32>>> =
-        None;
-    let mut star_rx: Option<std::sync::mpsc::Receiver<std::collections::HashMap<String, u32>>> =
-        None;
-    let mut fork_meta_rx: Option<std::sync::mpsc::Receiver<ForkMetaResult>> = None;
-    let mut local_rx: Option<std::sync::mpsc::Receiver<Vec<LocalCandidate>>> = None;
-    let mut bg_rx: Option<std::sync::mpsc::Receiver<BgTaskOutcome>> = None;
+    let mut channels = BgChannels {
+        update: update_rx,
+        gist: Some(spawn_gist_fetch()),
+        fork: None,
+        star: None,
+        fork_meta: None,
+        local: None,
+        bg: None,
+    };
 
     loop {
         terminal.draw(|frame| render(frame, &state, &mut mouse_layout))?;
@@ -58,7 +59,7 @@ pub(super) fn run_loop(
 
         // Absorb the background gist list once it arrives.
         if state.loading {
-            if let Some(ref rx) = gist_rx {
+            if let Some(ref rx) = channels.gist {
                 if let Ok((
                     gists,
                     starred,
@@ -91,45 +92,45 @@ pub(super) fn run_loop(
                     if count > 0 && state.gist_manager.index >= count {
                         state.gist_manager.index = count - 1;
                     }
-                    gist_rx = None;
+                    channels.gist = None;
                     let gist_ids: std::collections::HashSet<String> = state
                         .gists
                         .iter()
                         .chain(state.starred_gists.iter())
                         .map(|g| g.gist_id.clone())
                         .collect();
-                    fork_rx = Some(spawn_fork_count_fetch(
+                    channels.fork = Some(spawn_fork_count_fetch(
                         owned_raw,
                         starred_raw,
                         gist_ids.clone(),
                     ));
-                    fork_meta_rx = Some(spawn_fork_metadata_fetch(
+                    channels.fork_meta = Some(spawn_fork_metadata_fetch(
                         state.gists.iter().map(|g| g.gist_id.clone()).collect(),
                     ));
                     let node_ids =
                         crate::gh::merge_gist_node_id_maps(&state.gists, &state.starred_gists);
-                    star_rx = Some(spawn_star_count_fetch(node_ids));
+                    channels.star = Some(spawn_star_count_fetch(node_ids));
                 }
             }
         }
 
-        if let Some(ref rx) = fork_rx {
+        if let Some(ref rx) = channels.fork {
             if let Ok(fork_counts) = rx.try_recv() {
                 state.gist_fork_counts = fork_counts;
                 persist_gist_cache_from_state(&state);
-                fork_rx = None;
+                channels.fork = None;
             }
         }
 
-        if let Some(ref rx) = star_rx {
+        if let Some(ref rx) = channels.star {
             if let Ok(star_counts) = rx.try_recv() {
                 state.gist_star_counts = star_counts;
                 persist_gist_cache_from_state(&state);
-                star_rx = None;
+                channels.star = None;
             }
         }
 
-        if let Some(ref rx) = fork_meta_rx {
+        if let Some(ref rx) = channels.fork_meta {
             if let Ok(result) = rx.try_recv() {
                 match result {
                     Ok(fork_of) => {
@@ -138,13 +139,13 @@ pub(super) fn run_loop(
                     }
                     Err(error) => state.set_status(format!("fork detection unavailable: {error}")),
                 }
-                fork_meta_rx = None;
+                channels.fork_meta = None;
             }
         }
 
         // Absorb a completed background local scan.
         if state.local_scanning {
-            if let Some(ref rx) = local_rx {
+            if let Some(ref rx) = channels.local {
                 if let Ok(locals) = rx.try_recv() {
                     let selected = state.selected_local().map(|c| c.path.clone());
                     state.locals = locals;
@@ -157,16 +158,16 @@ pub(super) fn run_loop(
                     }
                     state.local_scanning = false;
                     state.status = None;
-                    local_rx = None;
+                    channels.local = None;
                 }
             }
         }
 
         // Absorb the background update-check result: show the hint and persist the throttle.
         // Failed checks are silent and not recorded, so they retry on the next launch.
-        if let Some(ref rx) = update_rx {
+        if let Some(ref rx) = channels.update {
             if let Ok(outcome) = rx.try_recv() {
-                update_rx = None;
+                channels.update = None;
                 let now = crate::update_check::now_secs();
                 match outcome {
                     crate::update_check::UpdateCheckOutcome::Newer(version) => {
@@ -199,10 +200,10 @@ pub(super) fn run_loop(
         }
 
         // Absorb a completed background per-action task.
-        if let Some(ref rx) = bg_rx {
+        if let Some(ref rx) = channels.bg {
             if let Ok(outcome) = rx.try_recv() {
                 state.bg_task_msg = None;
-                bg_rx = None;
+                channels.bg = None;
                 match outcome {
                     BgTaskOutcome::PreviewDiff {
                         result,
@@ -361,7 +362,7 @@ pub(super) fn run_loop(
                             }
                             state.back_to_list();
                             state.loading = true;
-                            gist_rx = Some(spawn_gist_fetch());
+                            channels.gist = Some(spawn_gist_fetch());
                         }
                         Err(error) => {
                             state.set_status(format!("upload failed: {error}"));
@@ -383,7 +384,7 @@ pub(super) fn run_loop(
                             state.description_input.clear();
                             state.back_to_list();
                             state.loading = true;
-                            gist_rx = Some(spawn_gist_fetch());
+                            channels.gist = Some(spawn_gist_fetch());
                         }
                         Err(error) => {
                             state.set_status(format!("create failed: {error}"));
@@ -415,7 +416,7 @@ pub(super) fn run_loop(
                         Ok(_) => {
                             state.set_status(format!("Deleted gist {gist_id}"));
                             state.loading = true;
-                            gist_rx = Some(spawn_gist_fetch());
+                            channels.gist = Some(spawn_gist_fetch());
                         }
                         Err(error) => state.set_status(format!("delete failed: {error}")),
                     },
@@ -430,7 +431,7 @@ pub(super) fn run_loop(
                                 .remove(&(gist_id.clone(), filename.clone()));
                             state.set_status(format!("Removed {filename} from gist {gist_id}"));
                             state.loading = true;
-                            gist_rx = Some(spawn_gist_fetch());
+                            channels.gist = Some(spawn_gist_fetch());
                         }
                         Err(error) => state.set_status(format!("remove failed: {error}")),
                     },
@@ -438,7 +439,7 @@ pub(super) fn run_loop(
                         Ok(_) => {
                             state.set_status(format!("Updated description for gist {gist_id}"));
                             state.loading = true;
-                            gist_rx = Some(spawn_gist_fetch());
+                            channels.gist = Some(spawn_gist_fetch());
                         }
                         Err(error) => {
                             state.set_status(format!("description update failed: {error}"))
@@ -478,7 +479,7 @@ pub(super) fn run_loop(
                                 "Compacted \"{label}\" ({count} → 1 revision)"
                             ));
                             state.loading = true;
-                            gist_rx = Some(spawn_gist_fetch());
+                            channels.gist = Some(spawn_gist_fetch());
                         }
                         Err(error) => state.set_status(format!("compact failed: {error}")),
                     },
@@ -584,7 +585,7 @@ pub(super) fn run_loop(
                                 state.set_status(format!("unstarred {gist_id}"));
                             }
                             state.loading = true;
-                            gist_rx = Some(spawn_gist_fetch());
+                            channels.gist = Some(spawn_gist_fetch());
                         }
                         Err(error) => state.set_status(format!("star toggle failed: {error}")),
                     },
@@ -592,7 +593,7 @@ pub(super) fn run_loop(
                         Ok(()) => {
                             state.set_status(format!("forked {gist_id} into your account"));
                             state.loading = true;
-                            gist_rx = Some(spawn_gist_fetch());
+                            channels.gist = Some(spawn_gist_fetch());
                         }
                         Err(error) => state.set_status(format!("fork failed: {error}")),
                     },
@@ -613,11 +614,11 @@ pub(super) fn run_loop(
                             state.revision.index = 0;
                             state.revision.entries = None;
                             state.loading = true;
-                            gist_rx = Some(spawn_gist_fetch());
+                            channels.gist = Some(spawn_gist_fetch());
                             if let Some(gist_id) = state.revision.gist_id.clone() {
                                 spawn_bg(
                                     &mut state,
-                                    &mut bg_rx,
+                                    &mut channels.bg,
                                     "Loading revisions…",
                                     move || {
                                         let result = crate::gh::fetch_gist_commits_json(&gist_id)
@@ -656,7 +657,7 @@ pub(super) fn run_loop(
                 if state.bg_task_msg.is_some() {
                     if key.code == KeyCode::Esc {
                         state.bg_task_msg = None;
-                        bg_rx = None;
+                        channels.bg = None;
                         state.set_status("Cancelled");
                     }
                     continue;
@@ -706,7 +707,7 @@ pub(super) fn run_loop(
                 let target = state.cwd.join(&filename);
                 let upload_orientation = state.focus == FocusPane::Local;
 
-                spawn_bg(&mut state, &mut bg_rx, "Loading diff…", move || {
+                spawn_bg(&mut state, &mut channels.bg, "Loading diff…", move || {
                     let result = fetch_gist_content(&gist_id, &filename, raw_url.as_deref());
                     BgTaskOutcome::PreviewDiff {
                         result,
@@ -730,7 +731,7 @@ pub(super) fn run_loop(
                 let target = state.cwd.join(&filename);
                 let (local_label, gist_label) = diff_labels(Some(&target), &gist);
 
-                spawn_bg(&mut state, &mut bg_rx, "Downloading…", move || {
+                spawn_bg(&mut state, &mut channels.bg, "Downloading…", move || {
                     let result = fetch_gist_content(&gist_id, &filename, raw_url.as_deref());
                     BgTaskOutcome::DownloadSelected {
                         result,
@@ -763,13 +764,18 @@ pub(super) fn run_loop(
                 }
                 state.detail.comments_loading = true;
                 let fetch_id = gist_id.clone();
-                spawn_bg(&mut state, &mut bg_rx, "Loading comments…", move || {
-                    let result = load_initial_comments(&fetch_id);
-                    BgTaskOutcome::CommentsInitialLoaded {
-                        gist_id: fetch_id,
-                        result,
-                    }
-                });
+                spawn_bg(
+                    &mut state,
+                    &mut channels.bg,
+                    "Loading comments…",
+                    move || {
+                        let result = load_initial_comments(&fetch_id);
+                        BgTaskOutcome::CommentsInitialLoaded {
+                            gist_id: fetch_id,
+                            result,
+                        }
+                    },
+                );
             }
             KeyOutcome::LoadOlderComments => {
                 let Some(gist_id) = state.detail.gist_id.clone() else {
@@ -786,7 +792,7 @@ pub(super) fn run_loop(
                 let fetch_id = gist_id.clone();
                 spawn_bg(
                     &mut state,
-                    &mut bg_rx,
+                    &mut channels.bg,
                     "Loading older comments…",
                     move || {
                         let result = crate::gh::fetch_gist_comments_page(
@@ -818,21 +824,26 @@ pub(super) fn run_loop(
                     group.description.clone()
                 };
 
-                spawn_bg(&mut state, &mut bg_rx, "Checking revisions…", move || {
-                    let result = crate::actions::execute_command(
-                        &crate::actions::gist_revision_count_command(&gist_id),
-                    )
-                    .map_err(|e| e.to_string())
-                    .and_then(|out| {
-                        crate::actions::parse_revision_count(&out)
-                            .ok_or_else(|| "could not parse revision count".to_string())
-                    });
-                    BgTaskOutcome::CompactAnalyze {
-                        result,
-                        gist_id,
-                        label,
-                    }
-                });
+                spawn_bg(
+                    &mut state,
+                    &mut channels.bg,
+                    "Checking revisions…",
+                    move || {
+                        let result = crate::actions::execute_command(
+                            &crate::actions::gist_revision_count_command(&gist_id),
+                        )
+                        .map_err(|e| e.to_string())
+                        .and_then(|out| {
+                            crate::actions::parse_revision_count(&out)
+                                .ok_or_else(|| "could not parse revision count".to_string())
+                        });
+                        BgTaskOutcome::CompactAnalyze {
+                            result,
+                            gist_id,
+                            label,
+                        }
+                    },
+                );
             }
             KeyOutcome::Pin => pin_selected(&mut state),
             KeyOutcome::Unpin => unpin_selected(&mut state),
@@ -912,7 +923,7 @@ pub(super) fn run_loop(
                 let raw_url = gist_file.raw_url.clone();
                 let (local_label, gist_label) = diff_labels(Some(&local_path), &gist_file);
 
-                spawn_bg(&mut state, &mut bg_rx, "Loading diff…", move || {
+                spawn_bg(&mut state, &mut channels.bg, "Loading diff…", move || {
                     let result = fetch_gist_content(&gist_id, &filename, raw_url.as_deref());
                     BgTaskOutcome::UploadPreview {
                         result,
@@ -968,7 +979,7 @@ pub(super) fn run_loop(
                 };
 
                 state.back_to_list();
-                spawn_bg(&mut state, &mut bg_rx, "Uploading…", move || {
+                spawn_bg(&mut state, &mut channels.bg, "Uploading…", move || {
                     let result = crate::actions::execute_command(&plan)
                         .map(|_| ())
                         .map_err(|e| e.to_string());
@@ -993,16 +1004,21 @@ pub(super) fn run_loop(
                 let description = state.description_input.to_string();
                 let plan = crate::actions::create_command(&local_path, public, &description);
 
-                spawn_bg(&mut state, &mut bg_rx, "Creating gist…", move || {
-                    let result = crate::actions::execute_command(&plan)
-                        .map(|_| ())
-                        .map_err(|e| e.to_string());
-                    BgTaskOutcome::CreateGist {
-                        result,
-                        local_path,
-                        public,
-                    }
-                });
+                spawn_bg(
+                    &mut state,
+                    &mut channels.bg,
+                    "Creating gist…",
+                    move || {
+                        let result = crate::actions::execute_command(&plan)
+                            .map(|_| ())
+                            .map_err(|e| e.to_string());
+                        BgTaskOutcome::CreateGist {
+                            result,
+                            local_path,
+                            public,
+                        }
+                    },
+                );
             }
             KeyOutcome::PreviewContent => {
                 // A detail-view number key records the exact file in `preview_request`;
@@ -1027,14 +1043,20 @@ pub(super) fn run_loop(
                     let filename = key.1.clone();
                     let raw_url = state.gist_file_raw_url(&gist_id, &filename);
                     let preview_title = format!("Preview: {gist_id} / {filename}");
-                    spawn_bg(&mut state, &mut bg_rx, "Loading preview…", move || {
-                        let result = fetch_gist_content(&gist_id, &filename, raw_url.as_deref());
-                        BgTaskOutcome::PreviewContent {
-                            result,
-                            key,
-                            preview_title,
-                        }
-                    });
+                    spawn_bg(
+                        &mut state,
+                        &mut channels.bg,
+                        "Loading preview…",
+                        move || {
+                            let result =
+                                fetch_gist_content(&gist_id, &filename, raw_url.as_deref());
+                            BgTaskOutcome::PreviewContent {
+                                result,
+                                key,
+                                preview_title,
+                            }
+                        },
+                    );
                 }
             }
             KeyOutcome::RefreshPreview => {
@@ -1044,14 +1066,20 @@ pub(super) fn run_loop(
                     let filename = key.1.clone();
                     let raw_url = state.gist_file_raw_url(&gist_id, &filename);
                     let preview_title = format!("Preview: {gist_id} / {filename}");
-                    spawn_bg(&mut state, &mut bg_rx, "Loading preview…", move || {
-                        let result = fetch_gist_content(&gist_id, &filename, raw_url.as_deref());
-                        BgTaskOutcome::PreviewContent {
-                            result,
-                            key,
-                            preview_title,
-                        }
-                    });
+                    spawn_bg(
+                        &mut state,
+                        &mut channels.bg,
+                        "Loading preview…",
+                        move || {
+                            let result =
+                                fetch_gist_content(&gist_id, &filename, raw_url.as_deref());
+                            BgTaskOutcome::PreviewContent {
+                                result,
+                                key,
+                                preview_title,
+                            }
+                        },
+                    );
                 }
             }
             KeyOutcome::OpenBrowser => open_browser(&mut state),
@@ -1066,12 +1094,17 @@ pub(super) fn run_loop(
                 let plan = crate::actions::delete_command(&gist_id);
                 state.back_to_list();
 
-                spawn_bg(&mut state, &mut bg_rx, "Deleting gist…", move || {
-                    let result = crate::actions::execute_command(&plan)
-                        .map(|_| ())
-                        .map_err(|e| e.to_string());
-                    BgTaskOutcome::DeleteGist { result, gist_id }
-                });
+                spawn_bg(
+                    &mut state,
+                    &mut channels.bg,
+                    "Deleting gist…",
+                    move || {
+                        let result = crate::actions::execute_command(&plan)
+                            .map(|_| ())
+                            .map_err(|e| e.to_string());
+                        BgTaskOutcome::DeleteGist { result, gist_id }
+                    },
+                );
             }
             KeyOutcome::ExecuteRemoveFile => {
                 let Some(PendingAction::RemoveFile {
@@ -1083,16 +1116,21 @@ pub(super) fn run_loop(
                 let plan = crate::actions::remove_file_command(&gist_id, &filename);
                 state.back_to_list();
 
-                spawn_bg(&mut state, &mut bg_rx, "Removing file…", move || {
-                    let result = crate::actions::execute_command(&plan)
-                        .map(|_| ())
-                        .map_err(|e| e.to_string());
-                    BgTaskOutcome::RemoveFile {
-                        result,
-                        gist_id,
-                        filename,
-                    }
-                });
+                spawn_bg(
+                    &mut state,
+                    &mut channels.bg,
+                    "Removing file…",
+                    move || {
+                        let result = crate::actions::execute_command(&plan)
+                            .map(|_| ())
+                            .map_err(|e| e.to_string());
+                        BgTaskOutcome::RemoveFile {
+                            result,
+                            gist_id,
+                            filename,
+                        }
+                    },
+                );
             }
             KeyOutcome::ExecuteCompactGist => {
                 let Some(PendingAction::CompactGist {
@@ -1108,7 +1146,7 @@ pub(super) fn run_loop(
 
                 spawn_bg(
                     &mut state,
-                    &mut bg_rx,
+                    &mut channels.bg,
                     "Compacting revisions…",
                     move || {
                         let result = crate::actions::execute_compact_gist(&gist_id)
@@ -1138,7 +1176,7 @@ pub(super) fn run_loop(
 
                 spawn_bg(
                     &mut state,
-                    &mut bg_rx,
+                    &mut channels.bg,
                     "Updating description…",
                     move || {
                         let result = crate::actions::execute_command(&plan)
@@ -1151,7 +1189,7 @@ pub(super) fn run_loop(
             KeyOutcome::RefreshLocals => {
                 state.set_status("Scanning files…");
                 state.local_scanning = true;
-                local_rx = Some(spawn_local_scan(
+                channels.local = Some(spawn_local_scan(
                     state.cwd.clone(),
                     state.pinned.clone(),
                     state.local_recursive,
@@ -1179,8 +1217,12 @@ pub(super) fn run_loop(
                 };
                 let m = state.pinned[idx].clone();
                 match state.pin_sync_status(idx) {
-                    crate::domain::SyncStatus::Push => spawn_pin_push(&mut state, &mut bg_rx, &m),
-                    crate::domain::SyncStatus::Pull => spawn_pin_pull(&mut state, &mut bg_rx, &m),
+                    crate::domain::SyncStatus::Push => {
+                        spawn_pin_push(&mut state, &mut channels.bg, &m)
+                    }
+                    crate::domain::SyncStatus::Pull => {
+                        spawn_pin_pull(&mut state, &mut channels.bg, &m)
+                    }
                     crate::domain::SyncStatus::InSync => state.set_status("already in sync"),
                     crate::domain::SyncStatus::Unknown => state
                         .set_status("can't tell which side is newer — use u to push or d to pull"),
@@ -1188,12 +1230,12 @@ pub(super) fn run_loop(
             }
             KeyOutcome::SyncPinPush => {
                 if let Some(m) = selected_pin(&state) {
-                    spawn_pin_push(&mut state, &mut bg_rx, &m);
+                    spawn_pin_push(&mut state, &mut channels.bg, &m);
                 }
             }
             KeyOutcome::SyncPinPull => {
                 if let Some(m) = selected_pin(&state) {
-                    spawn_pin_pull(&mut state, &mut bg_rx, &m);
+                    spawn_pin_pull(&mut state, &mut channels.bg, &m);
                 }
             }
             KeyOutcome::SyncPinAuto => {
@@ -1203,7 +1245,9 @@ pub(super) fn run_loop(
                 let m = state.pinned[pin_idx].clone();
                 match state.pin_sync_status(pin_idx) {
                     crate::domain::SyncStatus::InSync => state.set_status("already in sync"),
-                    crate::domain::SyncStatus::Pull => spawn_pin_pull(&mut state, &mut bg_rx, &m),
+                    crate::domain::SyncStatus::Pull => {
+                        spawn_pin_pull(&mut state, &mut channels.bg, &m)
+                    }
                     crate::domain::SyncStatus::Push => {
                         // Cheap, network-free no-op check: if the local file still
                         // hashes to last_seen_hash, the newer mtime is a touch with
@@ -1220,7 +1264,7 @@ pub(super) fn run_loop(
                         if unchanged {
                             state.set_status("already in sync");
                         } else {
-                            spawn_pin_push(&mut state, &mut bg_rx, &m);
+                            spawn_pin_push(&mut state, &mut channels.bg, &m);
                         }
                     }
                     crate::domain::SyncStatus::Unknown => state
@@ -1230,7 +1274,7 @@ pub(super) fn run_loop(
             KeyOutcome::PreviewPinDiff => {
                 if let Some(m) = selected_pin(&state) {
                     state.diff_return = Screen::Pins;
-                    spawn_pin_diff(&mut state, &mut bg_rx, &m);
+                    spawn_pin_diff(&mut state, &mut channels.bg, &m);
                 }
             }
             KeyOutcome::PersistDiffContext => persist_diff_context(&mut state),
@@ -1239,14 +1283,19 @@ pub(super) fn run_loop(
                 let Some(gist_id) = state.revision.gist_id.clone() else {
                     continue;
                 };
-                spawn_bg(&mut state, &mut bg_rx, "Loading revisions…", move || {
-                    let result = crate::gh::fetch_gist_commits_json(&gist_id)
-                        .map_err(|e| e.to_string())
-                        .and_then(|raw| {
-                            crate::gh::parse_gist_commits_json(&raw).map_err(|e| e.to_string())
-                        });
-                    BgTaskOutcome::RevisionsFetched { gist_id, result }
-                });
+                spawn_bg(
+                    &mut state,
+                    &mut channels.bg,
+                    "Loading revisions…",
+                    move || {
+                        let result = crate::gh::fetch_gist_commits_json(&gist_id)
+                            .map_err(|e| e.to_string())
+                            .and_then(|raw| {
+                                crate::gh::parse_gist_commits_json(&raw).map_err(|e| e.to_string())
+                            });
+                        BgTaskOutcome::RevisionsFetched { gist_id, result }
+                    },
+                );
             }
             KeyOutcome::RevisionDiffIncremental => {
                 let Some(gist_id) = state.revision.gist_id.clone() else {
@@ -1272,7 +1321,7 @@ pub(super) fn run_loop(
                 };
                 let new_label = format!("revision {child_label}");
                 let owner_login = state.gist_owner_login(&gist_id);
-                spawn_bg(&mut state, &mut bg_rx, "Loading diff…", move || {
+                spawn_bg(&mut state, &mut channels.bg, "Loading diff…", move || {
                     let result = fetch_revision_incremental_pair(
                         &gist_id,
                         &child_version,
@@ -1301,7 +1350,7 @@ pub(super) fn run_loop(
                 let new_label = format!("current {filename}");
                 let raw_url = state.gist_file_raw_url(&gist_id, &filename);
                 let owner_login = state.gist_owner_login(&gist_id);
-                spawn_bg(&mut state, &mut bg_rx, "Loading diff…", move || {
+                spawn_bg(&mut state, &mut channels.bg, "Loading diff…", move || {
                     let result = fetch_revision_pair(
                         &gist_id,
                         &version,
@@ -1330,22 +1379,27 @@ pub(super) fn run_loop(
                 let version_label = revision_version_label(&revision);
                 let raw_url = state.gist_file_raw_url(&gist_id, &filename);
                 let owner_login = state.gist_owner_login(&gist_id);
-                spawn_bg(&mut state, &mut bg_rx, "Loading revision…", move || {
-                    let result = fetch_revision_pair_for_restore(
-                        &gist_id,
-                        &version,
-                        &filename,
-                        raw_url.as_deref(),
-                        &owner_login,
-                    );
-                    BgTaskOutcome::RestoreRevisionReady {
-                        result,
-                        gist_id,
-                        filename,
-                        version,
-                        version_label,
-                    }
-                });
+                spawn_bg(
+                    &mut state,
+                    &mut channels.bg,
+                    "Loading revision…",
+                    move || {
+                        let result = fetch_revision_pair_for_restore(
+                            &gist_id,
+                            &version,
+                            &filename,
+                            raw_url.as_deref(),
+                            &owner_login,
+                        );
+                        BgTaskOutcome::RestoreRevisionReady {
+                            result,
+                            gist_id,
+                            filename,
+                            version,
+                            version_label,
+                        }
+                    },
+                );
             }
             KeyOutcome::ExecuteRestoreRevision => {
                 let Some(PendingAction::RestoreRevision {
@@ -1374,17 +1428,22 @@ pub(super) fn run_loop(
                     continue;
                 }
                 let plan = crate::actions::restore_revision_command(&gist_id, &json_path);
-                spawn_bg(&mut state, &mut bg_rx, "Restoring revision…", move || {
-                    let result = crate::actions::execute_command(&plan)
-                        .map(|_| ())
-                        .map_err(|e| e.to_string());
-                    let _ = std::fs::remove_dir_all(&temp_dir);
-                    BgTaskOutcome::RestoreRevisionDone {
-                        result,
-                        gist_id,
-                        filename,
-                    }
-                });
+                spawn_bg(
+                    &mut state,
+                    &mut channels.bg,
+                    "Restoring revision…",
+                    move || {
+                        let result = crate::actions::execute_command(&plan)
+                            .map(|_| ())
+                            .map_err(|e| e.to_string());
+                        let _ = std::fs::remove_dir_all(&temp_dir);
+                        BgTaskOutcome::RestoreRevisionDone {
+                            result,
+                            gist_id,
+                            filename,
+                        }
+                    },
+                );
             }
             KeyOutcome::ToggleGistStar => {
                 let Some(gist_id) = state.context_gist_id() else {
@@ -1402,7 +1461,7 @@ pub(super) fn run_loop(
                 } else {
                     "Unstarring…"
                 };
-                spawn_bg(&mut state, &mut bg_rx, msg, move || {
+                spawn_bg(&mut state, &mut channels.bg, msg, move || {
                     let result = crate::actions::execute_command(&plan)
                         .map(|_| ())
                         .map_err(|e| e.to_string());
@@ -1423,7 +1482,7 @@ pub(super) fn run_loop(
                     continue;
                 }
                 let plan = crate::actions::fork_gist_command(&gist_id);
-                spawn_bg(&mut state, &mut bg_rx, "Forking…", move || {
+                spawn_bg(&mut state, &mut channels.bg, "Forking…", move || {
                     let result = crate::actions::execute_command(&plan)
                         .map(|_| ())
                         .map_err(|e| e.to_string());
@@ -2284,4 +2343,16 @@ fn unpin_at_pin_index(state: &mut AppState) {
 
 fn upload_local_filename(local: &std::path::Path) -> Option<String> {
     local.file_name().and_then(|n| n.to_str()).map(String::from)
+}
+
+/// The seven background-work receivers `run_loop` drains each iteration, bundled so the
+/// extracted loop steps take one `&mut BgChannels` instead of seven `&mut` parameters.
+struct BgChannels {
+    update: Option<std::sync::mpsc::Receiver<crate::update_check::UpdateCheckOutcome>>,
+    gist: Option<std::sync::mpsc::Receiver<GistFetchResult>>,
+    fork: Option<std::sync::mpsc::Receiver<std::collections::HashMap<String, u32>>>,
+    star: Option<std::sync::mpsc::Receiver<std::collections::HashMap<String, u32>>>,
+    fork_meta: Option<std::sync::mpsc::Receiver<ForkMetaResult>>,
+    local: Option<std::sync::mpsc::Receiver<Vec<LocalCandidate>>>,
+    bg: BgRx,
 }


### PR DESCRIPTION
First half of #164's arch-2 (the run_loop split). Two commits:

1. **Bundle the 7 `*_rx` receivers into `BgChannels`** — mechanical rename within `run_loop`'s body; `spawn_*` helpers now take `&mut channels.bg`.
2. **Extract `absorb_background_results(&mut state, &mut channels, &update_check_path) -> Result<LoopFlow>`** — moves the receiver-drain section (incl. the ~440-line `bg_rx` `BgTaskOutcome` match) out of `run_loop`. The new `LoopFlow { Proceed, SkipIteration, Quit }` enum carries loop control; the two `continue`s in the moved block become `SkipIteration`. The render-follow-up (scroll-to-bottom one-shot) and spinner tick stay in `run_loop` (they need `mouse_layout`, not receivers).

`run_loop()` shed ~582 lines. `LoopFlow::Quit` has a temporary `#[allow(dead_code)]` until the next increment (`dispatch_outcome`) constructs it.

**Verbatim move** — the only non-copy changes are `&mut state`/`&state` → reborrows of the `&mut` param and the two `continue` → `SkipIteration`. `run_loop` is an untested IO boundary, so correctness rests on: it compiles (borrow-checker proves the threading), **441 tests baseline-identical**, fmt/clippy `-D warnings`/check green, and re-reading the moved block against the diff (the region appears once, not duplicated). `skip-changelog`.

Next: increment 2 extracts `dispatch_outcome` (the `KeyOutcome` match, ~40 `continue`s + the `break`), which removes the `#[allow]`.

Refs #164