### PR TITLE
fix(tui): show files once for a gist you own and starred

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.1] — 2026-06-23
+
+- Fixed: a gist you own *and* starred no longer shows its files twice in the detail view (it was fetched by both the owned and starred list APIs and merged without deduplication).
+
 ## [0.14.0] — 2026-06-22
 
 - Fixed: owned-fork detection now paginates past 100 gists (the `forked` filter no longer misses forks on large accounts), and a failed fork-detection query surfaces a `fork detection unavailable` hint instead of silently showing no forks.
@@ -137,7 +141,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Off-thread loading with an on-disk cache.
 - Overwrite-confirm safety gate.
 
-[unreleased]: https://github.com/akunzai/gistui/compare/v0.14.0...HEAD
+[unreleased]: https://github.com/akunzai/gistui/compare/v0.14.1...HEAD
+[0.14.1]: https://github.com/akunzai/gistui/releases/tag/v0.14.1
 [0.14.0]: https://github.com/akunzai/gistui/releases/tag/v0.14.0
 [0.13.0]: https://github.com/akunzai/gistui/releases/tag/v0.13.0
 [0.12.0]: https://github.com/akunzai/gistui/releases/tag/v0.12.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "gistui"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gistui"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 license = "MIT"
 description = "A terminal UI for managing GitHub Gists"

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -771,7 +771,16 @@ impl AppState {
     /// Iterator over every in-memory gist file — owned first, then starred. The shared base
     /// for the many lookups that must search both lists.
     fn all_gist_files(&self) -> impl Iterator<Item = &GistFile> {
-        self.gists.iter().chain(self.starred_gists.iter())
+        // A gist you own *and* starred is fetched by both `/gists` and `/gists/starred`,
+        // so it appears in both lists. Owned takes precedence; skip the starred copy to
+        // avoid showing each of its files twice in the detail view (issue #188).
+        let owned_ids: std::collections::HashSet<&str> =
+            self.gists.iter().map(|g| g.gist_id.as_str()).collect();
+        self.gists.iter().chain(
+            self.starred_gists
+                .iter()
+                .filter(move |g| !owned_ids.contains(g.gist_id.as_str())),
+        )
     }
 
     pub fn gist_owner_login(&self, gist_id: &str) -> String {

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -3271,6 +3271,35 @@ fn gist_info_line_shows_counts_when_nonzero() {
     assert!(rich.contains(&group.id));
 }
 
+// A gist you own *and* starred lands in both `gists` and `starred_gists`. The detail
+// file list (gist_filenames -> all_gist_files) must not show each file twice (issue #188).
+#[test]
+fn gist_filenames_dedupes_owned_gist_that_is_also_starred() {
+    let make = |filename: &str| GistFile {
+        gist_id: "g1".into(),
+        description: "My ZSH profile".into(),
+        filename: filename.into(),
+        public: true,
+        updated_at: "2026-06-10T00:00:00Z".into(),
+        created_at: "2020-01-01T00:00:00Z".into(),
+        owner_login: "akunzai".into(),
+        fork_of_id: None,
+        raw_url: None,
+        content_type: None,
+        node_id: None,
+    };
+    let mut state = initial_state();
+    state.gists = vec![make(".zprofile"), make(".zshenv"), make(".zshrc")];
+    // Same gist, fetched again from /gists/starred because the owner starred it.
+    state.starred_gists = vec![make(".zprofile"), make(".zshenv"), make(".zshrc")];
+
+    assert_eq!(
+        state.gist_filenames("g1"),
+        vec![".zprofile", ".zshenv", ".zshrc"]
+    );
+    assert_eq!(state.gist_file_display_names("g1").len(), 3);
+}
+
 #[test]
 fn list_filter_routes_chars_to_focused_pane() {
     let mut state = state_with_local_paths(&["/cwd/a.json", "/cwd/b.txt"]);


### PR DESCRIPTION
## Summary

Fixes #188 — a gist that is both **owned** and **starred** by the current user rendered every file twice in the detail view (`Files (6)` for a 3-file gist), because it is returned by both the owned (`/gists`) and starred (`/gists/starred`) list APIs and merged without deduplication.

## Cause

`AppState::all_gist_files()` chained `self.gists` and `self.starred_gists` with no dedupe. A gist present in both lists therefore yielded each file twice via `gist_filenames()` → the detail file list and its `Files (N)` count.

## Fix

Dedupe in `all_gist_files()`: skip starred rows whose `gist_id` already appears in the owned list (owned takes precedence). This corrects the detail file list and every query routed through `all_gist_files()`. Other merge sites already dedupe (`spawn_fork_count_fetch` via `HashSet`, `merge_gist_node_id_maps` via a map), so no change was needed there.

## Tests

- New `gist_filenames_dedupes_owned_gist_that_is_also_starred` (RED → GREEN): asserts a gist in both owned and starred lists yields each file once.
- Full gate green: `cargo fmt --check`, `cargo test` (455 tests), `cargo check`, `cargo clippy --all-targets -- -D warnings`.

## Release

Bumps `Cargo.toml` to `0.14.1` and adds a CHANGELOG entry under `## [Unreleased]` (to be stamped at the `v0.14.1` tag). No keymap/screen change, so README and `?` help are unchanged.