### PR TITLE
feat(tui): use content hash for the Pins in-sync indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] — 2026-07-02
+
 - Editing the upload redact buffer (`e` on the upload confirm) in a GUI editor (`zed`, `code`, `cursor`, `subl`, …) now live-updates the diff as you save, instead of only refreshing after you close the editor; `y`/`e` are disabled until you do. Terminal editors are unchanged.
 - Fixed: a diff line whose old-side text has no trailing newline (and is no longer the file's last line) no longer merges with the line that follows it into one malformed row in the diff view.
 - Fixed: completing or cancelling an upload started from the Pins view now stays on the Pins view instead of returning to the File List view.
 - Pins view: a pinned entry whose local file no longer exists on disk is now flagged in the list (a distinct `✕` icon and a red row) instead of only surfacing as an error after you select or act on it.
+- Pins view: a pinned entry whose content is actually identical on both sides now shows the synced (`✓`) indicator instead of a misleading push/pull arrow, even if the local and gist timestamps differ.
 
 ## [0.14.2] — 2026-06-25
 
@@ -150,7 +153,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Off-thread loading with an on-disk cache.
 - Overwrite-confirm safety gate.
 
-[unreleased]: https://github.com/akunzai/gistui/compare/v0.14.2...HEAD
+[unreleased]: https://github.com/akunzai/gistui/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/akunzai/gistui/releases/tag/v0.15.0
 [0.14.2]: https://github.com/akunzai/gistui/releases/tag/v0.14.2
 [0.14.1]: https://github.com/akunzai/gistui/releases/tag/v0.14.1
 [0.14.0]: https://github.com/akunzai/gistui/releases/tag/v0.14.0

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -517,10 +517,10 @@ pub fn pin_mapping(
     Ok(config)
 }
 
-/// Record the result of a successful sync for the pin identified by
-/// `(local_path, gist_id, gist_filename)`: set `last_seen_hash` to the agreed
-/// content hash and `direction` to the direction performed, then persist.
-/// No-op if the pin is not found.
+/// Records that `local_path`'s content (hashed to `hash`) is now known to match the gist side.
+/// `direction: Some(d)` also records which action produced that state (an actual push/pull);
+/// `None` means the match was passively confirmed (e.g. a diff turned out identical) — the
+/// mapping's existing `direction` is left untouched in that case.
 pub fn record_sync(
     config_path: &Path,
     mut config: AppConfig,
@@ -528,13 +528,15 @@ pub fn record_sync(
     gist_id: &str,
     gist_filename: &str,
     hash: &str,
-    direction: SyncDirection,
+    direction: Option<SyncDirection>,
 ) -> Result<AppConfig> {
     if let Some(mapping) = config.pinned.iter_mut().find(|m| {
         m.local_path == local_path && m.gist_id == gist_id && m.gist_filename == gist_filename
     }) {
         mapping.last_seen_hash = Some(hash.to_string());
-        mapping.direction = Some(direction);
+        if let Some(direction) = direction {
+            mapping.direction = Some(direction);
+        }
         save_config(config_path, &config)?;
     }
     Ok(config)
@@ -992,13 +994,51 @@ mod tests {
             "g1",
             "a.txt",
             "deadbeef",
-            SyncDirection::Upload,
+            Some(SyncDirection::Upload),
         )
         .unwrap();
 
         let m = &updated.pinned[0];
         assert_eq!(m.last_seen_hash.as_deref(), Some("deadbeef"));
         assert_eq!(m.direction, Some(SyncDirection::Upload));
+    }
+
+    #[test]
+    fn record_sync_with_none_direction_updates_hash_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg_path = dir.path().join("config.toml");
+        let mut config = AppConfig::default();
+        config.pinned.push(PinnedMapping {
+            local_path: PathBuf::from("/tmp/a.txt"),
+            gist_id: "g1".into(),
+            gist_filename: "a.txt".into(),
+            direction: Some(SyncDirection::Download),
+            last_seen_hash: Some("stale".into()),
+        });
+
+        let updated = record_sync(
+            &cfg_path,
+            config,
+            Path::new("/tmp/a.txt"),
+            "g1",
+            "a.txt",
+            "freshhash",
+            None,
+        )
+        .unwrap();
+
+        let m = &updated.pinned[0];
+        assert_eq!(
+            m.last_seen_hash.as_deref(),
+            Some("freshhash"),
+            "the hash must still update even when no direction is recorded"
+        );
+        assert_eq!(
+            m.direction,
+            Some(SyncDirection::Download),
+            "a None direction must leave the mapping's prior direction untouched, \
+             not clear it — this call means \"confirmed equal\", not \"synced\""
+        );
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1663,6 +1663,15 @@ pub fn run(no_mouse: bool, no_update_check: bool) -> Result<()> {
 }
 
 impl AppState {
+    /// Resolve a pin's absolute local path against `cwd`.
+    fn pin_local_abs(&self, m: &crate::domain::PinnedMapping) -> PathBuf {
+        if m.local_path.is_absolute() {
+            m.local_path.clone()
+        } else {
+            self.cwd.join(&m.local_path)
+        }
+    }
+
     /// `(local_ts, remote_ts)` Unix-seconds for `pinned[index]`. The remote side comes
     /// from the matching gist's in-memory `updated_at`; the local side prefers the
     /// discovered candidate's mtime and falls back to stat-ing the path on disk.
@@ -1670,11 +1679,7 @@ impl AppState {
         let Some(m) = self.pinned.get(index) else {
             return (None, None);
         };
-        let local_abs = if m.local_path.is_absolute() {
-            m.local_path.clone()
-        } else {
-            self.cwd.join(&m.local_path)
-        };
+        let local_abs = self.pin_local_abs(m);
         let local_ts = self
             .locals
             .iter()
@@ -1698,12 +1703,33 @@ impl AppState {
         (local_ts, remote_ts)
     }
 
-    /// Derive the [`SyncStatus`] for `pinned[index]` from in-memory mtimes.
-    /// Local mtime comes from the matching local candidate (if discovered);
-    /// remote mtime from the matching gist's `updated_at`.
+    /// Derive the [`SyncStatus`] for `pinned[index]` from in-memory mtimes, with a
+    /// content-hash fallback: when the timestamps disagree (`Push`/`Pull`) but the local
+    /// file's current content still hashes to the pin's `last_seen_hash` baseline, report
+    /// `InSync` instead — the timestamp drifted but nothing actually changed. The extra
+    /// file read only happens for this ambiguous, has-a-baseline case, not on every pin.
     pub fn pin_sync_status(&self, index: usize) -> crate::domain::SyncStatus {
         let (local_ts, remote_ts) = self.pin_mtimes(index);
-        crate::domain::sync_status(local_ts, remote_ts)
+        let status = crate::domain::sync_status(local_ts, remote_ts);
+        if !matches!(
+            status,
+            crate::domain::SyncStatus::Push | crate::domain::SyncStatus::Pull
+        ) {
+            return status;
+        }
+        let Some(m) = self.pinned.get(index) else {
+            return status;
+        };
+        let Some(baseline) = m.last_seen_hash.as_deref() else {
+            return status;
+        };
+        let local_abs = self.pin_local_abs(m);
+        match std::fs::read(&local_abs) {
+            Ok(bytes) if crate::domain::sha256_hex(&bytes) == baseline => {
+                crate::domain::SyncStatus::InSync
+            }
+            _ => status,
+        }
     }
 }
 

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -638,7 +638,7 @@ fn record_pin_sync(
     gist_id: &str,
     filename: &str,
     content: &str,
-    direction: crate::domain::SyncDirection,
+    direction: Option<crate::domain::SyncDirection>,
 ) {
     // Find the pin using its STORED (possibly relative) local_path form.
     let stored_local = state.pinned.iter().find_map(|m| {
@@ -993,7 +993,7 @@ fn download(state: &mut AppState) {
                     &gid,
                     &fname,
                     &content,
-                    crate::domain::SyncDirection::Download,
+                    Some(crate::domain::SyncDirection::Download),
                 );
             }
             state.back_to_list();
@@ -1367,6 +1367,30 @@ fn absorb_background_results(
                                     target,
                                 );
                                 state.diff_identical = identical;
+                                // A pin diff that turns out identical confirms the cached
+                                // last_seen_hash is (still) accurate — refresh it for free
+                                // using the content we already fetched, so the Pins list's
+                                // content-hash check (AppState::pin_sync_status) stays
+                                // correct even if the gist changed elsewhere since the last
+                                // real sync. Hash the LOCAL content's raw bytes (not the
+                                // trailing-newline-normalized `identical` comparison), so
+                                // this matches the raw-byte hashing pin_sync_status does.
+                                if identical {
+                                    if let (Some(gid), Some(fname)) = (
+                                        state.download_gist_id.clone(),
+                                        state.download_gist_filename.clone(),
+                                    ) {
+                                        let local_abs = state.preview_local.clone();
+                                        record_pin_sync(
+                                            state,
+                                            &local_abs,
+                                            &gid,
+                                            &fname,
+                                            &local_content,
+                                            None,
+                                        );
+                                    }
+                                }
                             }
                             Err(error) => state.set_status(format!("read failed: {error}")),
                         }
@@ -1420,7 +1444,7 @@ fn absorb_background_results(
                                         &gist_id,
                                         &filename,
                                         &remote,
-                                        crate::domain::SyncDirection::Download,
+                                        Some(crate::domain::SyncDirection::Download),
                                     );
                                     refresh_locals(state);
                                 }
@@ -1485,7 +1509,7 @@ fn absorb_background_results(
                                 &gist_id,
                                 &filename,
                                 &content,
-                                crate::domain::SyncDirection::Upload,
+                                Some(crate::domain::SyncDirection::Upload),
                             );
                         }
                         // Return to wherever this upload was initiated from (List, or Pins
@@ -2298,25 +2322,10 @@ fn dispatch_outcome(
             match state.pin_sync_status(pin_idx) {
                 crate::domain::SyncStatus::InSync => state.set_status("already in sync"),
                 crate::domain::SyncStatus::Pull => spawn_pin_pull(state, &mut channels.bg, &m),
-                crate::domain::SyncStatus::Push => {
-                    // Cheap, network-free no-op check: if the local file still
-                    // hashes to last_seen_hash, the newer mtime is a touch with
-                    // no content change. Note: only fires for plain pushes — a
-                    // push whose baseline was a JSON-transformed/redacted upload
-                    // won't match the raw file, so it harmlessly falls through to
-                    // a full push.
-                    let local_abs = pin_local_abs(state, &m);
-                    let unchanged = m.last_seen_hash.as_deref().is_some_and(|baseline| {
-                        std::fs::read(&local_abs)
-                            .map(|b| crate::domain::sha256_hex(&b) == baseline)
-                            .unwrap_or(false)
-                    });
-                    if unchanged {
-                        state.set_status("already in sync");
-                    } else {
-                        spawn_pin_push(state, &mut channels.bg, &m);
-                    }
-                }
+                // The content-hash no-op check now happens upstream in
+                // AppState::pin_sync_status (a matching hash is already reclassified to
+                // InSync above), so a genuine Push here always means a real change.
+                crate::domain::SyncStatus::Push => spawn_pin_push(state, &mut channels.bg, &m),
                 crate::domain::SyncStatus::Missing => {
                     state.set_status("local file is missing — use d to pull it back")
                 }

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -4396,6 +4396,94 @@ fn pin_sync_status_is_missing_when_local_file_absent() {
 }
 
 #[test]
+fn pin_sync_status_upgrades_to_in_sync_when_content_hash_matches_baseline() {
+    // Timestamps disagree (forcing Push), but the content hash still matches what was
+    // last recorded as synced — the Pins list should show synced (✓), not a misleading
+    // push arrow, since nothing has actually changed content-wise.
+    let dir = tempfile::tempdir().unwrap();
+    let local = dir.path().join("settings.json");
+    let content = b"{\"key\":\"value\"}";
+    std::fs::write(&local, content).unwrap();
+    let hash = crate::domain::sha256_hex(content);
+
+    let mut state = initial_state();
+    state.locals.clear();
+    state.pinned = vec![crate::domain::PinnedMapping {
+        local_path: local,
+        gist_id: "g1".into(),
+        gist_filename: "settings.json".into(),
+        direction: None,
+        last_seen_hash: Some(hash),
+    }];
+    state.gists = vec![GistFile {
+        // Far in the past, so the just-written local file (mtime ~ now) reads as newer —
+        // sync_status(Some(local_ts), Some(remote_ts)) would normally resolve to Push.
+        updated_at: "2020-01-01T00:00:00Z".into(),
+        ..GistFile::for_sync("g1".into(), "settings.json".into(), None)
+    }];
+
+    assert_eq!(
+        state.pin_sync_status(0),
+        crate::domain::SyncStatus::InSync,
+        "a matching content hash must override a stale-timestamp Push into InSync"
+    );
+}
+
+#[test]
+fn pin_sync_status_keeps_push_when_content_hash_does_not_match_baseline() {
+    // Same timestamp setup as above, but the recorded baseline hash doesn't match the
+    // file's actual current content — a real, unrecorded local change. Must stay Push.
+    let dir = tempfile::tempdir().unwrap();
+    let local = dir.path().join("settings.json");
+    std::fs::write(&local, b"{\"key\":\"value\"}").unwrap();
+
+    let mut state = initial_state();
+    state.locals.clear();
+    state.pinned = vec![crate::domain::PinnedMapping {
+        local_path: local,
+        gist_id: "g1".into(),
+        gist_filename: "settings.json".into(),
+        direction: None,
+        last_seen_hash: Some("does-not-match-anything".into()),
+    }];
+    state.gists = vec![GistFile {
+        updated_at: "2020-01-01T00:00:00Z".into(),
+        ..GistFile::for_sync("g1".into(), "settings.json".into(), None)
+    }];
+
+    assert_eq!(
+        state.pin_sync_status(0),
+        crate::domain::SyncStatus::Push,
+        "a non-matching baseline hash must not mask a real content change"
+    );
+}
+
+#[test]
+fn pin_sync_status_keeps_push_when_no_baseline_hash_recorded() {
+    // Regression guard: a pin that was never synced (no baseline hash at all) must fall
+    // back to the plain timestamp-based status, not attempt a hash comparison.
+    let dir = tempfile::tempdir().unwrap();
+    let local = dir.path().join("settings.json");
+    std::fs::write(&local, b"{\"key\":\"value\"}").unwrap();
+
+    let mut state = initial_state();
+    state.locals.clear();
+    state.pinned = vec![crate::domain::PinnedMapping {
+        local_path: local,
+        gist_id: "g1".into(),
+        gist_filename: "settings.json".into(),
+        direction: None,
+        last_seen_hash: None,
+    }];
+    state.gists = vec![GistFile {
+        updated_at: "2020-01-01T00:00:00Z".into(),
+        ..GistFile::for_sync("g1".into(), "settings.json".into(), None)
+    }];
+
+    assert_eq!(state.pin_sync_status(0), crate::domain::SyncStatus::Push);
+}
+
+#[test]
 fn forked_filter_shows_only_forks() {
     let mut state = initial_state();
     state.gists = vec![


### PR DESCRIPTION
## Summary
- The Pins view now shows the synced (`✓`) indicator for an entry whose content is actually identical on both sides, instead of a misleading push/pull arrow caused by differing timestamps — checked via the existing `last_seen_hash` cache, with no new network calls.
- The cache self-heals for free: opening a pin's read-only diff (which already fetches real gist content) updates `last_seen_hash` whenever it discovers the two sides match, even if the gist changed elsewhere since the last real sync.
- Removes a now-redundant duplicate of this same hash check that previously lived only inside the `s` (smart auto-sync) key handler.
- Stamps the `CHANGELOG.md` `## [0.15.0] — 2026-07-02` release heading — this is the last planned PR for the `v0.15.0` milestone.

Fixes #202

## Test plan
- [x] `cargo test` — new `record_sync`/`pin_sync_status` coverage, full suite green
- [x] `mise run check` — fmt/test/check/clippy all pass