### PR TITLE
chore(release): 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.1] — 2026-07-08
+
 - The Homebrew formula (`akunzai/tap/gistui`) now installs a prebuilt binary instead of compiling from source, cutting install time from 1-2 minutes to a few seconds; `brew install --HEAD` still builds from source.
 
 ## [0.15.0] — 2026-07-02
@@ -155,7 +157,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Off-thread loading with an on-disk cache.
 - Overwrite-confirm safety gate.
 
-[unreleased]: https://github.com/akunzai/gistui/compare/v0.15.0...HEAD
+[unreleased]: https://github.com/akunzai/gistui/compare/v0.15.1...HEAD
+[0.15.1]: https://github.com/akunzai/gistui/releases/tag/v0.15.1
 [0.15.0]: https://github.com/akunzai/gistui/releases/tag/v0.15.0
 [0.14.2]: https://github.com/akunzai/gistui/releases/tag/v0.14.2
 [0.14.1]: https://github.com/akunzai/gistui/releases/tag/v0.14.1

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,11 +13,17 @@ triggers the full pipeline:
   [crates.io](https://crates.io/crates/gistui).
 
 The crate is published and the `CARGO_REGISTRY_TOKEN` secret is configured, so the publish
-step runs automatically on tag. The downstream package definitions update themselves on a
-schedule — no manual bump on release:
+step runs automatically on tag. `release.yml` also pushes the downstream package definitions
+directly — no manual bump, no waiting on a schedule:
 
-- [Homebrew tap](https://github.com/akunzai/homebrew-tap) — `brew livecheck` scheduled bump.
-- [Scoop bucket](https://github.com/akunzai/scoop-bucket) — `checkver` + `autoupdate` Excavator.
+- [Homebrew tap](https://github.com/akunzai/homebrew-tap) — `Formula/gistui.rb` regenerated
+  from the new release's per-platform checksums and pushed straight to `main`.
+- [Scoop bucket](https://github.com/akunzai/scoop-bucket) — `bucket/gistui.json` patched with
+  the new version/URL/hash and pushed straight to `main`.
+
+Both pushes require the `HOMEBREW_BUMP_TOKEN` repository secret (a PAT scoped to those two
+repos); if it's unset, the corresponding step skips itself and logs a message instead of
+failing the release.
 
 Packaging stays lean via `Cargo.toml` `exclude` (the demo harness, site assets and CI config
 are kept out of the published tarball); `cargo publish --dry-run` validates the tarball.
@@ -31,5 +37,7 @@ are kept out of the published tarball); `cargo publish --dry-run` validates the 
 3. Merge to `main` (CI gate green).
 4. Tag and push: `git tag vX.Y.Z && git push origin vX.Y.Z`.
 5. Verify: the GitHub release has the binaries, [crates.io](https://crates.io/crates/gistui)
-   shows the new version (and docs.rs built), and the Homebrew tap / Scoop bucket pick it up
-   on their next scheduled run.
+   shows the new version (and docs.rs built), and `Formula/gistui.rb` / `bucket/gistui.json`
+   show a new `chore: bump gistui to vX.Y.Z` commit on the tap's / bucket's `main` (pushed by
+   `release.yml` within the same run — if either is missing, check that run's "Update Homebrew
+   formula" / "Update Scoop manifest" step and confirm `HOMEBREW_BUMP_TOKEN` is still valid).


### PR DESCRIPTION
## Summary
- Rename `## [Unreleased]` to `## [0.15.1] — 2026-07-08` in CHANGELOG.md and add its release link.
- Fix `RELEASING.md`, which still described the pre-#206 scheduled-bump mechanism (`brew livecheck`, Scoop Excavator) for the Homebrew tap/Scoop bucket — now documents the push-on-release steps added in #206.

## Test plan
- [x] `cargo publish --dry-run` — clean
- [ ] Tag `v0.15.1` after merge to exercise the full release pipeline, including the new push-on-release automation, for the first time