### PR TITLE
perf(tui): snapshot ranked lists in list Enter/revisions paths

### DIFF
--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -1099,12 +1099,18 @@ impl AppState {
                 return KeyOutcome::DownloadGist;
             }
             // Enter works from either pane: it diffs the selected local file against the
-            // selected gist (the top match when focus is on the local pane).
-            KeyCode::Enter if self.gist_index < self.ranked_gists().len() => {
-                let Some(gist) = self.selected_gist() else {
+            // selected gist (the top match when focus is on the local pane). Snapshot both
+            // ranked lists once here instead of recomputing them through the bounds guard plus
+            // `selected_gist`/`selected_local` (perf-1, #154).
+            KeyCode::Enter => {
+                let ranked = self.ranked_gists();
+                let Some(gist) = ranked.get(self.gist_index) else {
                     return KeyOutcome::None;
                 };
-                let local_path = self.selected_local().map(|l| l.path.clone());
+                let local_path = self
+                    .visible_locals()
+                    .get(self.local_index)
+                    .map(|r| r.candidate.path.clone());
                 if self.block_if_non_previewable_diff(
                     &gist.file.gist_id,
                     &gist.file.filename,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1108,8 +1108,14 @@ impl AppState {
     /// Open `Screen::Revisions` for the gist on `return_screen`. Returns false when no gist
     /// is selected or the gist has no files.
     pub fn open_revisions(&mut self, return_screen: Screen) -> bool {
+        // Snapshot the selected gist once for the List path; it feeds both `gist_id` and
+        // `target_file` below, avoiding a second `ranked_gists` recompute (perf-1, #154).
+        let selected_list_gist = match return_screen {
+            Screen::List => self.selected_gist(),
+            _ => None,
+        };
         let gist_id = match return_screen {
-            Screen::List => self.selected_gist().map(|g| g.file.gist_id.clone()),
+            Screen::List => selected_list_gist.as_ref().map(|g| g.file.gist_id.clone()),
             Screen::GistDetail => self.detail.gist_id.clone(),
             Screen::Gists => self.selected_group().map(|g| g.id.clone()),
             _ => None,
@@ -1119,8 +1125,8 @@ impl AppState {
         };
         let filenames = self.gist_filenames(&gist_id);
         let target_file = match return_screen {
-            Screen::List => self
-                .selected_gist()
+            Screen::List => selected_list_gist
+                .as_ref()
                 .map(|g| g.file.filename.clone())
                 .filter(|f| filenames.iter().any(|name| name == f)),
             Screen::GistDetail => filenames


### PR DESCRIPTION
## What

The `Enter` arm in `handle_key_list` recomputed the ranked gist list **3+
times for a single keypress**: once via the bounds guard
(`self.gist_index < self.ranked_gists().len()`), again through
`selected_gist()`, and the local list again through `selected_local()` —
each a full filter / clone / rank / sort pass (and the two lists recompute
each other internally through the anchor). `open_revisions(Screen::List)`
likewise called `selected_gist()` twice.

This snapshots each ranked list **once per handler** and indexes the
snapshot instead.

## Why it's safe (no stale-ordering risk)

- Snapshot indexing is *definitionally equal* to the prior `selected_*`
  calls (`selected_gist()` ≡ `ranked_gists()[gist_index]`, etc.).
- The snapshot lives only within the single handler call, so it cannot go
  stale across events — the failure mode a content-hash/epoch cache would
  risk (see the design analysis on #154).
- List **lengths** are invariant under selection-index mutation, so moving
  the bounds check into the body (dropping the `Enter` guard) preserves the
  exact "do nothing" fall-through behaviour.

## Scope

`src/tui/keys.rs` (`Enter` arm) and `src/tui/mod.rs` (`open_revisions`).
Render and the public `selected_*` API are untouched. Per-event
cross-handler caching and the internal mutual recompute between the two
lists are intentionally **left alone** (latent, only matters at hundreds of
gists; tracked by the deferral on #154).

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`,
`cargo test` (441 pass), `cargo check` — all green. Behaviour is covered by
existing tests: `enter_in_gist_focus_with_selection_returns_preview`,
`enter_in_local_focus_previews_top_gist`,
`enter_with_no_gists_is_noop_in_local_focus`, and the `H` → revisions tests.

Refs #154 (perf-1). Labelled `skip-changelog` — behaviour-preserving
internal refactor with no user-visible effect at normal scale.