### PR TITLE
test(tui): pin ranked-list no-cache contract (closes #154)

### DIFF
--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1704,6 +1704,100 @@ fn local_selection_changes_ranked_gists() {
     assert_eq!(state.ranked_gists()[0].file.filename, "statusline.sh");
 }
 
+/// `ranked_gists` / `visible_locals` are recomputed from current state on every call —
+/// there is intentionally NO cache for them (see #154, closed by-design: a content-hash /
+/// epoch memo could silently render a stale ordering the unit suite would not catch).
+/// `selected_gist` / `selected_local` are defined as `list[index]`, so they must stay
+/// identical to a fresh recompute even after an earlier read and an input mutation. This
+/// test pins that invariant: a future stale cache would break it loudly here.
+#[test]
+fn selected_accessors_track_recomputed_lists_with_no_cache() {
+    let mut state = initial_state();
+    state.locals = vec![
+        LocalCandidate {
+            path: PathBuf::from("/tmp/settings.json"),
+            pinned: false,
+            modified: None,
+        },
+        LocalCandidate {
+            path: PathBuf::from("/tmp/statusline.sh"),
+            pinned: false,
+            modified: None,
+        },
+    ];
+    state.gists = vec![
+        GistFile {
+            gist_id: "a".into(),
+            description: "settings".into(),
+            filename: "settings.json".into(),
+            public: false,
+            updated_at: "x".into(),
+            created_at: "x".into(),
+            owner_login: String::new(),
+            fork_of_id: None,
+            raw_url: None,
+            content_type: None,
+            node_id: None,
+        },
+        GistFile {
+            gist_id: "b".into(),
+            description: "status".into(),
+            filename: "statusline.sh".into(),
+            public: false,
+            updated_at: "x".into(),
+            created_at: "x".into(),
+            owner_login: String::new(),
+            fork_of_id: None,
+            raw_url: None,
+            content_type: None,
+            node_id: None,
+        },
+    ];
+
+    // Read both lists first — this would warm any hypothetical cache.
+    let _ = state.ranked_gists();
+    let _ = state.visible_locals();
+    // Accessors equal a fresh recompute at the current indices.
+    assert_eq!(
+        state.selected_gist().map(|g| g.file.filename),
+        state
+            .ranked_gists()
+            .into_iter()
+            .nth(state.gist_index)
+            .map(|g| g.file.filename),
+    );
+    assert_eq!(
+        state.selected_local().map(|l| l.path),
+        state
+            .visible_locals()
+            .into_iter()
+            .nth(state.local_index)
+            .map(|r| r.candidate.path),
+    );
+    assert_eq!(state.ranked_gists()[0].file.filename, "settings.json");
+
+    // Move the local selection: ranking must reflect the *new* state, not the earlier read.
+    state.handle_key(KeyCode::Down);
+    assert_eq!(state.ranked_gists()[0].file.filename, "statusline.sh");
+    // The accessors still match a fresh recompute after the mutation.
+    assert_eq!(
+        state.selected_gist().map(|g| g.file.filename),
+        state
+            .ranked_gists()
+            .into_iter()
+            .nth(state.gist_index)
+            .map(|g| g.file.filename),
+    );
+    assert_eq!(
+        state.selected_local().map(|l| l.path),
+        state
+            .visible_locals()
+            .into_iter()
+            .nth(state.local_index)
+            .map(|r| r.candidate.path),
+    );
+}
+
 #[test]
 fn changing_local_selection_resets_gist_index() {
     let mut state = initial_state();


### PR DESCRIPTION
## What

Adds one invariant test pinning the **no-cache contract** for
`ranked_gists` / `visible_locals`, and resolves #154 (perf-1) **by design**.

## Why (the original #154 caching concern)

#154 asked to cache `ranked_gists` / `visible_locals` instead of recomputing
them per keypress / frame. Investigation (see the design comment on #154)
showed a cache is the wrong tool here:

- Their ordering depends on a large transitive input set (gist source,
  `gist_type_filter`, `filter_query`, `anchor`, `gist_sort`, `pinned`, and —
  when `anchor == Local` — `locals`, `local_filter_query`, `local_sort`,
  `local_index`, `cwd`), and the two lists are **mutually recursive** through
  the anchor.
- Any memo key that misses one input silently renders a **stale / wrong
  ordering** — a user-visible bug the unit suite would not catch.
- At realistic gist counts the recompute is imperceptible, so a cache buys
  almost nothing while adding a high-blast-radius correctness trap.

The pragmatic root cure is therefore **not to build the cache**: keep
recompute as the single source of truth, and pin that contract with a test
so a future stale-cache regression fails loudly instead of silently.

#185 already removed the genuine waste (per-event multi-recompute in the
list `Enter` / revisions paths) without any cache.

## The test

`selected_accessors_track_recomputed_lists_with_no_cache` reads both lists
(warming any hypothetical cache), asserts `selected_gist` / `selected_local`
equal a fresh `list[index]`, then mutates the local selection and re-asserts
the accessors still match a fresh recompute — exactly what a stale cache
would break.

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`,
`cargo test` (442 pass), `cargo check` — all green.

Closes #154. Test-only / by-design decision → `skip-changelog`.