### PR TITLE
feat(tui): flag pinned entries whose local file is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Editing the upload redact buffer (`e` on the upload confirm) in a GUI editor (`zed`, `code`, `cursor`, `subl`, …) now live-updates the diff as you save, instead of only refreshing after you close the editor; `y`/`e` are disabled until you do. Terminal editors are unchanged.
 - Fixed: a diff line whose old-side text has no trailing newline (and is no longer the file's last line) no longer merges with the line that follows it into one malformed row in the diff view.
 - Fixed: completing or cancelling an upload started from the Pins view now stays on the Pins view instead of returning to the File List view.
+- Pins view: a pinned entry whose local file no longer exists on disk is now flagged in the list (a distinct `✕` icon and a red row) instead of only surfacing as an error after you select or act on it.
 
 ## [0.14.2] — 2026-06-25
 

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -28,6 +28,8 @@ pub enum SyncStatus {
     Push,
     /// Remote is newer → download the gist into the local file.
     Pull,
+    /// The local file could not be stat-ed (almost always: it no longer exists).
+    Missing,
     /// A timestamp is unavailable — direction cannot be suggested.
     Unknown,
 }
@@ -39,19 +41,23 @@ impl SyncStatus {
             SyncStatus::InSync => "✓",
             SyncStatus::Push => "↑",
             SyncStatus::Pull => "↓",
+            SyncStatus::Missing => "✕",
             SyncStatus::Unknown => "?",
         }
     }
 }
 
 /// Pure decision: which side is newer? `local_ts`/`remote_ts` are Unix seconds;
-/// `None` means the timestamp was unavailable.
+/// `None` means the timestamp was unavailable. A missing `local_ts` always means
+/// `Missing`, regardless of `remote_ts` — that's a stronger, more actionable fact
+/// than "remote timestamp unknown" (which stays `Unknown`).
 pub fn sync_status(local_ts: Option<u64>, remote_ts: Option<u64>) -> SyncStatus {
     match (local_ts, remote_ts) {
+        (None, _) => SyncStatus::Missing,
         (Some(l), Some(r)) if l > r => SyncStatus::Push,
         (Some(l), Some(r)) if r > l => SyncStatus::Pull,
         (Some(_), Some(_)) => SyncStatus::InSync,
-        _ => SyncStatus::Unknown,
+        (Some(_), None) => SyncStatus::Unknown,
     }
 }
 
@@ -400,9 +406,17 @@ mod tests {
         assert_eq!(sync_status(Some(20), Some(10)), SyncStatus::Push); // local newer
         assert_eq!(sync_status(Some(10), Some(20)), SyncStatus::Pull); // remote newer
         assert_eq!(sync_status(Some(15), Some(15)), SyncStatus::InSync);
-        assert_eq!(sync_status(None, Some(10)), SyncStatus::Unknown);
-        assert_eq!(sync_status(Some(10), None), SyncStatus::Unknown);
-        assert_eq!(sync_status(None, None), SyncStatus::Unknown);
+        assert_eq!(
+            sync_status(None, Some(10)),
+            SyncStatus::Missing,
+            "local file is gone (or unreadable) even though the gist has a known mtime"
+        );
+        assert_eq!(sync_status(Some(10), None), SyncStatus::Unknown); // local exists, remote mtime unknown
+        assert_eq!(
+            sync_status(None, None),
+            SyncStatus::Missing,
+            "local missing takes priority even when remote mtime is also unknown"
+        );
     }
 
     #[test]
@@ -410,6 +424,7 @@ mod tests {
         assert_eq!(SyncStatus::InSync.icon(), "✓");
         assert_eq!(SyncStatus::Push.icon(), "↑");
         assert_eq!(SyncStatus::Pull.icon(), "↓");
+        assert_eq!(SyncStatus::Missing.icon(), "✕");
         assert_eq!(SyncStatus::Unknown.icon(), "?");
     }
 

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -126,7 +126,7 @@ Mouse (on by default; disable with mouse = false in config or --no-mouse)
   u          force push  (upload local → gist)
   d          force pull  (download gist → local, diff + y/n confirm)
   x          unpin the selected pair
-  status     ✓ synced · ↑ local newer · ↓ remote newer · ? unknown
+  status     ✓ synced · ↑ local newer · ↓ remote newer · ✕ missing · ? unknown
   Each row shows (local <age> · gist <age>) relative modification times."
         }
         HelpTopic::GistManager => {
@@ -376,7 +376,7 @@ pub(super) fn render_pins(frame: &mut Frame, state: &AppState, layout: &mut Mous
     let hints = if state.pinned.is_empty() {
         "Esc/q back"
     } else {
-        "↑↓ move · ←→ scroll · / filter · o sort · Enter diff · s sync · u push · d pull · x unpin · ? help  ·  ✓ synced ↑ local-newer ↓ remote-newer ? n/a  ·  Esc/q back"
+        "↑↓ move · ←→ scroll · / filter · o sort · Enter diff · s sync · u push · d pull · x unpin · ? help  ·  ✓ synced ↑ local-newer ↓ remote-newer ✕ missing ? n/a  ·  Esc/q back"
     };
     let (ftitle, footer, colored) = if state.pins.filtering {
         (
@@ -417,17 +417,28 @@ pub(super) fn render_pins(frame: &mut Frame, state: &AppState, layout: &mut Mous
                     ts.map(|t| crate::domain::humanize_age(now - t as i64))
                         .unwrap_or_else(|| "?".to_string())
                 };
-                ListItem::new(hscroll_str(
+                let status = state.pin_sync_status(i);
+                let local_age = if status == crate::domain::SyncStatus::Missing {
+                    "missing".to_string()
+                } else {
+                    age(lts)
+                };
+                let item = ListItem::new(hscroll_str(
                     &pin_row_label(
-                        state.pin_sync_status(i).icon(),
+                        status.icon(),
                         &m.local_path,
                         &m.gist_id,
                         &m.gist_filename,
-                        &age(lts),
+                        &local_age,
                         &age(rts),
                     ),
                     state.pins.hscroll,
-                ))
+                ));
+                if status == crate::domain::SyncStatus::Missing {
+                    item.style(Style::default().fg(state.theme.del_color))
+                } else {
+                    item
+                }
             })
             .collect()
     };

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -2272,6 +2272,9 @@ fn dispatch_outcome(
                 crate::domain::SyncStatus::Push => spawn_pin_push(state, &mut channels.bg, &m),
                 crate::domain::SyncStatus::Pull => spawn_pin_pull(state, &mut channels.bg, &m),
                 crate::domain::SyncStatus::InSync => state.set_status("already in sync"),
+                crate::domain::SyncStatus::Missing => {
+                    state.set_status("local file is missing — use d to pull it back")
+                }
                 crate::domain::SyncStatus::Unknown => {
                     state.set_status("can't tell which side is newer — use u to push or d to pull")
                 }
@@ -2313,6 +2316,9 @@ fn dispatch_outcome(
                     } else {
                         spawn_pin_push(state, &mut channels.bg, &m);
                     }
+                }
+                crate::domain::SyncStatus::Missing => {
+                    state.set_status("local file is missing — use d to pull it back")
                 }
                 crate::domain::SyncStatus::Unknown => {
                     state.set_status("can't tell which side is newer — use u to push or d to pull")

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -4365,6 +4365,37 @@ fn pin_mtimes_local_falls_back_to_disk_when_not_discovered() {
 }
 
 #[test]
+fn pin_sync_status_is_missing_when_local_file_absent() {
+    // A pinned local path that doesn't exist on disk should report Missing,
+    // not the generic Unknown ambiguity used when a timestamp is merely
+    // unavailable for other reasons.
+    let dir = tempfile::tempdir().unwrap();
+    let gone = dir.path().join("settings.json");
+    // Deliberately never created — this path must not exist.
+
+    let mut state = initial_state();
+    state.locals.clear();
+    state.pinned = vec![crate::domain::PinnedMapping {
+        local_path: gone,
+        gist_id: "g1".into(),
+        gist_filename: "settings.json".into(),
+        direction: None,
+        last_seen_hash: None,
+    }];
+    state.gists = vec![GistFile {
+        updated_at: "2026-01-01T00:00:00Z".into(),
+        ..GistFile::for_sync("g1".into(), "settings.json".into(), None)
+    }];
+
+    assert_eq!(
+        state.pin_sync_status(0),
+        crate::domain::SyncStatus::Missing,
+        "a pin whose local file doesn't exist must report Missing even though \
+         the gist side has a known mtime"
+    );
+}
+
+#[test]
 fn forked_filter_shows_only_forks() {
     let mut state = initial_state();
     state.gists = vec![


### PR DESCRIPTION
## Summary
- The Pins view now marks a pinned entry whose local file no longer exists on disk directly in the list — a distinct `✕` icon, a red row, and a "missing" local-age label — instead of only surfacing the problem as an error after the entry is selected/acted on.
- Adds `SyncStatus::Missing`, derived from the same local-timestamp signal `pin_mtimes` already computes (no new filesystem call).
- `s` (smart auto-sync) on a missing-local pin now hints `use d to pull it back` instead of hitting a compiler-caught-but-unhandled case; `u`/`d` behavior is unchanged (both already handled this case correctly before this PR).

Fixes #198

## Test plan
- [x] `cargo test` — updated `sync_status_from_mtime`/`sync_status_icons`, new `pin_sync_status_is_missing_when_local_file_absent`, full suite green
- [x] `mise run check` — fmt/test/check/clippy all pass