### PR TITLE
feat: cross-screen top bar + minimal footer (TUI UX redesign Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Click the repository URL in the footer to open the GitHub repository in the system's default browser.
-- Every screen now shows a `(G)ists (P)ins (?)Help` shortcut bar in the top-right corner (click, or use the existing `g`/`P`/`?` keys, from any screen); the footer's long per-screen hotkey list is gone — it now stays empty when idle, since Help discoverability lives in the top bar (press `?` for the full keymap).
+- Every screen now shows a `(G)ists (P)ins (?)Help` shortcut bar in the top-right corner (click, or use the existing `g`/`P`/`?` keys, from any screen); the footer's long per-screen hotkey list is gone — it now drops its idle hint (just the repository URL remains), since Help discoverability lives in the top bar (press `?` for the full keymap).
 
 ## [0.15.2] — 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Click the repository URL in the footer to open the GitHub repository in the system's default browser.
-- Every screen now shows a `(G)ists (P)ins (?)Help` shortcut bar in the top-right corner (click, or use the existing `g`/`P`/`?` keys, from any screen); the footer's long per-screen hotkey list has been replaced with a single minimal `? Help` prompt (press `?` for the full keymap).
+- Every screen now shows a `(G)ists (P)ins (?)Help` shortcut bar in the top-right corner (click, or use the existing `g`/`P`/`?` keys, from any screen); the footer's long per-screen hotkey list is gone — it now stays empty when idle, since Help discoverability lives in the top bar (press `?` for the full keymap).
 
 ## [0.15.2] — 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Click the repository URL in the footer to open the GitHub repository in the system's default browser.
+- Every screen now shows a `(G)ists (P)ins (?)Help` shortcut bar in the top-right corner (click, or use the existing `g`/`P`/`?` keys, from any screen); the footer's long per-screen hotkey list has been replaced with a single minimal `? Help` prompt (press `?` for the full keymap).
 
 ## [0.15.2] — 2026-07-08
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "gistui"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gistui"
-version = "0.15.2"
+version = "0.16.0"
 edition = "2021"
 license = "MIT"
 description = "A terminal UI for managing GitHub Gists"

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ without resetting order. Pinned pairs show `📌`; same-filename candidates are 
 
 Press **`?`** anytime for the **full, contextual keymap** — it opens the current screen's
 topic; `Tab` browses all topics (List, Pins, Gist manager, Gist detail, Diff, Preview, …).
-The footer stays minimal (`? Help`); every screen also shows a `(G)ists (P)ins (?)Help`
-shortcut bar in the top-right corner (click, or use the underlying key).
+The footer stays empty when idle; every screen shows a `(G)ists (P)ins (?)Help`
+shortcut bar in the top-right corner instead (click, or use the underlying key).
 
 **Mouse** (on by default; disable with `mouse = false` in config or `--no-mouse`):
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ without resetting order. Pinned pairs show `📌`; same-filename candidates are 
 
 Press **`?`** anytime for the **full, contextual keymap** — it opens the current screen's
 topic; `Tab` browses all topics (List, Pins, Gist manager, Gist detail, Diff, Preview, …).
-The footer stays empty when idle; every screen shows a `(G)ists (P)ins (?)Help`
-shortcut bar in the top-right corner instead (click, or use the underlying key).
+The footer drops its idle hotkey hint (just the repository URL remains); every screen
+shows a `(G)ists (P)ins (?)Help` shortcut bar in the top-right corner instead (click,
+or use the underlying key).
 
 **Mouse** (on by default; disable with `mouse = false` in config or `--no-mouse`):
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ without resetting order. Pinned pairs show `📌`; same-filename candidates are 
 
 Press **`?`** anytime for the **full, contextual keymap** — it opens the current screen's
 topic; `Tab` browses all topics (List, Pins, Gist manager, Gist detail, Diff, Preview, …).
-The footer also shows keys for the focused pane.
+The footer stays minimal (`? Help`); every screen also shows a `(G)ists (P)ins (?)Help`
+shortcut bar in the top-right corner (click, or use the underlying key).
 
 **Mouse** (on by default; disable with `mouse = false` in config or `--no-mouse`):
 
@@ -87,6 +88,7 @@ The footer also shows keys for the focused pane.
 | Double-click a row | open it — List diff, gist detail, pin diff, revision diff, or file preview (same as `Enter`) |
 | Click a tab (Gist details) | switch between Files / Comments (newest 30 comments load first; `m` or clicking the top line loads 30 older comments) |
 | Click `[✕]` button (pop-up screens) | close / go back |
+| Click `(G)ists` / `(P)ins` / `(?)Help` (top bar) | jump to that screen, from anywhere — same as pressing `g` / `P` / `?` |
 | Click the repository URL | open the GitHub repository in the system's default browser |
 
 ## Safety

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -84,7 +84,13 @@ impl AppState {
     }
 
     /// Open the Help screen on the topic for the current screen, remembering where to return.
+    /// A no-op while already on Help — otherwise the top bar's `(?)Help` click (reachable from
+    /// any screen, including Help itself) would overwrite `return_screen` with `Screen::Help`,
+    /// trapping Esc/`?`/the close button in Help with no keyboard way out.
     fn open_help(&mut self) {
+        if self.screen == Screen::Help {
+            return;
+        }
         self.help.return_screen = self.screen;
         self.help.topic = HelpTopic::for_screen(self.screen);
         self.help.index_open = false;

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -893,6 +893,26 @@ impl AppState {
                         return KeyOutcome::OpenRepoUrl;
                     }
                 }
+                // Top-bar (G)ists / (P)ins / (?)Help — same effect as pressing the key,
+                // from any screen (not just wherever that key happens to be bound).
+                if let Some(rect) = layout.top_bar_gists {
+                    if point_in(rect, col, row) {
+                        self.open_gist_manager();
+                        return KeyOutcome::None;
+                    }
+                }
+                if let Some(rect) = layout.top_bar_pins {
+                    if point_in(rect, col, row) {
+                        self.open_pins();
+                        return KeyOutcome::None;
+                    }
+                }
+                if let Some(rect) = layout.top_bar_help {
+                    if point_in(rect, col, row) {
+                        self.open_help();
+                        return KeyOutcome::None;
+                    }
+                }
                 // A GistDetail tab header click switches focus (single-click action).
                 if let Some(outcome) = self.click_detail_tab(col, row, layout) {
                     return outcome;
@@ -1072,11 +1092,7 @@ impl AppState {
             KeyCode::Char('/') => self.filtering = true,
             KeyCode::Char('y') => return KeyOutcome::CopyGistUrl,
             KeyCode::Char('?') => self.open_help(),
-            KeyCode::Char('P') => {
-                self.pins.index = 0;
-                self.pins.hscroll = 0;
-                self.screen = Screen::Pins;
-            }
+            KeyCode::Char('P') => self.open_pins(),
             KeyCode::Char('S') => return KeyOutcome::SyncSelectedPair,
             KeyCode::Char('g') => self.open_gist_manager(),
             KeyCode::Char('H') if self.gist_index < self.ranked_gists().len() => {
@@ -1270,6 +1286,14 @@ impl AppState {
             .and_then(|id| groups.iter().position(|g| g.id == id))
             .unwrap_or(0);
         self.screen = Screen::Gists;
+    }
+
+    /// Open the Pins view (`Screen::Pins`), resetting its selection/scroll so a stale
+    /// filtered-in position from a previous visit never lingers.
+    fn open_pins(&mut self) {
+        self.pins.index = 0;
+        self.pins.hscroll = 0;
+        self.screen = Screen::Pins;
     }
 
     /// Pin/unpin the selected local↔gist pair: returns [`KeyOutcome::Unpin`] when the exact

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -412,6 +412,11 @@ pub struct MouseLayout {
     /// to honour a one-shot scroll-to-bottom after the newest page loads).
     pub comments_max_scroll: Option<u16>,
     pub repo_link: Option<Rect>,
+    /// Cross-screen top-bar shortcut hit-rects — `(G)ists`, `(P)ins`, `(?)Help`. Set by
+    /// `render_top_bar` on every screen except the transient `Confirm` y/n modal.
+    pub top_bar_gists: Option<Rect>,
+    pub top_bar_pins: Option<Rect>,
+    pub top_bar_help: Option<Rect>,
 }
 
 /// A classified mouse intent handed to the pure `handle_mouse`.

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -50,6 +50,74 @@ fn render_close_button(frame: &mut Frame, outer: Rect, theme: &Theme) -> Rect {
     rect
 }
 
+/// The three cross-screen top-bar shortcuts: bracketed hotkey letter + label. Kept in one
+/// place so the click hit-rect math and the rendered text can never drift apart.
+const TOP_BAR_ITEMS: [(&str, &str); 3] = [("G", "ists"), ("P", "ins"), ("?", "Help")];
+
+/// Height of the persistent top bar rendered on every screen except the transient `Confirm`
+/// y/n modal (which keeps its full-bleed diff/gist-info background — see `render_confirm`).
+const TOP_BAR_HEIGHT: u16 = 1;
+
+/// Renders the cross-screen top bar — ` gistui` on the left, `(G)ists (P)ins (?)Help`
+/// right-aligned — into the top row of `area`, then returns the remaining rect below it for
+/// the caller's existing content/footer layout (otherwise unchanged). The icons render as
+/// plain text even with the mouse disabled, so the shortcuts stay visible; their hit-rects are
+/// only recorded in `layout` when `mouse_enabled`, matching every other clickable region.
+pub(super) fn render_top_bar(
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    mouse_enabled: bool,
+    layout: &mut MouseLayout,
+) -> Rect {
+    if area.height == 0 {
+        return area;
+    }
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(TOP_BAR_HEIGHT), Constraint::Min(0)])
+        .split(area);
+    let bar = chunks[0];
+
+    frame.render_widget(Paragraph::new(" gistui").style(theme.base_style()), bar);
+
+    let key_style = Style::default()
+        .fg(theme.accent)
+        .add_modifier(Modifier::BOLD);
+    let label_style = Style::default().fg(theme.fg);
+    let widths: Vec<u16> = TOP_BAR_ITEMS
+        .into_iter()
+        .map(|(k, rest)| (k.chars().count() + rest.chars().count() + 2) as u16) // "(" + key + ")" + rest
+        .collect();
+    const GAP: u16 = 2;
+    let total: u16 = widths.iter().sum::<u16>() + GAP * (TOP_BAR_ITEMS.len() as u16 - 1);
+    let mut x = bar.right().saturating_sub(total + 1); // 1-column right margin
+
+    for (i, (key, rest)) in TOP_BAR_ITEMS.into_iter().enumerate() {
+        let w = widths[i].min(bar.right().saturating_sub(x));
+        let rect = Rect::new(x, bar.y, w, 1);
+        let spans = vec![
+            Span::styled("(", label_style),
+            Span::styled(key.to_string(), key_style),
+            Span::styled(format!("){rest}"), label_style),
+        ];
+        frame.render_widget(
+            Paragraph::new(Line::from(spans)).style(theme.base_style()),
+            rect,
+        );
+        if mouse_enabled {
+            match i {
+                0 => layout.top_bar_gists = Some(rect),
+                1 => layout.top_bar_pins = Some(rect),
+                _ => layout.top_bar_help = Some(rect),
+            }
+        }
+        x += widths[i] + GAP;
+    }
+
+    chunks[1]
+}
+
 /// A count suffix for a list title: `(N)` normally, or `(shown/total)` when a filter has
 /// narrowed the list (`shown < total`). Extends the existing `Files (N)` / `Comments (N)`
 /// convention to the other panes consistently.
@@ -226,6 +294,8 @@ Mouse (on by default; disable with mouse = false in config or --no-mouse)
 }
 
 pub(super) fn render_help(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout) {
+    let area = frame.area();
+    let area = render_top_bar(frame, area, &state.theme, state.mouse_enabled, layout);
     if state.help.index_open {
         let items: Vec<ListItem> = HelpTopic::all()
             .iter()
@@ -251,7 +321,7 @@ pub(super) fn render_help(frame: &mut Frame, state: &AppState, layout: &mut Mous
             .highlight_symbol("▶ ");
         let mut list_state = ListState::default();
         list_state.select(Some(state.help.index_sel));
-        frame.render_stateful_widget(list, frame.area(), &mut list_state);
+        frame.render_stateful_widget(list, area, &mut list_state);
     } else {
         let title = format!(
             "Help · {} — Tab topics · ↑↓ scroll · Esc back",
@@ -269,11 +339,11 @@ pub(super) fn render_help(frame: &mut Frame, state: &AppState, layout: &mut Mous
                         .style(state.theme.base_style())
                         .padding(Padding::horizontal(1)),
                 ),
-            frame.area(),
+            area,
         );
     }
     if state.mouse_enabled {
-        layout.close_button = Some(render_close_button(frame, frame.area(), &state.theme));
+        layout.close_button = Some(render_close_button(frame, area, &state.theme));
     }
 }
 
@@ -315,6 +385,7 @@ fn preview_line_spans(state: &AppState) -> Vec<Vec<Span<'static>>> {
 
 pub(super) fn render_preview(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout) {
     let area = frame.area();
+    let area = render_top_bar(frame, area, &state.theme, state.mouse_enabled, layout);
     // A `R`-refresh fetch error (set via state.status) must surface here, not be swallowed.
     let hints = if state.preview_wrap {
         "↑↓ PgUp/Dn scroll  ·  w wrap [on]  ·  y/Y copy url/content  ·  R refresh  ·  Esc/q back"
@@ -372,6 +443,7 @@ pub(super) fn render_preview(frame: &mut Frame, state: &AppState, layout: &mut M
 
 pub(super) fn render_pins(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout) {
     let area = frame.area();
+    let area = render_top_bar(frame, area, &state.theme, state.mouse_enabled, layout);
     // Sync feedback (e.g. "already in sync", "can't tell which side is newer") is set via
     // state.status while staying on this screen, so the footer must surface it (see #72).
     let (ftitle, footer, colored) = if state.pins.filtering {
@@ -584,6 +656,7 @@ pub(super) fn gist_group_row_label(
 
 pub(super) fn render_gists(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout) {
     let area = frame.area();
+    let area = render_top_bar(frame, area, &state.theme, state.mouse_enabled, layout);
     // Footer: filter input while filtering, else a one-shot status message (e.g. the compaction
     // result) when present, else the command hints. Only the hints get key colouring.
     let (ftitle, footer, colored) = if state.gist_manager.filtering {
@@ -778,6 +851,7 @@ pub(super) fn revision_row_label(
 
 pub(super) fn render_revisions(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout) {
     let area = frame.area();
+    let area = render_top_bar(frame, area, &state.theme, state.mouse_enabled, layout);
     let (ftitle, footer, colored) = if let Some(message) = &state.status {
         (String::new(), message.clone(), false)
     } else if state.revision.entries.is_none() {
@@ -1246,6 +1320,7 @@ pub(super) fn detail_focus_tabs_line(focus: DetailFocus, theme: &Theme) -> Line<
 
 pub(super) fn render_gist_detail(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout) {
     let area = frame.area();
+    let area = render_top_bar(frame, area, &state.theme, state.mouse_enabled, layout);
     let (footer, colored) = footer_with_status(state.status.as_deref(), MINIMAL_HINT);
     let footer_lines = wrap_line_count(&footer, area.width.saturating_sub(2)).max(1);
     // Fixed 4-row header (borders + basic-info line + focus tabs); the active tab — the file
@@ -1587,6 +1662,7 @@ pub(super) fn input_line(prefix: &str, input: &TextInput, suffix: &str) -> Line<
 
 pub(super) fn render_list(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout) {
     let area = frame.area();
+    let area = render_top_bar(frame, area, &state.theme, state.mouse_enabled, layout);
     let footer_body = if state.filtering {
         let (pane, query) = match state.focus {
             FocusPane::Local => ("local", &state.local_filter_query),
@@ -2316,6 +2392,7 @@ pub(super) fn render_diff(frame: &mut Frame, state: &AppState, layout: &mut Mous
     let footer = diff_footer(state);
 
     let area = frame.area();
+    let area = render_top_bar(frame, area, &state.theme, state.mouse_enabled, layout);
     let footer_lines = wrap_line_count(&footer, area.width.saturating_sub(2)).max(1);
     let chunks = Layout::default()
         .direction(Direction::Vertical)

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -861,7 +861,7 @@ pub(super) fn render_revisions(frame: &mut Frame, state: &AppState, layout: &mut
         (String::new(), err.clone(), false)
     } else {
         let file = state.revision_target_file_label();
-        (String::new(), format!("file={file} · {MINIMAL_HINT}"), true)
+        (String::new(), format!("file={file}"), false)
     };
     let footer_lines = wrap_line_count(&footer, area.width.saturating_sub(2)).max(1);
     let chunks = Layout::default()
@@ -1269,10 +1269,11 @@ pub(super) fn render_gist_comments(
     render_text_scrollbar(frame, area, total_lines, state.detail.scroll as usize);
 }
 
-/// The default (idle) footer hint everywhere the footer used to print a long per-screen
-/// hotkey list. Discoverability now lives in the `?` Help topic (and, from Phase 3/4 of the
-/// TUI UX redesign, the right-click context menu and Ctrl+P command palette).
-pub(super) const MINIMAL_HINT: &str = "? Help";
+/// The default (idle) footer hint. Empty in Phase 1: the `(?)Help` shortcut in the
+/// top bar (see `render_top_bar`) already covers Help discoverability, so repeating it
+/// here would be a duplicate. Phase 3/4 of the TUI UX redesign will populate this with
+/// `; Menu` and `Ctrl+p Palette` once those features exist.
+pub(super) const MINIMAL_HINT: &str = "";
 
 /// Footer text + whether to colourise it: a one-shot `state.status` message (shown plain) when
 /// present, else the colourised key `hints`. Shared by every screen so action results/errors

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -180,7 +180,8 @@ Mouse (on by default; disable with mouse = false in config or --no-mouse)
   Dbl-click  open the clicked row (diff / detail / pin diff / preview)
   Tab click  switch Files / Comments on the Gist details screen
   [✕] btn    close / go back on any pop-up screen
-  Repo click open the GitHub repository in the browser"
+  Repo click open the GitHub repository in the browser
+  Top bar    click (G)ists / (P)ins / (?)Help (top-right, every screen) to jump there"
         }
         HelpTopic::Pins => {
             "\

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -374,11 +374,6 @@ pub(super) fn render_pins(frame: &mut Frame, state: &AppState, layout: &mut Mous
     let area = frame.area();
     // Sync feedback (e.g. "already in sync", "can't tell which side is newer") is set via
     // state.status while staying on this screen, so the footer must surface it (see #72).
-    let hints = if state.pinned.is_empty() {
-        "Esc/q back"
-    } else {
-        "↑↓ move · ←→ scroll · / filter · o sort · Enter diff · s sync · u push · d pull · x unpin · ? help  ·  ✓ synced ↑ local-newer ↓ remote-newer ✕ missing ? n/a  ·  Esc/q back"
-    };
     let (ftitle, footer, colored) = if state.pins.filtering {
         (
             "Filter (↑↓ move · Enter apply · Esc clear)".to_string(),
@@ -386,7 +381,7 @@ pub(super) fn render_pins(frame: &mut Frame, state: &AppState, layout: &mut Mous
             false,
         )
     } else {
-        let (footer, colored) = footer_with_status(state.status.as_deref(), hints);
+        let (footer, colored) = footer_with_status(state.status.as_deref(), MINIMAL_HINT);
         (String::new(), footer, colored)
     };
     let footer_lines = wrap_line_count(&footer, area.width.saturating_sub(2)).max(1);
@@ -597,15 +592,9 @@ pub(super) fn render_gists(frame: &mut Frame, state: &AppState, layout: &mut Mou
             format!("/{}_", state.gist_manager.filter_query),
             false,
         )
-    } else if let Some(message) = &state.status {
-        (String::new(), message.clone(), false)
     } else {
-        (
-            String::new(),
-            "↑↓ move · ←→ scroll · Enter detail · / filter · s sort · v type · * star · H history · o browser · y copy url · ? help · q back"
-                .to_string(),
-            true,
-        )
+        let (footer, colored) = footer_with_status(state.status.as_deref(), MINIMAL_HINT);
+        (String::new(), footer, colored)
     };
     let footer_lines = wrap_line_count(&footer, area.width.saturating_sub(2)).max(1);
     let chunks = Layout::default()
@@ -796,26 +785,8 @@ pub(super) fn render_revisions(frame: &mut Frame, state: &AppState, layout: &mut
     } else if let Some(err) = &state.revision.fetch_error {
         (String::new(), err.clone(), false)
     } else {
-        (
-            String::new(),
-            {
-                let file = state.revision_target_file_label();
-                let file_key = if state
-                    .revision
-                    .gist_id
-                    .as_ref()
-                    .is_some_and(|id| state.gist_filenames(id).len() > 1)
-                {
-                    "F next file · "
-                } else {
-                    ""
-                };
-                format!(
-                    "file={file} · {file_key}Enter incremental diff · D vs current · r restore · ? help · q back"
-                )
-            },
-            true,
-        )
+        let file = state.revision_target_file_label();
+        (String::new(), format!("file={file} · {MINIMAL_HINT}"), true)
     };
     let footer_lines = wrap_line_count(&footer, area.width.saturating_sub(2)).max(1);
     let chunks = Layout::default()
@@ -1223,6 +1194,11 @@ pub(super) fn render_gist_comments(
     render_text_scrollbar(frame, area, total_lines, state.detail.scroll as usize);
 }
 
+/// The default (idle) footer hint everywhere the footer used to print a long per-screen
+/// hotkey list. Discoverability now lives in the `?` Help topic (and, from Phase 3/4 of the
+/// TUI UX redesign, the right-click context menu and Ctrl+P command palette).
+pub(super) const MINIMAL_HINT: &str = "? Help";
+
 /// Footer text + whether to colourise it: a one-shot `state.status` message (shown plain) when
 /// present, else the colourised key `hints`. Shared by every screen so action results/errors
 /// surface consistently and are never swallowed by a hard-coded footer (see #72, #66).
@@ -1231,29 +1207,6 @@ pub(super) fn footer_with_status(status: Option<&str>, hints: &str) -> (String, 
         Some(message) => (message.to_string(), false),
         None => (hints.to_string(), true),
     }
-}
-
-/// The detail-view footer: a one-shot `state.status` message (e.g. the compaction result,
-/// including "nothing to compact") when present, else the focus-aware key hints.
-pub(super) fn detail_footer(
-    status: Option<&str>,
-    focus: DetailFocus,
-    owned: bool,
-) -> (String, bool) {
-    let manage = if owned {
-        " · e desc · c compact · X delete"
-    } else {
-        " · F fork"
-    };
-    let hints = match focus {
-        DetailFocus::Comments => format!(
-            "Tab files · ↑↓ scroll · 1-9 preview · H history · * star · o browser · y copy url{manage} · ? help · q back"
-        ),
-        DetailFocus::Files => format!(
-            "Tab comments · ↑↓ select · ⏎ preview · 1-9 preview · H history · * star · o browser · y copy url{manage} · ? help · q back"
-        ),
-    };
-    footer_with_status(status, &hints)
 }
 
 /// The Files|Comments tab index, mirroring `detail_focus`. Pure so the tab selection is
@@ -1293,12 +1246,7 @@ pub(super) fn detail_focus_tabs_line(focus: DetailFocus, theme: &Theme) -> Line<
 
 pub(super) fn render_gist_detail(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout) {
     let area = frame.area();
-    let owned = state
-        .detail
-        .gist_id
-        .as_deref()
-        .is_some_and(|id| state.gist_is_owned(id));
-    let (footer, colored) = detail_footer(state.status.as_deref(), state.detail.focus, owned);
+    let (footer, colored) = footer_with_status(state.status.as_deref(), MINIMAL_HINT);
     let footer_lines = wrap_line_count(&footer, area.width.saturating_sub(2)).max(1);
     // Fixed 4-row header (borders + basic-info line + focus tabs); the active tab — the file
     // list or the comments, never both — fills the rest above the footer.
@@ -1434,28 +1382,6 @@ pub(super) fn gist_row_display(g: &RankedGistFile, view: GistView, state: &AppSt
         gist_badge_prefix(state.gist_is_starred(&g.file.gist_id), g.file.is_fork()),
         base
     )
-}
-
-/// Command hint tailored to the focused pane: local-file actions on the left, gist actions
-/// on the right, plus the always-available navigation/help/quit keys. The footer word-wraps
-/// it to the terminal width.
-pub(super) fn commands_hint(focus: FocusPane) -> String {
-    // Focus-relevant common keys only; the full reference lives in the `?` help overlay.
-    let mut items = vec!["Tab panes", "↑↓/jk move", "Enter diff", "a anchor"];
-    match focus {
-        FocusPane::Local => items.extend(["r recursive", "e edit", "n create", "P pins"]),
-        FocusPane::Gist => items.extend([
-            "Space preview",
-            "H history",
-            "d download",
-            "u upload",
-            "X remove file",
-            "* star",
-            "g gists",
-        ]),
-    }
-    items.extend(["? help", "Esc/q quit"]);
-    items.join("  ·  ")
 }
 
 /// Greedy word-wrap line count, matching how `Paragraph` with `Wrap { trim: true }` breaks
@@ -1670,7 +1596,7 @@ pub(super) fn render_list(frame: &mut Frame, state: &AppState, layout: &mut Mous
     } else {
         match &state.status {
             Some(message) => message.clone(),
-            None => commands_hint(state.focus),
+            None => MINIMAL_HINT.to_string(),
         }
     };
     // Only the command-hint variant gets key colouring; filter input and status stay plain.

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -3443,6 +3443,32 @@ fn top_bar_help_click_opens_help_and_remembers_return_screen_from_any_screen() {
 }
 
 #[test]
+fn top_bar_help_click_while_already_on_help_does_not_trap_keyboard_exit() {
+    let mut state = state_with_gists();
+    state.screen = Screen::Preview;
+    let layout = MouseLayout {
+        top_bar_help: Some(Rect::new(30, 0, 7, 1)),
+        ..Default::default()
+    };
+    // First click opens Help from Preview, remembering Preview as the return screen.
+    state.handle_mouse(MouseInput::Click { col: 32, row: 0 }, &layout);
+    assert_eq!(state.screen, Screen::Help);
+    assert_eq!(state.help.return_screen, Screen::Preview);
+
+    // A second click on the same top-bar Help hotspot, now that Help is already open, must
+    // be a no-op — it must not overwrite return_screen with Screen::Help, which would trap
+    // Esc/`?`/the close button in Help with no keyboard way out.
+    let out = state.handle_mouse(MouseInput::Click { col: 32, row: 0 }, &layout);
+    assert_eq!(state.screen, Screen::Help);
+    assert_eq!(state.help.return_screen, Screen::Preview);
+    assert_eq!(out, KeyOutcome::None);
+
+    // Esc must still return to the real origin screen, not stay stuck on Help.
+    state.handle_key(KeyCode::Esc);
+    assert_eq!(state.screen, Screen::Preview);
+}
+
+#[test]
 fn list_screen_capital_s_syncs_selected_pair() {
     let mut state = initial_state();
     state.locals = vec![LocalCandidate {

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -3440,6 +3440,49 @@ fn entering_pins_screen_resets_hscroll() {
 }
 
 #[test]
+fn top_bar_gists_click_opens_gist_manager_from_any_screen() {
+    let mut state = state_with_gists();
+    state.screen = Screen::Preview; // arbitrary screen that has no 'g' binding of its own
+    let layout = MouseLayout {
+        top_bar_gists: Some(Rect::new(10, 0, 7, 1)),
+        ..Default::default()
+    };
+    let out = state.handle_mouse(MouseInput::Click { col: 12, row: 0 }, &layout);
+    assert_eq!(state.screen, Screen::Gists);
+    assert_eq!(out, KeyOutcome::None);
+}
+
+#[test]
+fn top_bar_pins_click_opens_pins_from_any_screen() {
+    let mut state = pins_state_with_long_home_path();
+    state.handle_key(KeyCode::Right); // dirty the hscroll so the reset is observable
+    assert!(state.pins.hscroll > 0);
+    state.screen = Screen::Preview;
+    let layout = MouseLayout {
+        top_bar_pins: Some(Rect::new(20, 0, 6, 1)),
+        ..Default::default()
+    };
+    let out = state.handle_mouse(MouseInput::Click { col: 22, row: 0 }, &layout);
+    assert_eq!(state.screen, Screen::Pins);
+    assert_eq!(state.pins.hscroll, 0);
+    assert_eq!(out, KeyOutcome::None);
+}
+
+#[test]
+fn top_bar_help_click_opens_help_and_remembers_return_screen_from_any_screen() {
+    let mut state = state_with_gists();
+    state.screen = Screen::Preview;
+    let layout = MouseLayout {
+        top_bar_help: Some(Rect::new(30, 0, 7, 1)),
+        ..Default::default()
+    };
+    let out = state.handle_mouse(MouseInput::Click { col: 32, row: 0 }, &layout);
+    assert_eq!(state.screen, Screen::Help);
+    assert_eq!(state.help.return_screen, Screen::Preview);
+    assert_eq!(out, KeyOutcome::None);
+}
+
+#[test]
 fn list_screen_capital_s_syncs_selected_pair() {
     let mut state = initial_state();
     state.locals = vec![LocalCandidate {

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -500,37 +500,6 @@ fn footer_with_status_prefers_status_else_colourised_hints() {
 }
 
 #[test]
-fn detail_footer_surfaces_status_else_hints() {
-    let (msg, colored) = detail_footer(Some("nothing to compact"), DetailFocus::Comments, true);
-    assert_eq!(msg, "nothing to compact");
-    assert!(!colored);
-    let (hint, colored) = detail_footer(None, DetailFocus::Comments, true);
-    assert!(hint.contains("1-9") && hint.contains("compact"));
-    assert!(!hint.contains("F fork"));
-    assert!(colored);
-}
-
-#[test]
-fn detail_footer_is_focus_aware() {
-    let (comments, _) = detail_footer(None, DetailFocus::Comments, true);
-    assert!(comments.contains("Tab files") && comments.contains("scroll"));
-    let (files, _) = detail_footer(None, DetailFocus::Files, true);
-    assert!(files.contains("Tab comments") && files.contains("preview"));
-}
-
-#[test]
-fn detail_footer_shows_manage_keys_for_owned_and_fork_for_foreign() {
-    let (owned, _) = detail_footer(None, DetailFocus::Files, true);
-    assert!(owned.contains("e desc") && owned.contains("compact"));
-    assert!(owned.contains("* star"));
-    assert!(!owned.contains("F fork"));
-    let (foreign, _) = detail_footer(None, DetailFocus::Files, false);
-    assert!(foreign.contains("F fork"));
-    assert!(foreign.contains("* star"));
-    assert!(!foreign.contains("compact"));
-}
-
-#[test]
 fn star_key_in_detail_returns_toggle_intent() {
     let mut state = state_with_gists();
     state.screen = Screen::GistDetail;
@@ -1344,32 +1313,23 @@ fn gist_time_label_normalises_rfc3339() {
 }
 
 #[test]
-fn commands_hint_is_focus_aware() {
-    let local = commands_hint(FocusPane::Local);
-    assert!(local.contains("e edit"));
-    assert!(local.contains("n create"));
-    assert!(!local.contains("d download"));
-
-    let gist = commands_hint(FocusPane::Gist);
-    assert!(gist.contains("H history"));
-    assert!(gist.contains("d download"));
-    assert!(gist.contains("g gists"));
-    assert!(!gist.contains("e edit"));
-
-    // Always-available keys appear in both.
-    for hint in [local, gist] {
-        assert!(hint.contains("? help"));
-        assert!(hint.contains("Esc/q quit"));
-    }
-}
-
-#[test]
 fn wrap_line_count_is_responsive_to_width() {
     let text = "aaa bbb ccc";
     assert_eq!(wrap_line_count(text, 100), 1);
     assert_eq!(wrap_line_count(text, 7), 2);
     assert_eq!(wrap_line_count(text, 3), 3);
     assert_eq!(wrap_line_count(text, 0), 1);
+}
+
+#[test]
+fn minimal_hint_points_to_help() {
+    assert_eq!(MINIMAL_HINT, "? Help");
+    let (hint, colored) = footer_with_status(None, MINIMAL_HINT);
+    assert_eq!(hint, "? Help");
+    assert!(colored);
+    let (status, colored) = footer_with_status(Some("Downloaded file.txt"), MINIMAL_HINT);
+    assert_eq!(status, "Downloaded file.txt");
+    assert!(!colored);
 }
 
 #[test]

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1322,10 +1322,10 @@ fn wrap_line_count_is_responsive_to_width() {
 }
 
 #[test]
-fn minimal_hint_points_to_help() {
-    assert_eq!(MINIMAL_HINT, "? Help");
+fn minimal_hint_is_empty_when_idle() {
+    assert_eq!(MINIMAL_HINT, "");
     let (hint, colored) = footer_with_status(None, MINIMAL_HINT);
-    assert_eq!(hint, "? Help");
+    assert_eq!(hint, "");
     assert!(colored);
     let (status, colored) = footer_with_status(Some("Downloaded file.txt"), MINIMAL_HINT);
     assert_eq!(status, "Downloaded file.txt");


### PR DESCRIPTION
## Summary

Phase 1 of #216's 4-phase TUI UX redesign:

- Adds a persistent top bar (` gistui` left, `(G)ists (P)ins (?)Help` right, clickable) on every screen except the `Screen::Confirm` y/n modal, which keeps its full-bleed background. The three shortcuts reuse the existing `g`/`P`/`?` key handlers — no new keybindings.
- Collapses the old long per-screen footer hotkey list down to an idle hint. That hint ended up empty (not `? Help`) after review caught it duplicating the top bar's `(?)Help` — the footer now shows nothing when idle (status messages/filter input still override it as before); only the repo-URL link (from #215) remains there.
- Bumps `0.15.2` → `0.16.0` (first feature since the last release).
- Updates README, the in-app `?` help text, and CHANGELOG to match.

Built with subagent-driven development: each task went through implementer → task review, followed by a full whole-branch review (most-capable model) that caught and fixed one real bug before this PR — clicking the top bar's `(?)Help` while already viewing Help overwrote the "return to" screen with Help itself, trapping Esc/`?`/the close button with no keyboard way out. Fixed in the last commit with a regression test.

## Test plan

- [x] `mise run check` green (`cargo fmt --check`, `cargo test` — 472 unit + 12 integration, `cargo check`, `cargo clippy --all-targets -- -D warnings`)
- [x] `Screen::Confirm` confirmed to never render the top bar (grepped all `render_*` call sites)
- [x] Top bar renders as plain (non-clickable) text when `mouse_enabled` is false
- [x] Manual `cargo run` visual pass across all screens (deferred to reviewer — no TTY in the automation environment used to build this)
- [ ] `website/demo.gif` / `website/*.png` re-recording (deferred — flagging per `mise run demo-gif`'s "re-run after any UI change" convention; not done in this PR)

Refs #216 (Phase 1 only — Phases 2-4 remain open).