### PR TITLE
chore: split demo task into demo-gif + demo-png

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,9 @@ mise install            # provision the pinned toolchain (one-time)
 cargo run               # launch the TUI (needs a TTY)
 cargo run -- --check    # print gh readiness, then exit (no TUI)
 cargo test              # full suite; must NOT touch the network or require gh auth
-mise run demo           # regenerate the README demo GIF; re-run after any UI change
-mise run shots          # regenerate the still PNG screenshots (docs/*.png)
+mise run demo-gif       # regenerate the README demo GIF; re-run after any UI change
+mise run demo-png       # regenerate the still PNG screenshots (docs/*.png)
+mise run demo           # regenerate all demo media (demo-gif + demo-png)
 ```
 
 The demo recording harness (`scripts/demo/`) drives the **real** binary in a pseudo-tty against a **fake `gh`** over fake data, then renders `docs/demo.gif` with `agg`. Only the GIF is versioned (the cast is a throwaway intermediate). Edit `storyboard.json` to change what the demo shows; see `scripts/demo/README.md`.

--- a/mise.toml
+++ b/mise.toml
@@ -38,10 +38,14 @@ run = [
 description = "Launch the TUI"
 run = "cargo run"
 
-[tasks.demo]
+[tasks.demo-gif]
 description = "Regenerate the README demo GIF"
 run = "scripts/demo/record.sh"
 
-[tasks.shots]
+[tasks.demo-png]
 description = "Regenerate the still PNG screenshots"
 run = "scripts/demo/shots.sh"
+
+[tasks.demo]
+description = "Regenerate all demo media (GIF + still PNGs)"
+depends = ["demo-gif", "demo-png"]

--- a/scripts/demo/README.md
+++ b/scripts/demo/README.md
@@ -55,7 +55,9 @@ so diff/preview syntax highlighting is captured even when the host shell disable
 ## Requirements
 
 `mise install` (from the repo root) provisions `cargo`, `uv`, and `agg` from the
-pinned [`mise.toml`](../../mise.toml); `mise run demo` then wraps `record.sh`.
+pinned [`mise.toml`](../../mise.toml); `mise run demo-gif` then wraps `record.sh`
+(and `mise run demo-png` wraps `shots.sh`; `mise run demo` regenerates all media
+— the GIF and the still PNGs — by depending on both).
 The Python helpers run through `uv run`, which provisions the interpreter (and
 Pillow, for screenshots) on demand — no manual virtualenv. The interpreter
 version is pinned in [`.python-version`](.python-version) and picked up


### PR DESCRIPTION
## What

Refactor the `demo` mise task so it no longer wraps `record.sh` directly, splitting it into two output-oriented tasks:

- **`demo-gif`** carries the former `demo` body (drives the TUI harness, renders `docs/demo.gif`).
- **`demo-png`** wraps `shots.sh` (still PNGs).
- **`demo`** is now an aggregator: `depends = ["demo-gif", "demo-png"]`, no `run` of its own — one task regenerates **all** demo media.

## Why

`mise run demo` previously regenerated only the GIF; the still PNGs needed a separate task. After any UI change both should be refreshed together, so `demo` now fans out to both. The `demo-*` names are output-oriented (GIF vs PNG) and group under the `demo` prefix in `mise tasks`.

## Notes

- The two tasks use isolated workspaces (`/tmp/gistui-demo` vs `/tmp/gistui-shots`) and `cargo build` serializes via its own file lock, so mise's default parallel `depends` execution is conflict-free.
- Docs kept in lockstep: `AGENTS.md` build block + `scripts/demo/README.md` updated to the new task names.
- Internal dev-tooling only — no Rust touched, hence `skip-changelog`.