### PR TITLE
fix(tui): auto-add --wait for GUI editors (release 0.14.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.2] — 2026-06-25
+
 - Fixed: editing the upload buffer (`e`) or a local file with a GUI editor (`zed`, `code`, `cursor`, `subl`, …) now works even when `$EDITOR`/`$VISUAL` omits a wait flag — gistui adds `--wait` automatically, so it no longer reads the file back before you save and upload the pre-edit (un-redacted) content.
 
 ## [0.14.1] — 2026-06-23
@@ -143,7 +145,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Off-thread loading with an on-disk cache.
 - Overwrite-confirm safety gate.
 
-[unreleased]: https://github.com/akunzai/gistui/compare/v0.14.1...HEAD
+[unreleased]: https://github.com/akunzai/gistui/compare/v0.14.2...HEAD
+[0.14.2]: https://github.com/akunzai/gistui/releases/tag/v0.14.2
 [0.14.1]: https://github.com/akunzai/gistui/releases/tag/v0.14.1
 [0.14.0]: https://github.com/akunzai/gistui/releases/tag/v0.14.0
 [0.13.0]: https://github.com/akunzai/gistui/releases/tag/v0.13.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed: editing the upload buffer (`e`) or a local file with a GUI editor (`zed`, `code`, `cursor`, `subl`, …) now works even when `$EDITOR`/`$VISUAL` omits a wait flag — gistui adds `--wait` automatically, so it no longer reads the file back before you save and upload the pre-edit (un-redacted) content.
+
 ## [0.14.1] — 2026-06-23
 
 - Fixed: a gist you own *and* starred no longer shows its files twice in the detail view (it was fetched by both the owned and starred list APIs and merged without deduplication).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "gistui"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gistui"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2021"
 license = "MIT"
 description = "A terminal UI for managing GitHub Gists"

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -688,9 +688,48 @@ fn copy_preview_content(state: &mut AppState) {
     }
 }
 
+/// Split a `$VISUAL`/`$EDITOR` string into `(program, args)`, injecting a "wait" flag for
+/// known GUI editors that fork and return immediately (`zed`, `code`, `cursor`, `subl`, …).
+/// Without it `Command::status()` returns *before* the user saves, so the caller reads back
+/// the stale, pre-edit buffer — which for the upload redact flow would silently publish the
+/// **un-redacted** original. Terminal editors (`vi`, `nano`, `emacs -nw`) already block and
+/// are left untouched. The file path is appended by the caller, so it always lands last.
+/// Returns `None` only when the string is blank (no program).
+pub(super) fn editor_command(editor: &str) -> Option<(String, Vec<String>)> {
+    let mut parts = editor.split_whitespace();
+    let program = parts.next()?.to_string();
+    let mut args: Vec<String> = parts.map(str::to_string).collect();
+
+    // GUI editors that need an explicit flag to block until the file is closed. All of the
+    // ones below accept `--wait`; key by the program's basename so a full path still matches.
+    let base = std::path::Path::new(&program)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or(&program)
+        .to_ascii_lowercase();
+    let needs_wait = matches!(
+        base.as_str(),
+        "code"
+            | "code-insiders"
+            | "codium"
+            | "vscodium"
+            | "cursor"
+            | "windsurf"
+            | "zed"
+            | "subl"
+            | "sublime_text"
+    );
+    if needs_wait && !args.iter().any(|a| a == "--wait" || a == "-w") {
+        args.push("--wait".to_string());
+    }
+
+    Some((program, args))
+}
+
 /// Opens the selected local file in `$VISUAL`/`$EDITOR` (default `vi`). A terminal editor
 /// needs the full terminal, so the TUI leaves raw mode / the alternate screen for the
-/// duration and restores afterwards. `$EDITOR` may include flags (e.g. `code --wait`).
+/// duration and restores afterwards. `$EDITOR` may include flags (e.g. `code --wait`); a
+/// wait flag is added automatically for known GUI editors (see [`editor_command`]).
 fn edit_local(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     state: &mut AppState,
@@ -701,12 +740,10 @@ fn edit_local(
     let editor = std::env::var("VISUAL")
         .or_else(|_| std::env::var("EDITOR"))
         .unwrap_or_else(|_| "vi".to_string());
-    let mut parts = editor.split_whitespace();
-    let Some(program) = parts.next() else {
+    let Some((program, args)) = editor_command(&editor) else {
         state.set_status("no editor configured (set $EDITOR)");
         return Ok(());
     };
-    let args: Vec<&str> = parts.collect();
 
     if state.mouse_enabled {
         execute!(terminal.backend_mut(), DisableMouseCapture)?;
@@ -761,13 +798,11 @@ fn edit_upload_buffer(
     let editor = std::env::var("VISUAL")
         .or_else(|_| std::env::var("EDITOR"))
         .unwrap_or_else(|_| "vi".to_string());
-    let mut parts = editor.split_whitespace();
-    let Some(program) = parts.next() else {
+    let Some((program, args)) = editor_command(&editor) else {
         state.set_status("no editor configured (set $EDITOR)");
         let _ = std::fs::remove_file(&temp_file_path);
         return Ok(());
     };
-    let args: Vec<&str> = parts.collect();
 
     if state.mouse_enabled {
         execute!(terminal.backend_mut(), DisableMouseCapture)?;

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -2430,6 +2430,87 @@ fn confirm_upload_json_toggles() {
     assert!(!state.upload.json_pretty);
 }
 
+// The upload buffer (and the local-file edit) shell out to `$EDITOR` and read the file back
+// once the editor exits. GUI editors that fork and return immediately (zed, code, …) must be
+// given a wait flag, or the read happens before the user saves and the *pre-edit* content is
+// uploaded — silently defeating a redact. `editor_command` injects that flag.
+
+#[test]
+fn editor_command_injects_wait_for_gui_editors() {
+    for ed in ["zed", "code", "code-insiders", "cursor", "windsurf", "subl"] {
+        let (program, args) = super::run_loop::editor_command(ed).unwrap();
+        assert_eq!(program, ed);
+        assert!(
+            args.iter().any(|a| a == "--wait" || a == "-w"),
+            "expected a wait flag for GUI editor {ed:?}, got {args:?}"
+        );
+    }
+}
+
+#[test]
+fn editor_command_matches_gui_editor_by_basename() {
+    // A full path or a `.exe` suffix must still be recognised as a GUI editor.
+    let (program, args) = super::run_loop::editor_command("/usr/local/bin/zed -n").unwrap();
+    assert_eq!(program, "/usr/local/bin/zed");
+    assert_eq!(args, vec!["-n", "--wait"]);
+}
+
+#[test]
+fn editor_command_leaves_terminal_editors_untouched() {
+    for ed in ["vi", "vim", "nvim", "nano", "emacs", "hx"] {
+        let (program, args) = super::run_loop::editor_command(ed).unwrap();
+        assert_eq!(program, ed);
+        assert!(
+            args.is_empty(),
+            "terminal editor {ed:?} should get no injected flag, got {args:?}"
+        );
+    }
+}
+
+#[test]
+fn editor_command_keeps_an_existing_wait_flag() {
+    // Don't duplicate a wait flag the user already configured (either spelling).
+    let (_, args) = super::run_loop::editor_command("code --wait").unwrap();
+    assert_eq!(args, vec!["--wait"]);
+    let (_, args) = super::run_loop::editor_command("subl -w").unwrap();
+    assert_eq!(args, vec!["-w"]);
+}
+
+#[test]
+fn editor_command_blank_is_none() {
+    assert!(super::run_loop::editor_command("").is_none());
+    assert!(super::run_loop::editor_command("   ").is_none());
+}
+
+// Whichever editor is used, the confirmed upload must send the edited (redacted) buffer, not
+// the original file snapshot taken at preview time.
+
+#[test]
+fn content_to_upload_prefers_edited_content() {
+    let mut state = initial_state();
+    state.pending_action = Some(PendingAction::Upload {
+        gist_id: "a".into(),
+        filename: "notes.txt".into(),
+        local_path: PathBuf::from("/tmp/notes.txt"),
+    });
+    state.upload.original_content = "token=abc123secret".into();
+    state.upload.edited_content = Some("token=REDACTED".into());
+    assert_eq!(state.content_to_upload(), "token=REDACTED");
+}
+
+#[test]
+fn content_to_upload_prefers_edited_content_for_json() {
+    let mut state = initial_state();
+    state.pending_action = Some(PendingAction::Upload {
+        gist_id: "a".into(),
+        filename: "settings.json".into(),
+        local_path: PathBuf::from("/tmp/settings.json"),
+    });
+    state.upload.original_content = r#"{"token":"abc123secret"}"#.into();
+    state.upload.edited_content = Some(r#"{"token":"REDACTED"}"#.into());
+    assert_eq!(state.content_to_upload(), r#"{"token":"REDACTED"}"#);
+}
+
 #[test]
 fn n_opens_create_confirm() {
     let mut state = initial_state();


### PR DESCRIPTION
## What & why

The upload **redact buffer** (`e`) and local-file edit shell out to `$EDITOR`/`$VISUAL` and read the file back once the editor process exits. GUI editors that fork and return immediately (`zed`, `code`, `cursor`, `subl`, …) make `Command::status()` return **before the user saves**, so the pre-edit buffer is read and uploaded — silently defeating a redaction (the **un-redacted original** gets published to the gist).

This was hit in practice with `VISUAL=zed` (no `--wait`).

## Fix

- New pure `editor_command()` helper injects a `--wait` flag for known GUI editors when none is present (matched by program **basename**, so full paths / `.exe` suffixes still resolve). Terminal editors (`vi`/`nano`/`emacs -nw`) already block and are untouched. An existing `-w`/`--wait` is never duplicated, so `VISUAL='zed --wait'` still composes cleanly.
- Both `edit_upload_buffer` and `edit_local` wired through it.
- Long-tail / niche editors remain solvable with no config via `$VISUAL='editor --flag'` (the escape hatch the helper preserves) — so no config surface was added.

## Tests

7 new unit tests: wait-flag injection for GUI editors, basename matching (full path), terminal editors untouched, no duplicate flag, blank → `None`, plus regression tests that `content_to_upload()` honours the edited (redacted) buffer for text and JSON.

## Release prep (0.14.2)

- `Cargo.toml`/`Cargo.lock` bumped to `0.14.2`; `cargo publish --dry-run` clean.
- `CHANGELOG.md` `[Unreleased]` stamped to `## [0.14.2] — 2026-06-25` with its release link reference (per `RELEASING.md`).

No related GitHub issue (reported directly). **Maintainer tags `v0.14.2` after merge** to trigger the binary build + crates.io publish.

## Verification

`cargo fmt --check` · `cargo test` (450 passed) · `cargo clippy --all-targets -- -D warnings` · `cargo publish --dry-run` — all green.