### PR TITLE
ci: push Homebrew formula and Scoop manifest updates on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,3 +117,15 @@ jobs:
         with:
           files: artifacts/*
           generate_release_notes: true
+
+      - name: Update Scoop manifest
+        env:
+          HOMEBREW_BUMP_TOKEN: ${{ secrets.HOMEBREW_BUMP_TOKEN }}
+          VERSION: ${{ github.ref_name }}
+        run: scripts/release/update-scoop-manifest.sh
+
+      - name: Update Homebrew formula
+        env:
+          HOMEBREW_BUMP_TOKEN: ${{ secrets.HOMEBREW_BUMP_TOKEN }}
+          VERSION: ${{ github.ref_name }}
+        run: scripts/release/update-homebrew-formula.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,14 +118,14 @@ jobs:
           files: artifacts/*
           generate_release_notes: true
 
-      - name: Update Scoop manifest
-        env:
-          HOMEBREW_BUMP_TOKEN: ${{ secrets.HOMEBREW_BUMP_TOKEN }}
-          VERSION: ${{ github.ref_name }}
-        run: scripts/release/update-scoop-manifest.sh
-
       - name: Update Homebrew formula
         env:
           HOMEBREW_BUMP_TOKEN: ${{ secrets.HOMEBREW_BUMP_TOKEN }}
           VERSION: ${{ github.ref_name }}
         run: scripts/release/update-homebrew-formula.sh
+
+      - name: Update Scoop manifest
+        env:
+          HOMEBREW_BUMP_TOKEN: ${{ secrets.HOMEBREW_BUMP_TOKEN }}
+          VERSION: ${{ github.ref_name }}
+        run: scripts/release/update-scoop-manifest.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- The Homebrew formula (`akunzai/tap/gistui`) now installs a prebuilt binary instead of compiling from source, cutting install time from 1-2 minutes to a few seconds; `brew install --HEAD` still builds from source.
+
 ## [0.15.0] — 2026-07-02
 
 - Editing the upload redact buffer (`e` on the upload confirm) in a GUI editor (`zed`, `code`, `cursor`, `subl`, …) now live-updates the diff as you save, instead of only refreshing after you close the editor; `y`/`e` are disabled until you do. Terminal editors are unchanged.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "gistui"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gistui"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 license = "MIT"
 description = "A terminal UI for managing GitHub Gists"

--- a/scripts/release/update-homebrew-formula.sh
+++ b/scripts/release/update-homebrew-formula.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${HOMEBREW_BUMP_TOKEN:-}" ]; then
+  echo "HOMEBREW_BUMP_TOKEN is not set; skipping Homebrew formula update."
+  exit 0
+fi
+
+VERSION="${VERSION:?VERSION must be set (e.g. v0.15.1)}"
+
+git clone "https://x-access-token:${HOMEBREW_BUMP_TOKEN}@github.com/akunzai/homebrew-tap.git" homebrew-tap
+
+SHA_MAC_INTEL=$(awk '{print $1}' "artifacts/gistui-${VERSION}-x86_64-apple-darwin.tar.gz.sha256")
+SHA_MAC_ARM=$(awk '{print $1}' "artifacts/gistui-${VERSION}-aarch64-apple-darwin.tar.gz.sha256")
+SHA_LINUX_INTEL=$(awk '{print $1}' "artifacts/gistui-${VERSION}-x86_64-unknown-linux-gnu.tar.gz.sha256")
+SHA_LINUX_ARM=$(awk '{print $1}' "artifacts/gistui-${VERSION}-aarch64-unknown-linux-gnu.tar.gz.sha256")
+
+cat <<EOF > homebrew-tap/Formula/gistui.rb
+class Gistui < Formula
+  desc "Terminal UI for managing GitHub Gists"
+  homepage "https://akunzai.github.io/gistui/"
+  license "MIT"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
+  head do
+    url "https://github.com/akunzai/gistui.git", branch: "main"
+    depends_on "rust" => :build
+  end
+
+  depends_on "gh" # gistui shells out to the GitHub CLI at runtime
+
+  on_macos do
+    if Hardware::CPU.intel?
+      url "https://github.com/akunzai/gistui/releases/download/${VERSION}/gistui-${VERSION}-x86_64-apple-darwin.tar.gz"
+      sha256 "${SHA_MAC_INTEL}"
+    end
+    if Hardware::CPU.arm?
+      url "https://github.com/akunzai/gistui/releases/download/${VERSION}/gistui-${VERSION}-aarch64-apple-darwin.tar.gz"
+      sha256 "${SHA_MAC_ARM}"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.intel?
+      url "https://github.com/akunzai/gistui/releases/download/${VERSION}/gistui-${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "${SHA_LINUX_INTEL}"
+    end
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "https://github.com/akunzai/gistui/releases/download/${VERSION}/gistui-${VERSION}-aarch64-unknown-linux-gnu.tar.gz"
+      sha256 "${SHA_LINUX_ARM}"
+    end
+  end
+
+  def install
+    if build.head?
+      system "cargo", "install", *std_cargo_args
+    else
+      bin.install "gistui"
+    end
+  end
+
+  test do
+    assert_match "gistui", shell_output("#{bin}/gistui --help")
+  end
+end
+EOF
+
+cd homebrew-tap
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+git add Formula/gistui.rb
+git commit -m "chore: bump gistui to ${VERSION}" || exit 0
+git push origin main

--- a/scripts/release/update-scoop-manifest.sh
+++ b/scripts/release/update-scoop-manifest.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "${HOMEBREW_BUMP_TOKEN:-}" ]; then
+  echo "HOMEBREW_BUMP_TOKEN is not set; skipping Scoop manifest update."
+  exit 0
+fi
+
+VERSION="${VERSION:?VERSION must be set (e.g. v0.15.1)}"
+
+git clone "https://x-access-token:${HOMEBREW_BUMP_TOKEN}@github.com/akunzai/scoop-bucket.git" scoop-bucket
+
+SHA_WIN=$(awk '{print $1}' "artifacts/gistui-${VERSION}-x86_64-pc-windows-msvc.zip.sha256")
+
+jq --indent 4 --arg version "${VERSION#v}" \
+   --arg url "https://github.com/akunzai/gistui/releases/download/${VERSION}/gistui-${VERSION}-x86_64-pc-windows-msvc.zip" \
+   --arg hash "$SHA_WIN" \
+   --arg extract_dir "gistui-${VERSION}-x86_64-pc-windows-msvc" \
+   '.version = $version | .architecture["64bit"].url = $url | .architecture["64bit"].hash = $hash | .architecture["64bit"].extract_dir = $extract_dir' \
+   scoop-bucket/bucket/gistui.json > /tmp/gistui.json.tmp
+mv /tmp/gistui.json.tmp scoop-bucket/bucket/gistui.json
+
+cd scoop-bucket
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+git add bucket/gistui.json
+git commit -m "chore: bump gistui to ${VERSION}" || exit 0
+git push origin main


### PR DESCRIPTION
## Summary
- On every tagged release, the `release` job now pushes an updated Homebrew formula and Scoop manifest directly to `homebrew-tap` and `scoop-bucket` (`git push origin main`, no PR — companion tap change: akunzai/homebrew-tap#13), instead of relying on those repos' own daily polling.
- Logic lives in two new standalone scripts (`scripts/release/update-homebrew-formula.sh`, `scripts/release/update-scoop-manifest.sh`) rather than inline in the workflow YAML — an inline heredoc-in-YAML approach was tried in a sibling project and silently broke CI (YAML block-scalar parsing ends at the first under-indented heredoc line); standalone scripts avoid the whole class of bug and are independently `shellcheck`-able.
- Bumped `Cargo.toml` to `0.15.1` and added a `CHANGELOG.md` entry for the faster Homebrew install.

Closes akunzai/gistui#205.

## Test plan
- [x] `actionlint .github/workflows/release.yml` — clean
- [x] `shellcheck scripts/release/*.sh` — clean
- [x] Dry-run of `update-homebrew-formula.sh`'s heredoc against real v0.15.0 checksums — byte-for-byte identical to the already-published `homebrew-tap` formula (akunzai/homebrew-tap#13)
- [x] Dry-run of `update-scoop-manifest.sh`'s `jq` patch against the real, current `scoop-bucket/bucket/gistui.json` — zero diff (no-op at today's version), preserves `depends`/`checkver`/`autoupdate`
- [x] `mise run check` (fmt/clippy/test/check) — all green
- [ ] End-to-end: only provable by the next real `vX.Y.Z` tag actually pushing to both downstream repos — not exercised by this PR's CI (the workflow only triggers on tag push)

Note: this PR alone doesn't speed up installs — akunzai/homebrew-tap#13 (already switching the formula to prebuilt binaries) needs to land too; this PR is what keeps that formula updated on future releases.