### PR TITLE
feat(tui): live-update the diff while editing the upload buffer in a GUI editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Editing the upload redact buffer (`e` on the upload confirm) in a GUI editor (`zed`, `code`, `cursor`, `subl`, …) now live-updates the diff as you save, instead of only refreshing after you close the editor; `y`/`e` are disabled until you do. Terminal editors are unchanged.
 - Fixed: a diff line whose old-side text has no trailing newline (and is no longer the file's last line) no longer merges with the line that follows it into one malformed row in the diff view.
 
 ## [0.14.2] — 2026-06-25

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -1422,10 +1422,21 @@ impl AppState {
                 _ => {}
             },
             Some(PendingAction::Upload { ref local_path, .. }) => match code {
+                KeyCode::Char('y') if self.upload.watching => {
+                    self.set_status("editor still open — finish editing first");
+                }
                 KeyCode::Char('y') => return KeyOutcome::Upload,
                 KeyCode::Char('n') | KeyCode::Char('q') | KeyCode::Esc => {
                     self.pending_action = None;
                     self.screen = Screen::List;
+                    // The background watch thread (if any) is not force-killed — it cleans
+                    // itself up once the editor closes. Reset the flag now so a stale
+                    // late-arriving event (see AppState::apply_upload_edit_event) doesn't
+                    // matter, and so a future upload-edit session isn't blocked by it.
+                    self.upload.watching = false;
+                }
+                KeyCode::Char('e') if self.upload.watching => {
+                    self.set_status("editor already open");
                 }
                 KeyCode::Char('e') => return KeyOutcome::EditUpload,
                 KeyCode::Char('p') if is_json_file(local_path) => {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -759,9 +759,6 @@ impl AppState {
     /// upload state. Discarded (no-op) if the Confirm/Upload context has since moved on — the
     /// user left Confirm, or a different upload edit session is now in progress — identified
     /// by comparing the event's `gist_id`/`filename` against the current `PendingAction::Upload`.
-    // Wired up by Task 4 (spawn_upload_edit_watch) and Task 5 (absorb_background_results) later
-    // in this branch — no caller yet.
-    #[allow(dead_code)]
     fn apply_upload_edit_event(&mut self, event: run_loop::UploadEditWatchEvent) {
         use run_loop::UploadEditWatchEvent as Ev;
         let (event_gist_id, event_filename) = match &event {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -757,8 +757,12 @@ impl AppState {
 
     /// Applies a background upload-edit-watch event (see `run_loop::UploadEditWatchEvent`) to
     /// upload state. Discarded (no-op) if the Confirm/Upload context has since moved on — the
-    /// user left Confirm, or a different upload edit session is now in progress — identified
-    /// by comparing the event's `gist_id`/`filename` against the current `PendingAction::Upload`.
+    /// user left Confirm, a different upload edit session is now in progress, or the current
+    /// session isn't actively watching (e.g. the user cancelled with `n`, which stops the
+    /// watch flag but does not kill the background thread; that thread's stale events must not
+    /// leak into a later, unrelated Confirm session for the same gist/file) — identified by
+    /// comparing the event's `gist_id`/`filename` against the current `PendingAction::Upload`
+    /// and requiring `self.upload.watching`.
     fn apply_upload_edit_event(&mut self, event: run_loop::UploadEditWatchEvent) {
         use run_loop::UploadEditWatchEvent as Ev;
         let (event_gist_id, event_filename) = match &event {
@@ -773,6 +777,7 @@ impl AppState {
             } => (gist_id.as_str(), filename.as_str()),
         };
         let context_matches = self.screen == Screen::Confirm
+            && self.upload.watching
             && matches!(
                 &self.pending_action,
                 Some(PendingAction::Upload { gist_id, filename, .. })

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -451,6 +451,10 @@ pub struct UploadState {
     pub remote_content: Option<String>,
     pub local_label: Option<String>,
     pub gist_label: Option<String>,
+    /// True while a GUI-editor background watch (see `run_loop::spawn_upload_edit_watch`) is
+    /// live-updating the diff. Gates `y`/`e` in `handle_key_confirm` — the upload can't be
+    /// confirmed, and a second editor instance can't be spawned, until the editor closes.
+    pub watching: bool,
 }
 
 /// Per-screen revision-history state (`Screen::Revisions`). Data only — the revision
@@ -749,6 +753,54 @@ impl AppState {
         self.upload.gist_label = Some(gist_label);
         self.update_upload_diff();
         Ok(())
+    }
+
+    /// Applies a background upload-edit-watch event (see `run_loop::UploadEditWatchEvent`) to
+    /// upload state. Discarded (no-op) if the Confirm/Upload context has since moved on — the
+    /// user left Confirm, or a different upload edit session is now in progress — identified
+    /// by comparing the event's `gist_id`/`filename` against the current `PendingAction::Upload`.
+    // Wired up by Task 4 (spawn_upload_edit_watch) and Task 5 (absorb_background_results) later
+    // in this branch — no caller yet.
+    #[allow(dead_code)]
+    fn apply_upload_edit_event(&mut self, event: run_loop::UploadEditWatchEvent) {
+        use run_loop::UploadEditWatchEvent as Ev;
+        let (event_gist_id, event_filename) = match &event {
+            Ev::ContentChanged {
+                gist_id, filename, ..
+            }
+            | Ev::EditorClosed {
+                gist_id, filename, ..
+            }
+            | Ev::ReadError {
+                gist_id, filename, ..
+            } => (gist_id.as_str(), filename.as_str()),
+        };
+        let context_matches = self.screen == Screen::Confirm
+            && matches!(
+                &self.pending_action,
+                Some(PendingAction::Upload { gist_id, filename, .. })
+                    if gist_id == event_gist_id && filename == event_filename
+            );
+        if !context_matches {
+            return;
+        }
+
+        match event {
+            Ev::ContentChanged { content, .. } => {
+                self.upload.edited_content = Some(content);
+                self.update_upload_diff();
+            }
+            Ev::EditorClosed { content, .. } => {
+                self.upload.edited_content = Some(content);
+                self.update_upload_diff();
+                self.upload.watching = false;
+                self.set_status("Edited redact buffer");
+            }
+            Ev::ReadError { message, .. } => {
+                self.upload.watching = false;
+                self.set_status(format!("failed to read edited file: {message}"));
+            }
+        }
     }
 
     fn list_gist_source(&self) -> &[GistFile] {

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -208,6 +208,8 @@ Mouse (on by default; disable with mouse = false in config or --no-mouse)
   y          confirm and execute the upload
   n / Esc    cancel the upload
   e          edit / redact the upload content in $EDITOR before upload
+             (GUI editors: the diff updates live while the editor stays open;
+             y/e wait until you close it — n still cancels immediately)
   p          (JSON only) toggle pretty-print formatting
   s          (JSON only) toggle recursive key sorting"
         }
@@ -2123,6 +2125,16 @@ pub(super) fn confirm_prompt(state: &AppState) -> String {
             format!(
                 "Create gist from {} ({desc})?  s secret  p public  Esc cancel",
                 crate::config::display_path(local_path)
+            )
+        }
+        Some(PendingAction::Upload {
+            gist_id: _,
+            filename: _,
+            local_path: _,
+        }) if state.upload.watching => {
+            format!(
+                "{} watching for edits — close the editor to continue  ·  n cancel",
+                spinner_glyph(state.spinner_frame)
             )
         }
         Some(PendingAction::Upload {

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -1149,9 +1149,6 @@ struct BgChannels {
     /// open (see `spawn_upload_edit_watch`). Unlike the other fields above (one-shot
     /// results), this channel can carry multiple `ContentChanged` events before its
     /// terminal `EditorClosed`/`ReadError` — drained in a loop in `absorb_background_results`.
-    // Read by Task 5's absorb_background_results drain loop, landing in a later commit on this
-    // branch.
-    #[allow(dead_code)]
     upload_edit_watch: Option<std::sync::mpsc::Receiver<UploadEditWatchEvent>>,
     bg: BgRx,
 }
@@ -1307,6 +1304,28 @@ fn absorb_background_results(
                 crate::update_check::UpdateCheckOutcome::Failed => {}
             }
         }
+    }
+
+    // Absorb upload-edit-watch events. Unlike the other channels above (one-shot), this one
+    // can carry several `ContentChanged` events before its terminal EditorClosed/ReadError —
+    // drain all of them so a burst of saves doesn't lag a tick behind.
+    let mut upload_watch_finished = false;
+    if let Some(ref rx) = channels.upload_edit_watch {
+        while let Ok(event) = rx.try_recv() {
+            if matches!(
+                event,
+                UploadEditWatchEvent::EditorClosed { .. } | UploadEditWatchEvent::ReadError { .. }
+            ) {
+                upload_watch_finished = true;
+            }
+            state.apply_upload_edit_event(event);
+            if upload_watch_finished {
+                break;
+            }
+        }
+    }
+    if upload_watch_finished {
+        channels.upload_edit_watch = None;
     }
 
     // Absorb a completed background per-action task.

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -42,6 +42,7 @@ pub(super) fn run_loop(
         star: None,
         fork_meta: None,
         local: None,
+        upload_edit_watch: None,
         bg: None,
     };
 
@@ -123,9 +124,6 @@ pub(super) fn run_loop(
 /// the upload-redact temp file open. `gist_id`/`filename` (the target `PendingAction::Upload`
 /// identity) ride along on every variant so `AppState::apply_upload_edit_event` can detect a
 /// stale event (the user left Confirm, or started a different upload edit) and discard it.
-// Wired up by Task 4 (spawn_upload_edit_watch) and Task 5 (absorb_background_results) later in
-// this branch — no caller yet.
-#[allow(dead_code)]
 pub(super) enum UploadEditWatchEvent {
     /// The temp file's mtime changed — re-read and live-update the diff.
     ContentChanged {
@@ -808,14 +806,87 @@ fn edit_local(
     Ok(())
 }
 
+/// Watches `temp_file_path` while a non-blocking GUI-editor child process has it open,
+/// sending a `ContentChanged` event on every detected save (polled every 500ms) and a
+/// terminal `EditorClosed`/`ReadError` event once the editor exits or fails to start. Deletes
+/// the temp file itself before returning — the caller never needs to clean up after this
+/// thread. This is the non-blocking counterpart to the `Command::status()` call further down
+/// in `edit_upload_buffer`, used only for editors `editor_is_gui` recognises.
+fn spawn_upload_edit_watch(
+    program: String,
+    args: Vec<String>,
+    temp_file_path: PathBuf,
+    gist_id: String,
+    filename: String,
+) -> std::sync::mpsc::Receiver<UploadEditWatchEvent> {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut child = match std::process::Command::new(&program)
+            .args(&args)
+            .arg(&temp_file_path)
+            .spawn()
+        {
+            Ok(child) => child,
+            Err(e) => {
+                let _ = tx.send(UploadEditWatchEvent::ReadError {
+                    gist_id,
+                    filename,
+                    message: format!("editor failed to start: {e}"),
+                });
+                let _ = std::fs::remove_file(&temp_file_path);
+                return;
+            }
+        };
+
+        let mut last_modified = std::fs::metadata(&temp_file_path)
+            .and_then(|m| m.modified())
+            .ok();
+        loop {
+            if matches!(child.try_wait(), Ok(Some(_))) {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(500));
+            if let Ok(modified) = std::fs::metadata(&temp_file_path).and_then(|m| m.modified()) {
+                if Some(modified) != last_modified {
+                    last_modified = Some(modified);
+                    if let Ok(content) = std::fs::read_to_string(&temp_file_path) {
+                        let _ = tx.send(UploadEditWatchEvent::ContentChanged {
+                            gist_id: gist_id.clone(),
+                            filename: filename.clone(),
+                            content,
+                        });
+                    }
+                }
+            }
+        }
+
+        let final_event = match std::fs::read_to_string(&temp_file_path) {
+            Ok(content) => UploadEditWatchEvent::EditorClosed {
+                gist_id,
+                filename,
+                content,
+            },
+            Err(e) => UploadEditWatchEvent::ReadError {
+                gist_id,
+                filename,
+                message: format!("failed to read edited file: {e}"),
+            },
+        };
+        let _ = tx.send(final_event);
+        let _ = std::fs::remove_file(&temp_file_path);
+    });
+    rx
+}
+
 fn edit_upload_buffer(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     state: &mut AppState,
+    channels: &mut BgChannels,
 ) -> Result<()> {
     let Some(local_path) = state.upload_local_path() else {
         return Ok(());
     };
-    let Some(filename) = local_path.file_name().and_then(|n| n.to_str()) else {
+    let Some(local_filename) = local_path.file_name().and_then(|n| n.to_str()) else {
         return Ok(());
     };
 
@@ -824,7 +895,7 @@ fn edit_upload_buffer(
         .map(|d| d.as_nanos())
         .unwrap_or(0);
     let temp_file_path =
-        std::env::temp_dir().join(format!(".gistui_redact_{timestamp}_{filename}"));
+        std::env::temp_dir().join(format!(".gistui_redact_{timestamp}_{local_filename}"));
 
     let current_content = state.content_to_upload();
     if let Err(e) = std::fs::write(&temp_file_path, &current_content) {
@@ -840,6 +911,31 @@ fn edit_upload_buffer(
         let _ = std::fs::remove_file(&temp_file_path);
         return Ok(());
     };
+
+    // GUI editors run in their own window, so gistui doesn't need the terminal back — spawn
+    // non-blocking and watch the temp file for saves instead of blocking on Command::status().
+    // Terminal editors (below) still need the full terminal and stay fully blocking.
+    if editor_is_gui(&program) {
+        let Some(PendingAction::Upload {
+            gist_id,
+            filename: gist_filename,
+            ..
+        }) = state.pending_action.clone()
+        else {
+            let _ = std::fs::remove_file(&temp_file_path);
+            return Ok(());
+        };
+        channels.upload_edit_watch = Some(spawn_upload_edit_watch(
+            program,
+            args,
+            temp_file_path,
+            gist_id,
+            gist_filename,
+        ));
+        state.upload.watching = true;
+        state.set_status("Editing in external editor — diff updates live");
+        return Ok(());
+    }
 
     if state.mouse_enabled {
         execute!(terminal.backend_mut(), DisableMouseCapture)?;
@@ -1040,8 +1136,8 @@ fn upload_local_filename(local: &std::path::Path) -> Option<String> {
     local.file_name().and_then(|n| n.to_str()).map(String::from)
 }
 
-/// The seven background-work receivers `run_loop` drains each iteration, bundled so the
-/// extracted loop steps take one `&mut BgChannels` instead of seven `&mut` parameters.
+/// The background-work receivers `run_loop` drains each iteration, bundled so the
+/// extracted loop steps take one `&mut BgChannels` instead of separate `&mut` parameters.
 struct BgChannels {
     update: Option<std::sync::mpsc::Receiver<crate::update_check::UpdateCheckOutcome>>,
     gist: Option<std::sync::mpsc::Receiver<GistFetchResult>>,
@@ -1049,6 +1145,14 @@ struct BgChannels {
     star: Option<std::sync::mpsc::Receiver<std::collections::HashMap<String, u32>>>,
     fork_meta: Option<std::sync::mpsc::Receiver<ForkMetaResult>>,
     local: Option<std::sync::mpsc::Receiver<Vec<LocalCandidate>>>,
+    /// Streams `UploadEditWatchEvent`s while a GUI editor has the upload-redact temp file
+    /// open (see `spawn_upload_edit_watch`). Unlike the other fields above (one-shot
+    /// results), this channel can carry multiple `ContentChanged` events before its
+    /// terminal `EditorClosed`/`ReadError` — drained in a loop in `absorb_background_results`.
+    // Read by Task 5's absorb_background_results drain loop, landing in a later commit on this
+    // branch.
+    #[allow(dead_code)]
+    upload_edit_watch: Option<std::sync::mpsc::Receiver<UploadEditWatchEvent>>,
     bg: BgRx,
 }
 
@@ -1938,7 +2042,7 @@ fn dispatch_outcome(
             });
         }
         KeyOutcome::EditUpload => {
-            edit_upload_buffer(terminal, state)?;
+            edit_upload_buffer(terminal, state, channels)?;
         }
         KeyOutcome::Create(public) => {
             let Some(PendingAction::Create { local_path }) = state.pending_action.clone() else {

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -119,6 +119,36 @@ pub(super) fn run_loop(
     Ok(())
 }
 
+/// Emitted by the background thread `spawn_upload_edit_watch` spawns while a GUI editor has
+/// the upload-redact temp file open. `gist_id`/`filename` (the target `PendingAction::Upload`
+/// identity) ride along on every variant so `AppState::apply_upload_edit_event` can detect a
+/// stale event (the user left Confirm, or started a different upload edit) and discard it.
+// Wired up by Task 4 (spawn_upload_edit_watch) and Task 5 (absorb_background_results) later in
+// this branch — no caller yet.
+#[allow(dead_code)]
+pub(super) enum UploadEditWatchEvent {
+    /// The temp file's mtime changed — re-read and live-update the diff.
+    ContentChanged {
+        gist_id: String,
+        filename: String,
+        content: String,
+    },
+    /// The editor process exited; this is the final content, and the temp file has already
+    /// been deleted by the sending thread.
+    EditorClosed {
+        gist_id: String,
+        filename: String,
+        content: String,
+    },
+    /// Either the editor failed to start, or the final read after it closed failed. The temp
+    /// file has already been cleaned up (best-effort) by the sending thread.
+    ReadError {
+        gist_id: String,
+        filename: String,
+        message: String,
+    },
+}
+
 enum BgTaskOutcome {
     PreviewDiff {
         result: std::result::Result<String, String>,
@@ -694,10 +724,7 @@ fn copy_preview_content(state: &mut AppState) {
 /// terminal). Keyed by basename so a full path or a `.exe` suffix still matches.
 pub(super) fn editor_is_gui(program: &str) -> bool {
     // Extract basename handling both Unix (/) and Windows (\) separators, then strip .exe if present.
-    let basename = program
-        .rsplit(['/', '\\'])
-        .next()
-        .unwrap_or(program);
+    let basename = program.rsplit(['/', '\\']).next().unwrap_or(program);
     let base = std::path::Path::new(basename)
         .file_stem()
         .and_then(|s| s.to_str())

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -688,6 +688,35 @@ fn copy_preview_content(state: &mut AppState) {
     }
 }
 
+/// Whether `program`'s basename matches a known GUI editor that forks and returns
+/// immediately (so it both needs `--wait` injected by `editor_command`, and — for the
+/// upload-redact-buffer flow — can be watched non-blocking instead of taking over the
+/// terminal). Keyed by basename so a full path or a `.exe` suffix still matches.
+pub(super) fn editor_is_gui(program: &str) -> bool {
+    // Extract basename handling both Unix (/) and Windows (\) separators, then strip .exe if present.
+    let basename = program
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(program);
+    let base = std::path::Path::new(basename)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or(basename)
+        .to_ascii_lowercase();
+    matches!(
+        base.as_str(),
+        "code"
+            | "code-insiders"
+            | "codium"
+            | "vscodium"
+            | "cursor"
+            | "windsurf"
+            | "zed"
+            | "subl"
+            | "sublime_text"
+    )
+}
+
 /// Split a `$VISUAL`/`$EDITOR` string into `(program, args)`, injecting a "wait" flag for
 /// known GUI editors that fork and return immediately (`zed`, `code`, `cursor`, `subl`, …).
 /// Without it `Command::status()` returns *before* the user saves, so the caller reads back
@@ -700,26 +729,7 @@ pub(super) fn editor_command(editor: &str) -> Option<(String, Vec<String>)> {
     let program = parts.next()?.to_string();
     let mut args: Vec<String> = parts.map(str::to_string).collect();
 
-    // GUI editors that need an explicit flag to block until the file is closed. All of the
-    // ones below accept `--wait`; key by the program's basename so a full path still matches.
-    let base = std::path::Path::new(&program)
-        .file_stem()
-        .and_then(|s| s.to_str())
-        .unwrap_or(&program)
-        .to_ascii_lowercase();
-    let needs_wait = matches!(
-        base.as_str(),
-        "code"
-            | "code-insiders"
-            | "codium"
-            | "vscodium"
-            | "cursor"
-            | "windsurf"
-            | "zed"
-            | "subl"
-            | "sublime_text"
-    );
-    if needs_wait && !args.iter().any(|a| a == "--wait" || a == "-w") {
+    if editor_is_gui(&program) && !args.iter().any(|a| a == "--wait" || a == "-w") {
         args.push("--wait".to_string());
     }
 

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -2406,6 +2406,60 @@ fn confirm_upload_e_returns_edit_upload() {
 }
 
 #[test]
+fn confirm_upload_y_is_blocked_while_watching() {
+    let mut state = initial_state();
+    state.pending_action = Some(PendingAction::Upload {
+        gist_id: "a".into(),
+        filename: "settings.json".into(),
+        local_path: PathBuf::from("/tmp/settings.json"),
+    });
+    state.screen = Screen::Confirm;
+    state.upload.watching = true;
+
+    assert_eq!(state.handle_key(KeyCode::Char('y')), KeyOutcome::None);
+    assert_eq!(
+        state.status.as_deref(),
+        Some("editor still open — finish editing first")
+    );
+}
+
+#[test]
+fn confirm_upload_e_is_blocked_while_watching() {
+    let mut state = initial_state();
+    state.pending_action = Some(PendingAction::Upload {
+        gist_id: "a".into(),
+        filename: "settings.json".into(),
+        local_path: PathBuf::from("/tmp/settings.json"),
+    });
+    state.screen = Screen::Confirm;
+    state.upload.watching = true;
+
+    assert_eq!(state.handle_key(KeyCode::Char('e')), KeyOutcome::None);
+    assert_eq!(state.status.as_deref(), Some("editor already open"));
+}
+
+#[test]
+fn confirm_upload_n_cancels_and_resets_watching() {
+    let mut state = initial_state();
+    state.pending_action = Some(PendingAction::Upload {
+        gist_id: "a".into(),
+        filename: "settings.json".into(),
+        local_path: PathBuf::from("/tmp/settings.json"),
+    });
+    state.screen = Screen::Confirm;
+    state.upload.watching = true;
+
+    assert_eq!(state.handle_key(KeyCode::Char('n')), KeyOutcome::None);
+    assert!(state.pending_action.is_none());
+    assert_eq!(state.screen, Screen::List);
+    assert!(
+        !state.upload.watching,
+        "cancelling must reset watching so a future upload-edit session isn't blocked forever \
+         by a stale flag (the background thread is not force-killed and cleans up on its own)"
+    );
+}
+
+#[test]
 fn confirm_upload_json_toggles() {
     let mut state = initial_state();
     state.pending_action = Some(PendingAction::Upload {

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -2547,6 +2547,118 @@ fn content_to_upload_prefers_edited_content_for_json() {
     assert_eq!(state.content_to_upload(), r#"{"token":"REDACTED"}"#);
 }
 
+fn upload_pending(gist_id: &str, filename: &str) -> PendingAction {
+    PendingAction::Upload {
+        gist_id: gist_id.into(),
+        filename: filename.into(),
+        local_path: PathBuf::from(format!("/tmp/{filename}")),
+    }
+}
+
+#[test]
+fn apply_upload_edit_event_content_changed_updates_diff_live() {
+    let mut state = initial_state();
+    state.screen = Screen::Confirm;
+    state.pending_action = Some(upload_pending("a", "notes.txt"));
+    state.upload.watching = true;
+    state.upload.remote_content = Some("old\n".into());
+    state.upload.local_label = Some("local".into());
+    state.upload.gist_label = Some("gist".into());
+
+    state.apply_upload_edit_event(super::run_loop::UploadEditWatchEvent::ContentChanged {
+        gist_id: "a".into(),
+        filename: "notes.txt".into(),
+        content: "new\n".into(),
+    });
+
+    assert_eq!(state.upload.edited_content.as_deref(), Some("new\n"));
+    assert!(
+        state.upload.watching,
+        "still watching — editor hasn't closed yet"
+    );
+    assert!(state.diff_text.contains("new"));
+}
+
+#[test]
+fn apply_upload_edit_event_editor_closed_stops_watching() {
+    let mut state = initial_state();
+    state.screen = Screen::Confirm;
+    state.pending_action = Some(upload_pending("a", "notes.txt"));
+    state.upload.watching = true;
+
+    state.apply_upload_edit_event(super::run_loop::UploadEditWatchEvent::EditorClosed {
+        gist_id: "a".into(),
+        filename: "notes.txt".into(),
+        content: "final\n".into(),
+    });
+
+    assert_eq!(state.upload.edited_content.as_deref(), Some("final\n"));
+    assert!(!state.upload.watching);
+}
+
+#[test]
+fn apply_upload_edit_event_read_error_stops_watching_and_sets_status() {
+    let mut state = initial_state();
+    state.screen = Screen::Confirm;
+    state.pending_action = Some(upload_pending("a", "notes.txt"));
+    state.upload.watching = true;
+
+    state.apply_upload_edit_event(super::run_loop::UploadEditWatchEvent::ReadError {
+        gist_id: "a".into(),
+        filename: "notes.txt".into(),
+        message: "permission denied".into(),
+    });
+
+    assert!(!state.upload.watching);
+    assert_eq!(
+        state.status.as_deref(),
+        Some("failed to read edited file: permission denied")
+    );
+}
+
+#[test]
+fn apply_upload_edit_event_discards_when_context_is_stale() {
+    let mut state = initial_state();
+    // The user already left Confirm (e.g. cancelled) before this late event arrived.
+    state.screen = Screen::List;
+    state.pending_action = None;
+    state.upload.watching = false;
+    state.upload.edited_content = None;
+
+    state.apply_upload_edit_event(super::run_loop::UploadEditWatchEvent::ContentChanged {
+        gist_id: "a".into(),
+        filename: "notes.txt".into(),
+        content: "should be ignored".into(),
+    });
+
+    assert_eq!(state.upload.edited_content, None);
+}
+
+#[test]
+fn apply_upload_edit_event_discards_when_a_different_upload_is_now_pending() {
+    let mut state = initial_state();
+    // A new upload edit session started before the OLD one's final event arrived.
+    state.screen = Screen::Confirm;
+    state.pending_action = Some(upload_pending("a", "other.txt"));
+    state.upload.watching = true;
+    state.upload.edited_content = Some("current session content".into());
+
+    state.apply_upload_edit_event(super::run_loop::UploadEditWatchEvent::EditorClosed {
+        gist_id: "a".into(),
+        filename: "notes.txt".into(), // stale session's filename, not "other.txt"
+        content: "stale content".into(),
+    });
+
+    assert_eq!(
+        state.upload.edited_content.as_deref(),
+        Some("current session content")
+    );
+    assert!(
+        state.upload.watching,
+        "the current session's watch must not be cancelled"
+    );
+}
+
 #[test]
 fn n_opens_create_confirm() {
     let mut state = initial_state();

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1432,6 +1432,25 @@ fn confirm_prompt_shows_description_editor_for_create() {
 }
 
 #[test]
+fn confirm_prompt_shows_watching_indicator_for_upload() {
+    let mut state = initial_state();
+    state.pending_action = Some(PendingAction::Upload {
+        gist_id: "a".into(),
+        filename: "notes.txt".into(),
+        local_path: PathBuf::from("/tmp/notes.txt"),
+    });
+    state.screen = Screen::Confirm;
+    state.upload.watching = true;
+
+    let prompt = confirm_prompt(&state);
+    assert!(prompt.contains("watching for edits"));
+    assert!(
+        !prompt.contains("y yes"),
+        "y/e hints should be hidden while watching"
+    );
+}
+
+#[test]
 fn row_mark_pinned_beats_same_name() {
     assert_eq!(
         row_mark(&[MatchReason::Pinned, MatchReason::ExactFilename]),

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -2482,6 +2482,42 @@ fn editor_command_blank_is_none() {
     assert!(super::run_loop::editor_command("   ").is_none());
 }
 
+#[test]
+fn editor_is_gui_matches_known_gui_editors() {
+    for ed in [
+        "zed",
+        "code",
+        "code-insiders",
+        "codium",
+        "vscodium",
+        "cursor",
+        "windsurf",
+        "subl",
+        "sublime_text",
+    ] {
+        assert!(
+            super::run_loop::editor_is_gui(ed),
+            "{ed} should be recognised as a GUI editor"
+        );
+    }
+}
+
+#[test]
+fn editor_is_gui_rejects_terminal_editors() {
+    for ed in ["vi", "vim", "nvim", "nano", "emacs", "hx"] {
+        assert!(
+            !super::run_loop::editor_is_gui(ed),
+            "{ed} should not be recognised as a GUI editor"
+        );
+    }
+}
+
+#[test]
+fn editor_is_gui_matches_by_basename_from_full_path() {
+    assert!(super::run_loop::editor_is_gui("/usr/local/bin/zed"));
+    assert!(super::run_loop::editor_is_gui("C:\\Tools\\code.exe"));
+}
+
 // Whichever editor is used, the confirmed upload must send the edited (redacted) buffer, not
 // the original file snapshot taken at preview time.
 

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -2733,6 +2733,31 @@ fn apply_upload_edit_event_discards_when_a_different_upload_is_now_pending() {
 }
 
 #[test]
+fn apply_upload_edit_event_discards_stale_event_after_cancel_reentry_same_identity() {
+    let mut state = initial_state();
+    // Simulates: user cancelled a GUI-editor watch session (n resets watching to false but
+    // does NOT kill the background thread), then re-entered upload for the SAME gist/file
+    // without pressing `e` again. An event from the abandoned first session's thread must
+    // not silently overwrite this new, non-watching session's content.
+    state.screen = Screen::Confirm;
+    state.pending_action = Some(upload_pending("a", "notes.txt"));
+    state.upload.watching = false; // never re-entered edit mode this session
+    state.upload.edited_content = None;
+
+    state.apply_upload_edit_event(super::run_loop::UploadEditWatchEvent::ContentChanged {
+        gist_id: "a".into(),
+        filename: "notes.txt".into(),
+        content: "leaked from abandoned session".into(),
+    });
+
+    assert_eq!(
+        state.upload.edited_content, None,
+        "an event from an abandoned (cancelled, still-running) watch session must not \
+         leak into a new, non-watching session with the same gist/file identity"
+    );
+}
+
+#[test]
 fn n_opens_create_confirm() {
     let mut state = initial_state();
     state.locals = vec![LocalCandidate {


### PR DESCRIPTION
## Summary
- Editing the gist upload-redact buffer (`e` on the Confirm screen's Upload prompt) in a GUI `$EDITOR`/`$VISUAL` (`zed`, `code`, `cursor`, `subl`, …) now live-updates the diff pane as you save, instead of only refreshing after you fully close the editor. The editor is spawned non-blocking and a background thread polls the temp file every 500ms, streaming updates back through the existing background-task channel plumbing.
- Terminal editors (`vi`, `nano`, …) are unchanged — they still take over the terminal and block synchronously, since they physically can't share it with gistui's own rendering.
- While a watch is active, `y`/`e` are disabled with a status hint until the editor closes; `n` still cancels immediately (the background thread isn't force-killed — it cleans itself up and any stale result is now safely discarded, see the fix commit below).
- Help text (`?` → Upload topic) and `CHANGELOG.md` updated to match.

Built with `superpowers:brainstorming` → `writing-plans` → `subagent-driven-development`: a design spec was worked out interactively, broken into a 7-step implementation plan, then executed task-by-task with a fresh implementer + reviewer per task, plus a final whole-branch review. That final review caught one real cross-task bug (a cancelled-but-still-running watch session's stale event could leak into a later, unrelated upload session for the same gist/file) — fixed and re-reviewed in the last commit.

## Test plan
- [x] `cargo fmt --check && cargo test && cargo check && cargo clippy --all-targets -- -D warnings` — all green on every commit in this branch.
- [x] Unit tests cover: `editor_is_gui` basename matching (GUI vs terminal editors, full paths), `apply_upload_edit_event`'s pure state transitions (content-changed, editor-closed, read-error, and three staleness-discard variants including the fixed cross-session-leak case), and the `y`/`e`/`n` key-gating in `handle_key_confirm`.
- [x] Manual smoke test with a real GUI editor and a real terminal editor — not yet performed (no interactive TTY was available anywhere in the automated pipeline that built this PR); should be done before merge.