### PR TITLE
fix(tui): stay on Pins after completing an upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Editing the upload redact buffer (`e` on the upload confirm) in a GUI editor (`zed`, `code`, `cursor`, `subl`, …) now live-updates the diff as you save, instead of only refreshing after you close the editor; `y`/`e` are disabled until you do. Terminal editors are unchanged.
 - Fixed: a diff line whose old-side text has no trailing newline (and is no longer the file's last line) no longer merges with the line that follows it into one malformed row in the diff view.
+- Fixed: completing or cancelling an upload started from the Pins view now stays on the Pins view instead of returning to the File List view.
 
 ## [0.14.2] — 2026-06-25
 

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -1428,7 +1428,9 @@ impl AppState {
                 KeyCode::Char('y') => return KeyOutcome::Upload,
                 KeyCode::Char('n') | KeyCode::Char('q') | KeyCode::Esc => {
                     self.pending_action = None;
-                    self.screen = Screen::List;
+                    // Return to wherever the upload was initiated from (List, or Pins for
+                    // a pin push) instead of always snapping back to List.
+                    self.screen = self.diff_return;
                     // The background watch thread (if any) is not force-killed — it cleans
                     // itself up once the editor closes. Reset the flag now so a stale
                     // late-arriving event (see AppState::apply_upload_edit_event) doesn't

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -542,6 +542,7 @@ fn pin_local_abs(state: &AppState, m: &crate::domain::PinnedMapping) -> PathBuf 
 /// Spawn the push (upload local → gist) flow for a pin: lands in the existing
 /// upload `Screen::Confirm` diff.
 fn spawn_pin_push(state: &mut AppState, bg_rx: &mut BgRx, m: &crate::domain::PinnedMapping) {
+    state.diff_return = Screen::Pins;
     let local_path = pin_local_abs(state, m);
     let gist_id = m.gist_id.clone();
     let filename = m.gist_filename.clone();
@@ -1487,7 +1488,11 @@ fn absorb_background_results(
                                 crate::domain::SyncDirection::Upload,
                             );
                         }
+                        // Return to wherever this upload was initiated from (List, or Pins
+                        // for a pin push) instead of always snapping to List.
+                        let return_screen = state.diff_return;
                         state.back_to_list();
+                        state.screen = return_screen;
                         state.loading = true;
                         channels.gist = Some(spawn_gist_fetch());
                     }
@@ -1927,6 +1932,9 @@ fn dispatch_outcome(
                 };
                 (state.preview_local.clone(), gist_id)
             } else {
+                // List-originated upload: reset any leftover Pins origin from an earlier
+                // pin push (mirrors KeyOutcome::PreviewDiff's own reset).
+                state.diff_return = Screen::List;
                 let (Some(local), Some(gist)) = (state.selected_local(), state.selected_gist())
                 else {
                     return Ok(LoopFlow::Proceed);
@@ -1973,6 +1981,9 @@ fn dispatch_outcome(
                     .unwrap_or_else(|| GistFile::for_sync(gist_id.clone(), filename.clone(), None));
                 (local_path, gist_id, gist_file)
             } else {
+                // List-originated upload: reset any leftover Pins origin from an earlier
+                // pin push (mirrors KeyOutcome::PreviewDiff's own reset).
+                state.diff_return = Screen::List;
                 let (Some(local), Some(gist)) = (state.selected_local(), state.selected_gist())
                 else {
                     return Ok(LoopFlow::Proceed);
@@ -2045,7 +2056,11 @@ fn dispatch_outcome(
                 crate::actions::upload_add_command(&temp_file_path, &gist_id)
             };
 
+            // Return to wherever this upload was initiated from (List, or Pins for a pin
+            // push) instead of always snapping to List (mirrors download()).
+            let return_screen = state.diff_return;
             state.back_to_list();
+            state.screen = return_screen;
             spawn_bg(state, &mut channels.bg, "Uploading…", move || {
                 let result = crate::actions::execute_command(&plan)
                     .map(|_| ())

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -2479,6 +2479,26 @@ fn confirm_upload_n_cancels_and_resets_watching() {
 }
 
 #[test]
+fn confirm_upload_n_cancels_to_diff_return_screen() {
+    let mut state = initial_state();
+    state.pending_action = Some(PendingAction::Upload {
+        gist_id: "a".into(),
+        filename: "settings.json".into(),
+        local_path: PathBuf::from("/tmp/settings.json"),
+    });
+    state.screen = Screen::Confirm;
+    state.diff_return = Screen::Pins;
+
+    assert_eq!(state.handle_key(KeyCode::Char('n')), KeyOutcome::None);
+    assert!(state.pending_action.is_none());
+    assert_eq!(
+        state.screen,
+        Screen::Pins,
+        "cancelling an upload initiated from Pins must return to Pins, not always List"
+    );
+}
+
+#[test]
 fn confirm_upload_json_toggles() {
     let mut state = initial_state();
     state.pending_action = Some(PendingAction::Upload {


### PR DESCRIPTION
## Summary
- After a successful (or cancelled) upload started from the Pins view, gistui now stays on Pins instead of jumping back to the File List view.
- Extends the existing `diff_return` origin-screen mechanism (already used by downloads/pulls) to the upload/push path, which previously hardcoded `Screen::List` at every exit point.
- This also covers uploading from a pin's read-only diff view (reached via Pins → Enter), not just a direct push from the Pins list — both origins now correctly return to Pins.

Fixes #199

## Test plan
- [x] `cargo test` — new `confirm_upload_n_cancels_to_diff_return_screen` test plus full suite green
- [x] `mise run check` — fmt/test/check/clippy all pass