### PR TITLE
feat: fold About into the ? Help index (TUI UX redesign Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Every screen now shows a `(G)ists (P)ins (?)Help` shortcut bar in the top-right corner (click, or use the existing `g`/`P`/`?` keys, from any screen); the footer's long per-screen hotkey list is gone and it now stays empty when idle, since Help discoverability lives in the top bar (press `?` for the full keymap).
+- Every screen now shows a `(G)ists (P)ins (?)Help` shortcut bar in the top-right corner (click, or use the existing `g`/`P`/`?` keys, from any screen); the footer's long per-screen hotkey list is gone and it now fully collapses when idle (no divider, no blank row — the space goes back to content), since Help discoverability lives in the top bar (press `?` for the full keymap).
 - The app version, the GitHub repo link (click to open in the browser), and update-check status have moved from the footer into a new **About** topic in `?` Help (press `0` from the Help index, or `Tab` then scroll to it).
 - The `?` Help topic index is now clickable: click a row to select it, double-click (or `Enter`) to open it — matching every other list in the app.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Every screen now shows a `(G)ists (P)ins (?)Help` shortcut bar in the top-right corner (click, or use the existing `g`/`P`/`?` keys, from any screen); the footer's long per-screen hotkey list is gone and it now stays empty when idle, since Help discoverability lives in the top bar (press `?` for the full keymap).
 - The app version, the GitHub repo link (click to open in the browser), and update-check status have moved from the footer into a new **About** topic in `?` Help (press `0` from the Help index, or `Tab` then scroll to it).
+- The `?` Help topic index is now clickable: click a row to select it, double-click (or `Enter`) to open it — matching every other list in the app.
 
 ## [0.15.2] — 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Click the repository URL in the footer to open the GitHub repository in the system's default browser.
-- Every screen now shows a `(G)ists (P)ins (?)Help` shortcut bar in the top-right corner (click, or use the existing `g`/`P`/`?` keys, from any screen); the footer's long per-screen hotkey list is gone — it now drops its idle hint (just the repository URL remains), since Help discoverability lives in the top bar (press `?` for the full keymap).
+- Every screen now shows a `(G)ists (P)ins (?)Help` shortcut bar in the top-right corner (click, or use the existing `g`/`P`/`?` keys, from any screen); the footer's long per-screen hotkey list is gone and it now stays empty when idle, since Help discoverability lives in the top bar (press `?` for the full keymap).
+- The app version, the GitHub repo link (click to open in the browser), and update-check status have moved from the footer into a new **About** topic in `?` Help (press `0` from the Help index, or `Tab` then scroll to it).
 
 ## [0.15.2] — 2026-07-08
 

--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ destructive remote actions
 each get their own confirm. Others' gists (e.g. starred) are read-only for pin/upload/delete
 — fork with `F` in gist detail. No GitHub token is stored; gist content is never written to
 config. Mouse is on by default and can be disabled with `mouse = false` in the config file or
-the `--no-mouse` flag. On startup gistui checks GitHub once a day for a newer release and shows
-a footer hint if one exists (no telemetry; fails silently offline) — disable with
-`check_updates = false` or `--no-update-check`.
+the `--no-mouse` flag. On startup gistui checks GitHub once a day for a newer release and
+surfaces it on the `?` Help → About topic if one exists (no telemetry; fails silently offline)
+— disable with `check_updates = false` or `--no-update-check`.
 
 Full rules: **[docs/SAFETY.md](docs/SAFETY.md)**.
 
@@ -121,7 +121,7 @@ automatically the first time you pin a file. All fields are optional.
 | `diff_show_full` | `bool` | Remembered state of the diff `c` toggle: `true` shows the full file, `false` collapses to `diff_context` lines. Rewritten when you press `c`. Default `false`. |
 | `theme` | `string` | Built-in colour theme: `"dark"` (default) or `"light"` (for light-background terminals). |
 | `mouse` | `bool` | Enable mouse support (wheel scroll, click/double-click, close button). Default `true`; `--no-mouse` forces it off for one session. |
-| `check_updates` | `bool` | Check GitHub once a day on startup for a newer release and show a footer hint. Default `true`; `--no-update-check` forces it off for one session. |
+| `check_updates` | `bool` | Check GitHub once a day on startup for a newer release and surface it on the `?` Help → About topic. Default `true`; `--no-update-check` forces it off for one session. |
 | `ignore_trailing_newline` | `bool` | Treat a difference that is *only* a file-final newline as no change in the diff view and the overwrite-confirm gate. Default `true`; set `false` for strict, byte-exact diffs. |
 | `skip_dirs` | `[string]` | Directory names skipped during recursive discovery (`r` key). Defaults to common build/dependency dirs (`node_modules`, `target`, …). Hidden dirs (`.`-prefix) are always skipped. |
 | `[[pinned]]` | `table array` | Local-file ↔ gist mappings managed by the `p`/`P` keys. Can also be edited by hand. |

--- a/README.md
+++ b/README.md
@@ -76,9 +76,10 @@ without resetting order. Pinned pairs show `📌`; same-filename candidates are 
 
 Press **`?`** anytime for the **full, contextual keymap** — it opens the current screen's
 topic; `Tab` browses all topics (List, Pins, Gist manager, Gist detail, Diff, Preview, …).
-The footer drops its idle hotkey hint (just the repository URL remains); every screen
-shows a `(G)ists (P)ins (?)Help` shortcut bar in the top-right corner instead (click,
-or use the underlying key).
+The footer stays empty when idle; every screen shows a `(G)ists (P)ins (?)Help`
+shortcut bar in the top-right corner instead (click, or use the underlying key). The
+app version, the GitHub repo link, and update-check status live in `?` Help's
+**About** topic (press `0` from the Help index, or `Tab` then scroll to it).
 
 **Mouse** (on by default; disable with `mouse = false` in config or `--no-mouse`):
 
@@ -90,7 +91,7 @@ or use the underlying key).
 | Click a tab (Gist details) | switch between Files / Comments (newest 30 comments load first; `m` or clicking the top line loads 30 older comments) |
 | Click `[✕]` button (pop-up screens) | close / go back |
 | Click `(G)ists` / `(P)ins` / `(?)Help` (top bar) | jump to that screen, from anywhere — same as pressing `g` / `P` / `?` |
-| Click the repository URL | open the GitHub repository in the system's default browser |
+| Click the repository URL (`?` Help → About) | open the GitHub repository in the system's default browser |
 
 ## Safety
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ app version, the GitHub repo link, and update-check status live in `?` Help's
 |--------|--------|
 | Wheel up/down | scroll the focused list or content pane |
 | Click a row | select it (List panes also switch focus) |
-| Double-click a row | open it — List diff, gist detail, pin diff, revision diff, or file preview (same as `Enter`) |
+| Double-click a row | open it — List diff, gist detail, pin diff, revision diff, file preview, or Help topic (same as `Enter`) |
 | Click a tab (Gist details) | switch between Files / Comments (newest 30 comments load first; `m` or clicking the top line loads 30 older comments) |
 | Click `[✕]` button (pop-up screens) | close / go back |
 | Click `(G)ists` / `(P)ins` / `(?)Help` (top bar) | jump to that screen, from anywhere — same as pressing `g` / `P` / `?` |

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -786,6 +786,19 @@ impl AppState {
                 }
                 false
             }
+            // Only set when the topic index is open (render_help), so this is a no-op while
+            // viewing a topic's body.
+            Screen::Help => {
+                if let Some(hit) = layout.list {
+                    if point_in(hit.rect, col, row) {
+                        if let Some(idx) = hit.index_at(row, HelpTopic::all().len()) {
+                            self.help.index_sel = idx;
+                            return true;
+                        }
+                    }
+                }
+                false
+            }
             Screen::GistDetail => {
                 if let Some(hit) = layout.detail_files {
                     if point_in(hit.rect, col, row) {

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -316,6 +316,11 @@ impl AppState {
                     self.help.index_open = false;
                     self.help.scroll = 0;
                 }
+                KeyCode::Char('0') if topics.len() > 9 => {
+                    self.help.topic = topics[9];
+                    self.help.index_open = false;
+                    self.help.scroll = 0;
+                }
                 KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => {
                     self.screen = self.help.return_screen;
                     self.help.index_open = false;
@@ -334,6 +339,10 @@ impl AppState {
                 }
                 KeyCode::Char(c @ '1'..='9') if (c as u8 - b'1') < topics.len() as u8 => {
                     self.help.topic = topics[(c as u8 - b'1') as usize];
+                    self.help.scroll = 0;
+                }
+                KeyCode::Char('0') if topics.len() > 9 => {
+                    self.help.topic = topics[9];
                     self.help.scroll = 0;
                 }
                 KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -402,7 +402,7 @@ impl PaneHit {
 pub struct MouseLayout {
     pub local: Option<PaneHit>,
     pub gist: Option<PaneHit>,
-    /// Single-list screens (Gists / Pins / Revisions).
+    /// Single-list screens (Gists / Pins / Revisions) and the Help topic index.
     pub list: Option<PaneHit>,
     /// GistDetail file list (Files tab).
     pub detail_files: Option<PaneHit>,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -34,7 +34,8 @@ pub enum Screen {
     Revisions,
 }
 
-/// A help topic — one per key-dense area. Ordered for the index list and `1`-`8` quick-jump.
+/// A help topic — one per key-dense area, plus `About` (version/repo/update info, not tied
+/// to a screen). Ordered for the index list and `1`-`9`,`0` quick-jump.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum HelpTopic {
     #[default]
@@ -47,11 +48,12 @@ pub enum HelpTopic {
     Upload,
     Revisions,
     General,
+    About,
 }
 
 impl HelpTopic {
     /// All topics in index / quick-jump order.
-    pub fn all() -> [HelpTopic; 9] {
+    pub fn all() -> [HelpTopic; 10] {
         use HelpTopic::*;
         [
             List,
@@ -63,6 +65,7 @@ impl HelpTopic {
             Preview,
             Upload,
             General,
+            About,
         ]
     }
 
@@ -78,6 +81,7 @@ impl HelpTopic {
             HelpTopic::Preview => "Preview",
             HelpTopic::Upload => "Upload confirmation",
             HelpTopic::General => "General",
+            HelpTopic::About => "About",
         }
     }
 

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -292,10 +292,45 @@ Mouse (on by default; disable with mouse = false in config or --no-mouse)
   NO_COLOR   set this env var to disable syntax highlighting (preview + diff)"
         }
         HelpTopic::About => {
-            "About
-(This section will show version, repository, and update information.)"
+            unreachable!(
+                "About has its own dynamic body in about_topic_lines, rendered before help_topic_body is ever called"
+            )
         }
     }
+}
+
+/// Fixed row (0-indexed, within the topic body) of the clickable repo-URL line — used to
+/// place `MouseLayout::repo_link`'s hit-rect. Kept stable regardless of update-check state
+/// (see `about_topic_lines`) so this constant never has to change.
+const ABOUT_REPO_LINE: u16 = 3;
+
+/// The `About` topic's body: version, the clickable repo link (relocated from the old
+/// per-screen footer — see `render_footer`), and the update-check status if a newer release
+/// is available. Unlike every other topic's `&'static str` (`help_topic_body`), this one
+/// needs `state`, so it returns owned `Line`s instead.
+fn about_topic_lines(state: &AppState) -> Vec<Line<'static>> {
+    let repo = env!("CARGO_PKG_REPOSITORY")
+        .trim_start_matches("https://")
+        .trim_start_matches("http://");
+    let mut lines = vec![
+        Line::from(format!("gistui v{}", env!("CARGO_PKG_VERSION"))),
+        Line::from(""),
+        Line::from("Repository (click to open in the browser)"),
+        Line::from(Span::styled(
+            format!("  {repo}"),
+            Style::default()
+                .fg(state.theme.fg)
+                .add_modifier(Modifier::UNDERLINED),
+        )),
+        Line::from(""),
+    ];
+    if let Some(latest) = &state.update_available {
+        lines.push(Line::from(crate::update_check::update_hint(
+            latest,
+            &state.install_method,
+        )));
+    }
+    lines
 }
 
 pub(super) fn render_help(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout) {
@@ -339,8 +374,13 @@ pub(super) fn render_help(frame: &mut Frame, state: &AppState, layout: &mut Mous
             "Help · {} — Tab topics · ↑↓ scroll · Esc back",
             state.help.topic.title()
         );
+        let body: Text = if state.help.topic == HelpTopic::About {
+            Text::from(about_topic_lines(state))
+        } else {
+            Text::from(help_topic_body(state.help.topic))
+        };
         frame.render_widget(
-            Paragraph::new(help_topic_body(state.help.topic))
+            Paragraph::new(body)
                 .style(state.theme.base_style())
                 .scroll((state.help.scroll, 0))
                 .block(
@@ -353,6 +393,21 @@ pub(super) fn render_help(frame: &mut Frame, state: &AppState, layout: &mut Mous
                 ),
             area,
         );
+        // The repo-link line only gets a click target while it's actually the About topic and
+        // currently scrolled into view — if the user has scrolled it off-screen, the hit-rect
+        // is simply omitted this frame rather than tracked at a stale position.
+        if state.help.topic == HelpTopic::About && state.mouse_enabled {
+            let visible_row = ABOUT_REPO_LINE as i32 - state.help.scroll as i32;
+            let inner_height = area.height.saturating_sub(2);
+            if visible_row >= 0 && (visible_row as u16) < inner_height {
+                layout.repo_link = Some(Rect::new(
+                    area.x + 1,
+                    area.y + 1 + visible_row as u16,
+                    area.width.saturating_sub(2),
+                    1,
+                ));
+            }
+        }
     }
     if state.mouse_enabled {
         layout.close_button = Some(render_close_button(frame, area, &state.theme));

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1607,28 +1607,14 @@ pub(super) fn hint_line(text: &str, theme: &Theme) -> Line<'static> {
     Line::from(spans)
 }
 
-/// The shared borderless footer block: a single dim top divider that carries the left `title` and
-/// the repo URL pinned to the bottom-right corner of every screen.
-///
-/// Deliberately omits the version number: printing it here would make every version bump a
-/// visible diff in the demo GIF/PNG, forcing a re-recording that the release flow doesn't
-/// otherwise need. The in-app update check already surfaces version freshness.
+/// The shared borderless footer block: a single dim top divider that carries the left `title`
+/// (the filter-input label while filtering; empty otherwise). The repo URL, app version, and
+/// update-check status used to live here (via `title` and a right-aligned repo span) but have
+/// moved to the Help → About topic (see `about_topic_lines`) — the footer is genuinely empty
+/// when idle now.
 pub(super) fn footer_block(title: &str, theme: &Theme) -> Block<'static> {
-    // Repo URL (scheme stripped — the host/path already names the project).
-    let repo = env!("CARGO_PKG_REPOSITORY")
-        .trim_start_matches("https://")
-        .trim_start_matches("http://");
-    let repo_span = Span::styled(
-        repo.to_string(),
-        Style::default()
-            .fg(theme.fg)
-            .add_modifier(ratatui::style::Modifier::UNDERLINED),
-    );
-    let line = Line::from(vec![Span::raw(" "), repo_span, Span::raw(" ")]).right_aligned();
-
     Block::default()
         .title(title.to_string())
-        .title_top(line)
         .borders(Borders::TOP)
         .border_style(Style::default().fg(theme.dim))
         .style(theme.base_style())
@@ -1644,18 +1630,8 @@ pub(super) fn render_footer(
     text: &str,
     colored: bool,
     theme: &Theme,
-    layout: &mut MouseLayout,
+    _layout: &mut MouseLayout,
 ) {
-    let repo = env!("CARGO_PKG_REPOSITORY")
-        .trim_start_matches("https://")
-        .trim_start_matches("http://");
-    let label = format!(" {} ", repo);
-    let label_len = label.chars().count() as u16;
-    let repo_x = area.x + area.width.saturating_sub(label_len);
-    let repo_width = label_len.min(area.width);
-    let repo_rect = Rect::new(repo_x, area.y, repo_width, 1);
-    layout.repo_link = Some(repo_rect);
-
     let para = if colored {
         Paragraph::new(hint_line(text, theme))
     } else {
@@ -1677,18 +1653,8 @@ pub(super) fn render_footer_line(
     title: &str,
     line: Line,
     theme: &Theme,
-    layout: &mut MouseLayout,
+    _layout: &mut MouseLayout,
 ) {
-    let repo = env!("CARGO_PKG_REPOSITORY")
-        .trim_start_matches("https://")
-        .trim_start_matches("http://");
-    let label = format!(" {} ", repo);
-    let label_len = label.chars().count() as u16;
-    let repo_x = area.x + area.width.saturating_sub(label_len);
-    let repo_width = label_len.min(area.width);
-    let repo_rect = Rect::new(repo_x, area.y, repo_width, 1);
-    layout.repo_link = Some(repo_rect);
-
     frame.render_widget(
         Paragraph::new(line)
             .style(theme.base_style())
@@ -1745,11 +1711,6 @@ pub(super) fn render_list(frame: &mut Frame, state: &AppState, layout: &mut Mous
     };
     // Only the command-hint variant gets key colouring; filter input and status stay plain.
     let footer_is_command = !state.filtering && state.status.is_none();
-    // A newer-release hint rides the footer's top-border title slot (non-intrusive, persistent).
-    let footer_title = match &state.update_available {
-        Some(v) => crate::update_check::update_hint(v, &state.install_method),
-        None => String::new(),
-    };
     // Width inside the footer block: minus the 2 horizontal padding columns (no side borders).
     let footer_lines = wrap_line_count(&footer_body, area.width.saturating_sub(2)).max(1);
     let chunks = Layout::default()
@@ -1892,7 +1853,7 @@ pub(super) fn render_list(frame: &mut Frame, state: &AppState, layout: &mut Mous
         render_footer(
             frame,
             chunks[1],
-            &footer_title,
+            "",
             &footer_body,
             footer_is_command,
             &state.theme,

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -532,10 +532,12 @@ pub(super) fn render_pins(frame: &mut Frame, state: &AppState, layout: &mut Mous
         let (footer, colored) = footer_with_status(state.status.as_deref(), MINIMAL_HINT);
         (String::new(), footer, colored)
     };
-    let footer_lines = wrap_line_count(&footer, area.width.saturating_sub(2)).max(1);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Min(3), Constraint::Length(footer_lines + 1)])
+        .constraints([
+            Constraint::Min(3),
+            Constraint::Length(footer_height(&footer, area.width)),
+        ])
         .split(area);
 
     let visible = state.visible_pin_indices();
@@ -745,10 +747,12 @@ pub(super) fn render_gists(frame: &mut Frame, state: &AppState, layout: &mut Mou
         let (footer, colored) = footer_with_status(state.status.as_deref(), MINIMAL_HINT);
         (String::new(), footer, colored)
     };
-    let footer_lines = wrap_line_count(&footer, area.width.saturating_sub(2)).max(1);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Min(3), Constraint::Length(footer_lines + 1)])
+        .constraints([
+            Constraint::Min(3),
+            Constraint::Length(footer_height(&footer, area.width)),
+        ])
         .split(area);
 
     let groups = state.visible_gist_groups();
@@ -1399,7 +1403,6 @@ pub(super) fn render_gist_detail(frame: &mut Frame, state: &AppState, layout: &m
     let area = frame.area();
     let area = render_top_bar(frame, area, &state.theme, state.mouse_enabled, layout);
     let (footer, colored) = footer_with_status(state.status.as_deref(), MINIMAL_HINT);
-    let footer_lines = wrap_line_count(&footer, area.width.saturating_sub(2)).max(1);
     // Fixed 4-row header (borders + basic-info line + focus tabs); the active tab — the file
     // list or the comments, never both — fills the rest above the footer.
     let chunks = Layout::default()
@@ -1407,7 +1410,7 @@ pub(super) fn render_gist_detail(frame: &mut Frame, state: &AppState, layout: &m
         .constraints([
             Constraint::Length(4),
             Constraint::Min(3),
-            Constraint::Length(footer_lines + 1),
+            Constraint::Length(footer_height(&footer, area.width)),
         ])
         .split(area);
     if let Some(id) = state.detail.gist_id.as_deref() {
@@ -1557,6 +1560,19 @@ pub(super) fn wrap_line_count(text: &str, width: u16) -> u16 {
         }
     }
     lines
+}
+
+/// Height to reserve for a screen's footer `Layout` row: `0` when `text` is empty (the footer
+/// fully collapses — no divider, no blank row — reclaiming the space for content above it) or
+/// the wrapped line count plus one (for the divider) otherwise. Screens whose footer always has
+/// real content (Diff, Preview) don't need this — only the ones whose idle state can be
+/// genuinely empty (`MINIMAL_HINT`) call it.
+pub(super) fn footer_height(text: &str, width: u16) -> u16 {
+    if text.is_empty() {
+        0
+    } else {
+        wrap_line_count(text, width.saturating_sub(2)).max(1) + 1
+    }
 }
 
 /// Colour a command key by what its action does, so destructive and mutating keys stand apart
@@ -1727,11 +1743,12 @@ pub(super) fn render_list(frame: &mut Frame, state: &AppState, layout: &mut Mous
     };
     // Only the command-hint variant gets key colouring; filter input and status stay plain.
     let footer_is_command = !state.filtering && state.status.is_none();
-    // Width inside the footer block: minus the 2 horizontal padding columns (no side borders).
-    let footer_lines = wrap_line_count(&footer_body, area.width.saturating_sub(2)).max(1);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Min(5), Constraint::Length(footer_lines + 1)])
+        .constraints([
+            Constraint::Min(5),
+            Constraint::Length(footer_height(&footer_body, area.width)),
+        ])
         .split(area);
     let columns = Layout::default()
         .direction(Direction::Horizontal)

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -301,7 +301,7 @@ Mouse (on by default; disable with mouse = false in config or --no-mouse)
 /// Fixed row (0-indexed, within the topic body) of the clickable repo-URL line — used to
 /// place `MouseLayout::repo_link`'s hit-rect. Kept stable regardless of update-check state
 /// (see `about_topic_lines`) so this constant never has to change.
-const ABOUT_REPO_LINE: u16 = 3;
+const ABOUT_REPO_LINE: u16 = 2;
 
 /// The `About` topic's body: version, the clickable repo link (relocated from the old
 /// per-screen footer — see `render_footer`), and the update-check status if a newer release
@@ -314,13 +314,17 @@ fn about_topic_lines(state: &AppState) -> Vec<Line<'static>> {
     let mut lines = vec![
         Line::from(format!("gistui v{}", env!("CARGO_PKG_VERSION"))),
         Line::from(""),
-        Line::from("Repository (click to open in the browser)"),
-        Line::from(Span::styled(
-            format!("  {repo}"),
-            Style::default()
-                .fg(state.theme.fg)
-                .add_modifier(Modifier::UNDERLINED),
-        )),
+        // The leading indent is a plain (unstyled) span so only the repo URL itself is
+        // underlined — not the whitespace in front of it.
+        Line::from(vec![
+            Span::raw("  "),
+            Span::styled(
+                repo.to_string(),
+                Style::default()
+                    .fg(state.theme.fg)
+                    .add_modifier(Modifier::UNDERLINED),
+            ),
+        ]),
         Line::from(""),
     ];
     if let Some(latest) = &state.update_available {
@@ -368,6 +372,12 @@ pub(super) fn render_help(frame: &mut Frame, state: &AppState, layout: &mut Mous
         let mut list_state = ListState::default();
         list_state.select(Some(state.help.index_sel));
         frame.render_stateful_widget(list, area, &mut list_state);
+        if state.mouse_enabled {
+            layout.list = Some(PaneHit {
+                rect: area,
+                offset: list_state.offset(),
+            });
+        }
     } else {
         let title = format!(
             "Help · {} — Tab topics · ↑↓ scroll · Esc back",
@@ -1606,15 +1616,21 @@ pub(super) fn hint_line(text: &str, theme: &Theme) -> Line<'static> {
     Line::from(spans)
 }
 
-/// The shared borderless footer block: a single dim top divider that carries the left `title`
-/// (the filter-input label while filtering; empty otherwise). The repo URL, app version, and
+/// The shared footer block: a dim top divider that carries the left `title` (the filter-input
+/// label while filtering; empty otherwise), shown only when there's something to divide from
+/// (`show_divider`) — an idle footer with no status/hint text renders with no border at all,
+/// rather than a stray horizontal rule above nothing. The repo URL, app version, and
 /// update-check status used to live here (via `title` and a right-aligned repo span) but have
-/// moved to the Help → About topic (see `about_topic_lines`) — the footer is genuinely empty
-/// when idle now.
-pub(super) fn footer_block(title: &str, theme: &Theme) -> Block<'static> {
+/// moved to the Help → About topic (see `about_topic_lines`).
+pub(super) fn footer_block(title: &str, theme: &Theme, show_divider: bool) -> Block<'static> {
+    let borders = if show_divider {
+        Borders::TOP
+    } else {
+        Borders::NONE
+    };
     Block::default()
         .title(title.to_string())
-        .borders(Borders::TOP)
+        .borders(borders)
         .border_style(Style::default().fg(theme.dim))
         .style(theme.base_style())
         .padding(Padding::horizontal(1))
@@ -1639,13 +1655,14 @@ pub(super) fn render_footer(
     frame.render_widget(
         para.style(theme.base_style())
             .wrap(Wrap { trim: true })
-            .block(footer_block(title, theme)),
+            .block(footer_block(title, theme, !text.is_empty())),
         area,
     );
 }
 
 /// Like [`render_footer`] but draws a prebuilt styled `line`, used for active text inputs
-/// so the cursor can be reverse-highlighted at its real position.
+/// so the cursor can be reverse-highlighted at its real position. Always shows the divider —
+/// unlike `render_footer`'s idle case, an active text input is never blank.
 pub(super) fn render_footer_line(
     frame: &mut Frame,
     area: Rect,
@@ -1658,7 +1675,7 @@ pub(super) fn render_footer_line(
         Paragraph::new(line)
             .style(theme.base_style())
             .wrap(Wrap { trim: true })
-            .block(footer_block(title, theme)),
+            .block(footer_block(title, theme, true)),
         area,
     );
 }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -180,7 +180,6 @@ Mouse (on by default; disable with mouse = false in config or --no-mouse)
   Dbl-click  open the clicked row (diff / detail / pin diff / preview)
   Tab click  switch Files / Comments on the Gist details screen
   [✕] btn    close / go back on any pop-up screen
-  Repo click open the GitHub repository in the browser
   Top bar    click (G)ists / (P)ins / (?)Help (top-right, every screen) to jump there"
         }
         HelpTopic::Pins => {

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -291,6 +291,10 @@ Mouse (on by default; disable with mouse = false in config or --no-mouse)
   Up/Down    scroll this help text
   NO_COLOR   set this env var to disable syntax highlighting (preview + diff)"
         }
+        HelpTopic::About => {
+            "About
+(This section will show version, repository, and update information.)"
+        }
     }
 }
 
@@ -301,12 +305,19 @@ pub(super) fn render_help(frame: &mut Frame, state: &AppState, layout: &mut Mous
         let items: Vec<ListItem> = HelpTopic::all()
             .iter()
             .enumerate()
-            .map(|(i, t)| ListItem::new(format!("  {}  {}", i + 1, t.title())))
+            .map(|(i, t)| {
+                let key = if i == 9 {
+                    "0".to_string()
+                } else {
+                    (i + 1).to_string()
+                };
+                ListItem::new(format!("  {}  {}", key, t.title()))
+            })
             .collect();
         let list = List::new(items)
             .block(
                 Block::default()
-                    .title("Help — pick a topic (1-9 / ↑↓ Enter · Esc back)")
+                    .title("Help — pick a topic (1-9,0 / ↑↓ Enter · Esc back)")
                     .borders(Borders::ALL)
                     .border_type(BorderType::Rounded)
                     .style(state.theme.base_style())

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -3943,11 +3943,13 @@ fn pins_filter_input_behaviors() {
 #[test]
 fn help_topic_all_is_ordered_and_titled() {
     let all = HelpTopic::all();
-    assert_eq!(all.len(), 9);
+    assert_eq!(all.len(), 10);
     assert_eq!(all[0], HelpTopic::List);
     assert_eq!(all[4], HelpTopic::Revisions);
     assert_eq!(all[8], HelpTopic::General);
+    assert_eq!(all[9], HelpTopic::About);
     assert_eq!(HelpTopic::Pins.title(), "Pinned Mappings");
+    assert_eq!(HelpTopic::About.title(), "About");
 }
 
 #[test]
@@ -4319,6 +4321,28 @@ fn help_topic_view_number_switches_topic() {
     assert_eq!(state.help.topic, HelpTopic::Pins);
     assert_eq!(state.help.scroll, 0);
     assert!(!state.help.index_open);
+}
+
+#[test]
+fn help_topic_view_zero_key_switches_to_about() {
+    let mut state = initial_state();
+    state.screen = Screen::Help;
+    state.help.topic = HelpTopic::List;
+    state.help.scroll = 5;
+    state.handle_key(KeyCode::Char('0')); // 0 -> About (index 9, the 10th topic)
+    assert_eq!(state.help.topic, HelpTopic::About);
+    assert_eq!(state.help.scroll, 0);
+    assert!(!state.help.index_open);
+}
+
+#[test]
+fn help_index_zero_key_opens_about_from_the_index_list() {
+    let mut state = initial_state();
+    state.screen = Screen::Help;
+    state.help.index_open = true;
+    state.handle_key(KeyCode::Char('0'));
+    assert!(!state.help.index_open);
+    assert_eq!(state.help.topic, HelpTopic::About);
 }
 
 #[test]

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1322,6 +1322,13 @@ fn wrap_line_count_is_responsive_to_width() {
 }
 
 #[test]
+fn footer_height_collapses_to_zero_when_empty_else_wraps_plus_divider() {
+    assert_eq!(footer_height("", 100), 0);
+    assert_eq!(footer_height("? Help", 100), 2); // 1 wrapped line + 1 divider row
+    assert_eq!(footer_height("aaa bbb ccc", 9), 3); // 2 wrapped lines (width-2=7) + 1 divider row
+}
+
+#[test]
 fn minimal_hint_is_empty_when_idle() {
     assert_eq!(MINIMAL_HINT, "");
     let (hint, colored) = footer_with_status(None, MINIMAL_HINT);

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -4346,6 +4346,17 @@ fn help_index_zero_key_opens_about_from_the_index_list() {
 }
 
 #[test]
+fn repo_link_click_opens_repo_url_regardless_of_which_screen_set_the_rect() {
+    let mut state = initial_state();
+    let layout = MouseLayout {
+        repo_link: Some(Rect::new(5, 10, 20, 1)),
+        ..Default::default()
+    };
+    let out = state.handle_mouse(MouseInput::Click { col: 10, row: 10 }, &layout);
+    assert_eq!(out, KeyOutcome::OpenRepoUrl);
+}
+
+#[test]
 fn help_topic_view_esc_returns_to_origin() {
     let mut state = initial_state();
     state.screen = Screen::Help;

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -5239,6 +5239,31 @@ fn revisions_click_selects_and_double_click_matches_enter() {
 }
 
 #[test]
+fn help_index_click_selects_and_double_click_opens_topic() {
+    let mut state = initial_state();
+    state.screen = Screen::Help;
+    state.help.index_open = true;
+    let hit = PaneHit {
+        rect: Rect::new(0, 0, 40, 15),
+        offset: 0,
+    };
+    let layout = MouseLayout {
+        list: Some(hit),
+        ..Default::default()
+    };
+    // Row 2 is the 2nd content row (border at row 0) -> idx 1 (Pins).
+    let out = state.handle_mouse(MouseInput::Click { col: 5, row: 2 }, &layout);
+    assert_eq!(out, KeyOutcome::None);
+    assert_eq!(state.help.index_sel, 1);
+    assert!(state.help.index_open); // a single click only selects, it doesn't open yet
+
+    let by_mouse = state.handle_mouse(MouseInput::DoubleClick { col: 5, row: 2 }, &layout);
+    assert_eq!(by_mouse, KeyOutcome::None);
+    assert!(!state.help.index_open);
+    assert_eq!(state.help.topic, HelpTopic::Pins);
+}
+
+#[test]
 fn gist_detail_file_click_selects_and_double_previews() {
     let mut state = state_with_gists(); // g1: a.txt (0), b.txt (1)
     state.screen = Screen::GistDetail;


### PR DESCRIPTION
## Summary

Phase 2 of #216's 4-phase TUI UX redesign (Phase 1 — top bar + minimal footer — shipped as #217):

- Adds a 10th `HelpTopic`, **About**, reachable from the `?` Help index via a new `0`-key quick-jump (topics 1-9 keep their existing digit keys).
- About shows the app version, a clickable GitHub repo link (opens in browser), and update-check status if a newer release is available — content that used to live in every screen's footer (added by #215, which landed in the same window as Phase 1; Phase 1's review chose to keep it in the footer for the time being).
- Removes that content from the shared footer entirely — every screen's footer is now genuinely empty when idle again (status messages/filter input still override it as before).
- Updates README and CHANGELOG to match.

Built with subagent-driven development, same as Phase 1: implementer → task review per task, then a full whole-branch review (most-capable model) that caught two real gaps the per-task reviews missed (each fixed same-session, before this PR):
- A stale `?` Help line on the List topic still described a "Repo click" action no longer available there.
- Two README lines still described the update-check hint as living in the footer.

## Test plan

- [x] `mise run check` green (`cargo fmt --check`, `cargo test` — 475 unit + 12 integration, `cargo check`, `cargo clippy --all-targets -- -D warnings`)
- [x] Digit-jump math re-derived independently: `'1'..='9'` → topics 0-8, `'0'` → `topics[9]` (About)
- [x] Repo-link hit-rect confirmed scoped to the About topic only (checked via `MouseLayout` being rebuilt fresh every frame) — clicking the same screen position on any other topic/screen does not open the repo URL
- [x] Manual `cargo run` visual pass (deferred to reviewer, per the same convention as #217)

Refs #216 (Phase 2 only — Phases 3-4 remain open).