### PR TITLE
fix(diff): don't merge lines when a mid-diff line loses its trailing newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed: a diff line whose old-side text has no trailing newline (and is no longer the file's last line) no longer merges with the line that follows it into one malformed row in the diff view.
+
 ## [0.14.2] — 2026-06-25
 
 - Fixed: editing the upload buffer (`e`) or a local file with a GUI editor (`zed`, `code`, `cursor`, `subl`, …) now works even when `$EDITOR`/`$VISUAL` omits a wait flag — gistui adds `--wait` automatically, so it no longer reads the file back before you save and upload the pre-edit (un-redacted) content.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "gistui"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gistui"
-version = "0.14.2"
+version = "0.15.0"
 edition = "2021"
 license = "MIT"
 description = "A terminal UI for managing GitHub Gists"

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -42,6 +42,9 @@ pub fn unified_diff(
         };
         out.push_str(sign);
         out.push_str(change.value());
+        if change.missing_newline() {
+            out.push('\n');
+        }
     }
 
     out
@@ -119,6 +122,23 @@ mod tests {
         assert!(!diff.contains("-}"));
         assert!(!diff.contains("+}"));
         assert!(diff.contains(" }"));
+    }
+
+    #[test]
+    fn missing_newline_on_a_non_final_line_does_not_merge_into_the_next() {
+        // Regression: `old`'s last line has no trailing newline, but `new` appends more
+        // content after that same line, so it is no longer the diff's true final line.
+        // Without compensating for `Change::missing_newline`, the delete and the following
+        // insert/change were concatenated onto a single raw line (no `\n` between them).
+        let old = "a\nreset-author = x";
+        let new = "a\nreset-author = x\ncleanup = y\n";
+        let diff = unified_diff("gist", old, "local", new, false);
+        let lines: Vec<&str> = diff.lines().collect();
+        assert!(lines.contains(&"-reset-author = x"));
+        assert!(lines.contains(&"+reset-author = x"));
+        assert!(lines.contains(&"+cleanup = y"));
+        // Each change lands on its own line — none of them got glued together.
+        assert!(!lines.iter().any(|l| l.contains("x+")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `unified_diff()` concatenated each `similar::Change`'s sign + value with no separator. A token whose underlying line had no trailing newline normally only occurs on the diff's true final line — but when more content is appended after that same line (e.g. a config file missing a final `\n`, with a new line added after it), `similar` treats "has trailing `\n`" vs "doesn't" as distinct tokens, emitting a Delete/Insert pair where the Delete's value lacks a `\n`. The following `+`/`-` line then gets glued onto the same raw row with no marker, so the diff view renders one malformed line (e.g. `-old...text+new...text`).
- Fixed by compensating with `Change::missing_newline()`, mirroring how `similar`'s own `Display for Change` and `UnifiedDiff` formatter handle this.
- Related to #149 (trailing-newline-only phantom changes), but distinct: that issue is about the diff's absolute last line; this is about a missing-newline line that is no longer last because content was appended after it.

## Test plan
- [x] Added `missing_newline_on_a_non_final_line_does_not_merge_into_the_next` regression test in `src/diff.rs`, reproducing the exact scenario.
- [x] `cargo fmt --check`
- [x] `cargo test`
- [x] `cargo check`
- [x] `cargo clippy --all-targets -- -D warnings`