### PR TITLE
feat: context menu and command palette (#216 phase 3–4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- The footer no longer draws a horizontal rule above its text — one fewer row of chrome on every screen that shows a footer hint or status.
 - A unified context menu (`;` or right-click) and command palette (`Ctrl+p`) list action verbs for the current screen — the menu shows only what's valid for your selection; the palette shows everything plus cross-screen shortcuts (`Go to Pins`, `Toggle theme`, `Quit`, …) with fuzzy-filter search. The idle footer now hints `; Menu · Ctrl+p Palette`.
 - Every screen now shows a `(G)ists (P)ins (?)Help` shortcut bar in the top-right corner (click, or use the existing `g`/`P`/`?` keys, from any screen); the footer's long per-screen hotkey list is gone and it now fully collapses when idle (no divider, no blank row — the space goes back to content), since Help discoverability lives in the top bar (press `?` for the full keymap).
 - The app version, the GitHub repo link (click to open in the browser), and update-check status have moved from the footer into a new **About** topic in `?` Help (press `0` from the Help index, or `Tab` then scroll to it).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Every screen now shows a `(G)ists (P)ins (?)Help` shortcut bar in the top-right corner (click, or use the existing `g`/`P`/`?` keys, from any screen); the footer's long per-screen hotkey list is gone and it now fully collapses when idle (no divider, no blank row — the space goes back to content), since Help discoverability lives in the top bar (press `?` for the full keymap).
 - The app version, the GitHub repo link (click to open in the browser), and update-check status have moved from the footer into a new **About** topic in `?` Help (press `0` from the Help index, or `Tab` then scroll to it).
 - The `?` Help topic index is now clickable: click a row to select it, double-click (or `Enter`) to open it — matching every other list in the app.
+- The context menu (`;` / right-click) now aligns key hints and action labels in separate columns so longer keys (`Enter`, `Space`, `Ctrl+p`, …) no longer run into the description.
 
 ## [0.15.2] — 2026-07-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- A unified context menu (`;` or right-click) and command palette (`Ctrl+p`) list action verbs for the current screen — the menu shows only what's valid for your selection; the palette shows everything plus cross-screen shortcuts (`Go to Pins`, `Toggle theme`, `Quit`, …) with fuzzy-filter search. The idle footer now hints `; Menu · Ctrl+p Palette`.
 - Every screen now shows a `(G)ists (P)ins (?)Help` shortcut bar in the top-right corner (click, or use the existing `g`/`P`/`?` keys, from any screen); the footer's long per-screen hotkey list is gone and it now fully collapses when idle (no divider, no blank row — the space goes back to content), since Help discoverability lives in the top bar (press `?` for the full keymap).
 - The app version, the GitHub repo link (click to open in the browser), and update-check status have moved from the footer into a new **About** topic in `?` Help (press `0` from the Help index, or `Tab` then scroll to it).
 - The `?` Help topic index is now clickable: click a row to select it, double-click (or `Enter`) to open it — matching every other list in the app.

--- a/README.md
+++ b/README.md
@@ -76,9 +76,12 @@ without resetting order. Pinned pairs show `📌`; same-filename candidates are 
 
 Press **`?`** anytime for the **full, contextual keymap** — it opens the current screen's
 topic; `Tab` browses all topics (List, Pins, Gist manager, Gist detail, Diff, Preview, …).
-The footer stays empty when idle; every screen shows a `(G)ists (P)ins (?)Help`
-shortcut bar in the top-right corner instead (click, or use the underlying key). The
-app version, the GitHub repo link, and update-check status live in `?` Help's
+The idle footer shows `; Menu · Ctrl+p Palette`; every screen also shows a
+`(G)ists (P)ins (?)Help` shortcut bar in the top-right corner (click, or use the
+underlying key). Press `;` (or right-click) for a context menu of actions valid on
+the current screen and selection; press `Ctrl+p` for the full command palette with
+fuzzy-filter search and cross-screen navigation (`Go to Pins`, `Toggle theme`, `Quit`, …).
+The app version, the GitHub repo link, and update-check status live in `?` Help's
 **About** topic (press `0` from the Help index, or `Tab` then scroll to it).
 
 **Mouse** (on by default; disable with `mouse = false` in config or `--no-mouse`):
@@ -91,6 +94,8 @@ app version, the GitHub repo link, and update-check status live in `?` Help's
 | Click a tab (Gist details) | switch between Files / Comments (newest 30 comments load first; `m` or clicking the top line loads 30 older comments) |
 | Click `[✕]` button (pop-up screens) | close / go back |
 | Click `(G)ists` / `(P)ins` / `(?)Help` (top bar) | jump to that screen, from anywhere — same as pressing `g` / `P` / `?` |
+| Right-click | open the context menu at the click (same as `;`) |
+| Click a menu / palette row | run that action (same as selecting it and pressing `Enter`) |
 | Click the repository URL (`?` Help → About) | open the GitHub repository in the system's default browser |
 
 ## Safety

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -47,6 +47,20 @@ impl AppState {
     }
 
     pub fn handle_key_with(&mut self, code: KeyCode, modifiers: KeyModifiers) -> KeyOutcome {
+        if self.screen == Screen::Palette {
+            return self.handle_key_palette(code, modifiers);
+        }
+        if code == KeyCode::Char(';') && modifiers.is_empty() && !self.palette_blocked() {
+            self.open_palette_menu(None);
+            return KeyOutcome::None;
+        }
+        if code == KeyCode::Char('p')
+            && modifiers.contains(KeyModifiers::CONTROL)
+            && !self.palette_blocked()
+        {
+            self.open_palette_command();
+            return KeyOutcome::None;
+        }
         // Global theme toggle: skip while any inline text input is active so `T` can still
         // be typed into filters and description editors.
         if code == KeyCode::Char('T')
@@ -80,6 +94,7 @@ impl AppState {
             Screen::Gists => self.handle_key_gists(code),
             Screen::GistDetail => self.handle_key_detail(code),
             Screen::Revisions => self.handle_key_revisions(code),
+            Screen::Palette => KeyOutcome::None,
         }
     }
 
@@ -87,7 +102,7 @@ impl AppState {
     /// A no-op while already on Help — otherwise the top bar's `(?)Help` click (reachable from
     /// any screen, including Help itself) would overwrite `return_screen` with `Screen::Help`,
     /// trapping Esc/`?`/the close button in Help with no keyboard way out.
-    fn open_help(&mut self) {
+    pub(crate) fn open_help(&mut self) {
         if self.screen == Screen::Help {
             return;
         }
@@ -113,6 +128,21 @@ impl AppState {
             return false;
         }
         match self.screen {
+            Screen::Palette => {
+                let len = self.palette_visible_items().len();
+                match action {
+                    NavAction::Up => {
+                        self.palette.selected = self.palette.selected.saturating_sub(1);
+                    }
+                    NavAction::Down => {
+                        if len > 0 && self.palette.selected + 1 < len {
+                            self.palette.selected += 1;
+                        }
+                    }
+                    _ => return false,
+                }
+                true
+            }
             Screen::Help => {
                 let topics = HelpTopic::all();
                 if self.help.index_open {
@@ -706,6 +736,7 @@ impl AppState {
             // steps one file at a time.
             Screen::GistDetail if self.detail.focus == DetailFocus::Comments => 3,
             Screen::Help if !self.help.index_open => 3, // help body scrolls; topic index is a list
+            Screen::Palette => 1,
             _ => 1, // List/Pins/Gists/Revisions/Help index/GistDetail Files
         }
     }
@@ -893,7 +924,34 @@ impl AppState {
     /// logic. Pure (no IO, no clock); returns a `KeyOutcome` so `run_loop` can perform any
     /// follow-up IO (e.g. `PreviewDiff` on double-click).
     pub fn handle_mouse(&mut self, input: MouseInput, layout: &MouseLayout) -> KeyOutcome {
+        if self.screen == Screen::Palette {
+            return match input {
+                MouseInput::Click { col, row } | MouseInput::DoubleClick { col, row } => {
+                    self.palette_click(col, row, layout)
+                }
+                MouseInput::RightClick { .. } => KeyOutcome::None,
+                MouseInput::ScrollUp | MouseInput::ScrollDown => {
+                    let action = if matches!(input, MouseInput::ScrollUp) {
+                        NavAction::Up
+                    } else {
+                        NavAction::Down
+                    };
+                    for _ in 0..self.wheel_step() {
+                        self.apply_navigation(action);
+                    }
+                    KeyOutcome::None
+                }
+            };
+        }
         match input {
+            MouseInput::RightClick { col, row } => {
+                if self.palette_blocked() {
+                    return KeyOutcome::None;
+                }
+                self.click_select(col, row, layout);
+                self.open_palette_menu(Some((col, row)));
+                KeyOutcome::None
+            }
             MouseInput::ScrollUp | MouseInput::ScrollDown => {
                 let action = if matches!(input, MouseInput::ScrollUp) {
                     NavAction::Up
@@ -1297,7 +1355,7 @@ impl AppState {
     /// Open the gist-level manager (`Screen::Gists`), landing on the gist that owns the
     /// selected file row. Resets the manager's own filters first so the target is always
     /// visible. No-op (with a status hint) when there are no gists to manage.
-    fn open_gist_manager(&mut self) {
+    pub(crate) fn open_gist_manager(&mut self) {
         if self.gists.is_empty() {
             self.status = Some("no gists to manage".into());
             return;
@@ -1318,7 +1376,7 @@ impl AppState {
 
     /// Open the Pins view (`Screen::Pins`), resetting its selection/scroll so a stale
     /// filtered-in position from a previous visit never lingers.
-    fn open_pins(&mut self) {
+    pub(crate) fn open_pins(&mut self) {
         self.pins.index = 0;
         self.pins.hscroll = 0;
         self.screen = Screen::Pins;
@@ -1575,6 +1633,6 @@ impl AppState {
 }
 
 /// Whether a column/row position lands inside a `Rect`.
-fn point_in(rect: ratatui::layout::Rect, col: u16, row: u16) -> bool {
+pub(crate) fn point_in(rect: ratatui::layout::Rect, col: u16, row: u16) -> bool {
     col >= rect.x && col < rect.right() && row >= rect.y && row < rect.bottom()
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1849,7 +1849,7 @@ impl AppState {
 /// confirm prompt.
 mod highlight;
 mod palette;
-use palette::{PaletteMode, PaletteState};
+use palette::{PaletteItem, PaletteMode, PaletteState};
 
 mod render;
 use render::*;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -32,6 +32,8 @@ pub enum Screen {
     GistDetail,
     /// Revision history for one gist (entered with `H` from the list, Gist manager, or Gist detail).
     Revisions,
+    /// Unified context menu / command palette overlay (`;` or right-click / `Ctrl+p`).
+    Palette,
 }
 
 /// A help topic — one per key-dense area, plus `About` (version/repo/update info, not tied
@@ -398,7 +400,7 @@ impl PaneHit {
 }
 
 /// Per-frame mouse hit regions, owned by `run_loop`, filled by `render`.
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone)]
 pub struct MouseLayout {
     pub local: Option<PaneHit>,
     pub gist: Option<PaneHit>,
@@ -421,6 +423,9 @@ pub struct MouseLayout {
     pub top_bar_gists: Option<Rect>,
     pub top_bar_pins: Option<Rect>,
     pub top_bar_help: Option<Rect>,
+    /// Palette overlay: one hit-rect per visible row, plus the `[✕]` close button.
+    pub palette_rows: Vec<Rect>,
+    pub palette_close: Option<Rect>,
 }
 
 /// A classified mouse intent handed to the pure `handle_mouse`.
@@ -430,6 +435,7 @@ pub enum MouseInput {
     ScrollDown,
     Click { col: u16, row: u16 },
     DoubleClick { col: u16, row: u16 },
+    RightClick { col: u16, row: u16 },
 }
 
 /// Max gap between two left-clicks on the same cell to count as a double-click.
@@ -670,6 +676,7 @@ pub struct AppState {
     /// Resolved colour palette for the current theme choice (from config).
     pub theme: Theme,
     pub revision: RevisionState,
+    pub palette: PaletteState,
 }
 
 fn unranked_gists(gists: Vec<GistFile>) -> Vec<RankedGistFile> {
@@ -1590,6 +1597,7 @@ pub fn initial_state() -> AppState {
             return_screen: Screen::GistDetail,
             ..Default::default()
         },
+        palette: PaletteState::default(),
     }
 }
 
@@ -1840,6 +1848,9 @@ impl AppState {
 /// This is the shared "centered window" primitive behind both the loading overlay and the
 /// confirm prompt.
 mod highlight;
+mod palette;
+use palette::{PaletteMode, PaletteState};
+
 mod render;
 use render::*;
 mod text;

--- a/src/tui/palette.rs
+++ b/src/tui/palette.rs
@@ -1,0 +1,641 @@
+use super::{keys::point_in, *};
+use crossterm::event::{KeyCode, KeyModifiers};
+
+/// Menu = context-filtered actions near the click; Command = full list + fuzzy query.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PaletteMode {
+    #[default]
+    Menu,
+    Command,
+}
+
+/// How selecting a palette row is executed once the overlay closes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PaletteExec {
+    Key(KeyCode, KeyModifiers),
+    Cross(CrossAction),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CrossAction {
+    GoToGists,
+    GoToPins,
+    OpenHelp,
+    ToggleTheme,
+    Quit,
+}
+
+#[derive(Debug, Clone)]
+pub struct PaletteItem {
+    pub key_hint: String,
+    pub label: String,
+    pub exec: PaletteExec,
+    pub enabled: bool,
+    /// Lowercased key+label string used for fuzzy filtering in command mode.
+    pub search: String,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PaletteState {
+    pub mode: PaletteMode,
+    pub query: TextInput,
+    pub items: Vec<PaletteItem>,
+    pub selected: usize,
+    pub origin_screen: Screen,
+    /// Menu-mode anchor (terminal col, row); command mode leaves this `None`.
+    pub anchor: Option<(u16, u16)>,
+}
+
+impl AppState {
+    /// Whether a global palette opener (`;` / `Ctrl+p`) should be ignored right now.
+    pub(crate) fn palette_blocked(&self) -> bool {
+        self.screen == Screen::Confirm
+            || self.filtering
+            || self.pins.filtering
+            || self.gist_manager.filtering
+            || self.editing_description
+    }
+
+    pub(crate) fn open_palette_menu(&mut self, anchor: Option<(u16, u16)>) {
+        let origin = self.screen;
+        let items = build_palette_items(self, origin, PaletteMode::Menu);
+        if items.is_empty() {
+            self.set_status("no actions available");
+            return;
+        }
+        self.palette = PaletteState {
+            mode: PaletteMode::Menu,
+            items,
+            origin_screen: origin,
+            anchor,
+            ..PaletteState::default()
+        };
+        self.screen = Screen::Palette;
+    }
+
+    pub(crate) fn open_palette_command(&mut self) {
+        let origin = self.screen;
+        let items = build_palette_items(self, origin, PaletteMode::Command);
+        self.palette = PaletteState {
+            mode: PaletteMode::Command,
+            items,
+            origin_screen: origin,
+            ..PaletteState::default()
+        };
+        self.screen = Screen::Palette;
+    }
+
+    pub(crate) fn close_palette(&mut self) {
+        self.screen = self.palette.origin_screen;
+        self.palette = PaletteState::default();
+    }
+
+    /// Visible palette rows after mode-specific filtering and (in command mode) fuzzy query.
+    pub(crate) fn palette_visible_items(&self) -> Vec<&PaletteItem> {
+        let query: &str = &self.palette.query;
+        let mut matched: Vec<(&PaletteItem, u32)> = self
+            .palette
+            .items
+            .iter()
+            .filter_map(|item| {
+                if self.palette.mode == PaletteMode::Menu && !item.enabled {
+                    return None;
+                }
+                fuzzy_match(query, &item.search).map(|score| (item, score))
+            })
+            .collect();
+        if self.palette.mode == PaletteMode::Command && !query.is_empty() {
+            matched.sort_by_key(|item| std::cmp::Reverse(item.1));
+        }
+        matched.into_iter().map(|(item, _)| item).collect()
+    }
+
+    fn palette_clamp_selection(&mut self) {
+        let len = self.palette_visible_items().len();
+        if len == 0 {
+            self.palette.selected = 0;
+        } else if self.palette.selected >= len {
+            self.palette.selected = len - 1;
+        }
+    }
+
+    pub(crate) fn handle_key_palette(
+        &mut self,
+        code: KeyCode,
+        _modifiers: KeyModifiers,
+    ) -> KeyOutcome {
+        if self.palette.mode == PaletteMode::Command {
+            match code {
+                KeyCode::Esc => {
+                    self.close_palette();
+                    return KeyOutcome::None;
+                }
+                KeyCode::Up => {
+                    self.palette.selected = self.palette.selected.saturating_sub(1);
+                    return KeyOutcome::None;
+                }
+                KeyCode::Down => {
+                    let len = self.palette_visible_items().len();
+                    if len > 0 && self.palette.selected + 1 < len {
+                        self.palette.selected += 1;
+                    }
+                    return KeyOutcome::None;
+                }
+                KeyCode::Enter => return self.execute_palette_selection(),
+                _ => {
+                    if let EditResult::Changed = self.palette.query.apply_edit(code) {
+                        self.palette.selected = 0;
+                    }
+                    self.palette_clamp_selection();
+                    return KeyOutcome::None;
+                }
+            }
+        }
+
+        // Menu mode: no query box — arrows pick a row, Enter runs it, Esc closes.
+        match code {
+            KeyCode::Esc | KeyCode::Char(';') => {
+                self.close_palette();
+                KeyOutcome::None
+            }
+            KeyCode::Up => {
+                self.palette.selected = self.palette.selected.saturating_sub(1);
+                KeyOutcome::None
+            }
+            KeyCode::Down => {
+                let len = self.palette_visible_items().len();
+                if len > 0 && self.palette.selected + 1 < len {
+                    self.palette.selected += 1;
+                }
+                KeyOutcome::None
+            }
+            KeyCode::Enter => self.execute_palette_selection(),
+            _ => KeyOutcome::None,
+        }
+    }
+
+    fn execute_palette_selection(&mut self) -> KeyOutcome {
+        let item = self
+            .palette_visible_items()
+            .get(self.palette.selected)
+            .map(|i| (*i).clone());
+        let Some(item) = item else {
+            return KeyOutcome::None;
+        };
+        if !item.enabled {
+            return KeyOutcome::None;
+        }
+        let exec = item.exec;
+        let origin = self.palette.origin_screen;
+        self.close_palette();
+        self.screen = origin;
+        match exec {
+            PaletteExec::Key(code, modifiers) => self.handle_key_with(code, modifiers),
+            PaletteExec::Cross(CrossAction::GoToGists) => {
+                self.open_gist_manager();
+                KeyOutcome::None
+            }
+            PaletteExec::Cross(CrossAction::GoToPins) => {
+                self.open_pins();
+                KeyOutcome::None
+            }
+            PaletteExec::Cross(CrossAction::OpenHelp) => {
+                self.open_help();
+                KeyOutcome::None
+            }
+            PaletteExec::Cross(CrossAction::ToggleTheme) => {
+                self.theme_choice = match self.theme_choice {
+                    crate::config::ThemeChoice::Dark => crate::config::ThemeChoice::Light,
+                    crate::config::ThemeChoice::Light => crate::config::ThemeChoice::Dark,
+                };
+                self.theme = Theme::for_choice(self.theme_choice);
+                KeyOutcome::ThemeToggle
+            }
+            PaletteExec::Cross(CrossAction::Quit) => KeyOutcome::Quit,
+        }
+    }
+
+    pub(crate) fn palette_click(&mut self, col: u16, row: u16, layout: &MouseLayout) -> KeyOutcome {
+        if let Some(rect) = layout.palette_close {
+            if point_in(rect, col, row) {
+                self.close_palette();
+                return KeyOutcome::None;
+            }
+        }
+        for (i, rect) in layout.palette_rows.iter().enumerate() {
+            if point_in(*rect, col, row) {
+                self.palette.selected = i;
+                return self.execute_palette_selection();
+            }
+        }
+        KeyOutcome::None
+    }
+}
+
+fn palette_item(key: &str, label: &str, exec: PaletteExec, enabled: bool) -> PaletteItem {
+    PaletteItem {
+        key_hint: key.to_string(),
+        label: label.to_string(),
+        exec,
+        enabled,
+        search: format!("{key} {label}").to_ascii_lowercase(),
+    }
+}
+
+fn key_item(key: &str, label: &str, code: KeyCode, enabled: bool) -> PaletteItem {
+    palette_item(
+        key,
+        label,
+        PaletteExec::Key(code, KeyModifiers::NONE),
+        enabled,
+    )
+}
+
+fn cross_items() -> Vec<PaletteItem> {
+    vec![
+        palette_item(
+            "g",
+            "Go to Gists",
+            PaletteExec::Cross(CrossAction::GoToGists),
+            true,
+        ),
+        palette_item(
+            "P",
+            "Go to Pins",
+            PaletteExec::Cross(CrossAction::GoToPins),
+            true,
+        ),
+        palette_item(
+            "?",
+            "Go to Help",
+            PaletteExec::Cross(CrossAction::OpenHelp),
+            true,
+        ),
+        palette_item(
+            "T",
+            "Toggle theme",
+            PaletteExec::Cross(CrossAction::ToggleTheme),
+            true,
+        ),
+        palette_item("q", "Quit", PaletteExec::Cross(CrossAction::Quit), true),
+    ]
+}
+
+fn build_palette_items(state: &AppState, screen: Screen, mode: PaletteMode) -> Vec<PaletteItem> {
+    let mut items = match screen {
+        Screen::List => list_palette_items(state),
+        Screen::Pins => pins_palette_items(state),
+        Screen::Gists => gists_palette_items(state),
+        Screen::GistDetail => detail_palette_items(state),
+        Screen::Revisions => revisions_palette_items(state),
+        Screen::Diff => diff_palette_items(state),
+        Screen::Preview => preview_palette_items(state),
+        Screen::Help => help_palette_items(),
+        Screen::Confirm | Screen::Palette => Vec::new(),
+    };
+    if mode == PaletteMode::Command {
+        items.extend(cross_items());
+    }
+    items
+}
+
+fn list_palette_items(state: &AppState) -> Vec<PaletteItem> {
+    let has_gist = state.gist_index < state.ranked_gists().len();
+    let has_local = state.selected_local().is_some();
+    let gist_id = state.selected_gist().map(|g| g.file.gist_id.clone());
+    let owned = gist_id
+        .as_deref()
+        .map(|id| state.gist_is_owned(id))
+        .unwrap_or(false);
+    let gist_file = state.selected_gist().map(|g| g.file.clone());
+    let previewable = gist_file
+        .as_ref()
+        .is_some_and(|f| state.gist_file_is_text_previewable(&f.gist_id, &f.filename));
+    let visible_locals = state.visible_locals();
+    let diffable = gist_file.as_ref().is_some_and(|f| {
+        let local_path = visible_locals
+            .get(state.local_index)
+            .map(|r| r.candidate.path.as_path());
+        diff_pair_previewable(state, &f.gist_id, &f.filename, local_path)
+    });
+    let multi_file = gist_id
+        .as_deref()
+        .map(|id| state.gist_file_count(id) > 1)
+        .unwrap_or(false);
+    let pinned_pair = state
+        .selected_local()
+        .zip(state.selected_gist())
+        .is_some_and(|(local, gist)| {
+            state.pinned.iter().any(|m| {
+                m.local_path == local.path
+                    && m.gist_id == gist.file.gist_id
+                    && m.gist_filename == gist.file.filename
+            })
+        });
+
+    vec![
+        key_item("Enter", "Diff local ↔ gist", KeyCode::Enter, diffable),
+        key_item(
+            "Space",
+            "Preview gist content",
+            KeyCode::Char(' '),
+            previewable,
+        ),
+        key_item(
+            "d",
+            "Download gist → cwd",
+            KeyCode::Char('d'),
+            has_gist && state.focus == FocusPane::Gist,
+        ),
+        key_item(
+            "u",
+            "Upload local → gist",
+            KeyCode::Char('u'),
+            has_local && has_gist && owned,
+        ),
+        key_item("n", "Create gist from local", KeyCode::Char('n'), has_local),
+        key_item(
+            "p",
+            "Pin / unpin pair",
+            KeyCode::Char('p'),
+            has_local && has_gist,
+        ),
+        key_item("P", "Open Pins view", KeyCode::Char('P'), true),
+        key_item(
+            "g",
+            "Open Gist manager",
+            KeyCode::Char('g'),
+            !state.gists.is_empty(),
+        ),
+        key_item(
+            "S",
+            "Smart-sync pinned pair",
+            KeyCode::Char('S'),
+            pinned_pair,
+        ),
+        key_item(
+            "X",
+            "Remove file from gist",
+            KeyCode::Char('X'),
+            has_gist && owned && multi_file,
+        ),
+        key_item("e", "Edit local file", KeyCode::Char('e'), has_local),
+        key_item(
+            "y",
+            "Copy gist URL",
+            KeyCode::Char('y'),
+            state.context_gist_id().is_some(),
+        ),
+        key_item("H", "Revision history", KeyCode::Char('H'), has_gist),
+        key_item(
+            "*",
+            "Star / unstar gist",
+            KeyCode::Char('*'),
+            state.context_gist_id().is_some(),
+        ),
+        key_item("r", "Toggle recursive scan", KeyCode::Char('r'), true),
+        key_item("/", "Filter focused pane", KeyCode::Char('/'), true),
+        key_item("Tab", "Switch pane", KeyCode::Tab, true),
+        key_item("a", "Flip ranking anchor", KeyCode::Char('a'), true),
+        key_item("t", "Toggle description / id", KeyCode::Char('t'), true),
+        key_item("v", "Cycle gist visibility", KeyCode::Char('v'), true),
+        key_item("s", "Cycle pane sort", KeyCode::Char('s'), true),
+        key_item("?", "Help", KeyCode::Char('?'), true),
+    ]
+}
+
+fn pins_palette_items(state: &AppState) -> Vec<PaletteItem> {
+    let has_pin = !state.pinned.is_empty() && state.selected_pin_index().is_some();
+    vec![
+        key_item("Enter", "Diff pinned pair", KeyCode::Enter, has_pin),
+        key_item("s", "Smart-sync", KeyCode::Char('s'), has_pin),
+        key_item("u", "Force push", KeyCode::Char('u'), has_pin),
+        key_item("d", "Force pull", KeyCode::Char('d'), has_pin),
+        key_item("x", "Unpin pair", KeyCode::Char('x'), has_pin),
+        key_item("/", "Filter pins", KeyCode::Char('/'), true),
+        key_item("o", "Cycle sort", KeyCode::Char('o'), true),
+        key_item("q", "Back to list", KeyCode::Char('q'), true),
+        key_item("?", "Help", KeyCode::Char('?'), true),
+    ]
+}
+
+fn gists_palette_items(state: &AppState) -> Vec<PaletteItem> {
+    let groups = state.visible_gist_groups();
+    let has_sel = state.gist_manager.index < groups.len();
+    vec![
+        key_item("Enter", "Open gist detail", KeyCode::Enter, has_sel),
+        key_item("o", "Open in browser", KeyCode::Char('o'), has_sel),
+        key_item("y", "Copy gist URL", KeyCode::Char('y'), has_sel),
+        key_item("H", "Revision history", KeyCode::Char('H'), has_sel),
+        key_item("*", "Star / unstar gist", KeyCode::Char('*'), has_sel),
+        key_item("/", "Filter gists", KeyCode::Char('/'), true),
+        key_item("s", "Cycle sort", KeyCode::Char('s'), true),
+        key_item("v", "Cycle visibility", KeyCode::Char('v'), true),
+        key_item("q", "Back to list", KeyCode::Char('q'), true),
+        key_item("?", "Help", KeyCode::Char('?'), true),
+    ]
+}
+
+fn detail_palette_items(state: &AppState) -> Vec<PaletteItem> {
+    let gist_id = state.detail.gist_id.clone();
+    let owned = gist_id
+        .as_deref()
+        .map(|id| state.gist_is_owned(id))
+        .unwrap_or(false);
+    let on_files = state.detail.focus == DetailFocus::Files;
+    let file_count = gist_id
+        .as_deref()
+        .map(|id| state.gist_filenames(id).len())
+        .unwrap_or(0);
+    let has_file = on_files && state.detail.file_cursor < file_count;
+    let previewable = gist_id.as_ref().is_some_and(|id| {
+        state
+            .gist_filenames(id)
+            .into_iter()
+            .nth(state.detail.file_cursor)
+            .is_some_and(|name| state.gist_file_is_text_previewable(id, &name))
+    }) && has_file;
+    vec![
+        key_item(
+            "Enter",
+            "Preview selected file",
+            KeyCode::Enter,
+            previewable,
+        ),
+        key_item(
+            "o",
+            "Open in browser",
+            KeyCode::Char('o'),
+            gist_id.is_some(),
+        ),
+        key_item("y", "Copy gist URL", KeyCode::Char('y'), gist_id.is_some()),
+        key_item(
+            "H",
+            "Revision history",
+            KeyCode::Char('H'),
+            gist_id.is_some(),
+        ),
+        key_item("e", "Edit description", KeyCode::Char('e'), owned),
+        key_item("c", "Compact revisions", KeyCode::Char('c'), owned),
+        key_item(
+            "*",
+            "Star / unstar gist",
+            KeyCode::Char('*'),
+            gist_id.is_some(),
+        ),
+        key_item(
+            "F",
+            "Fork gist",
+            KeyCode::Char('F'),
+            gist_id.is_some() && !owned,
+        ),
+        key_item("X", "Delete gist", KeyCode::Char('X'), owned),
+        key_item("Tab", "Switch Files / Comments", KeyCode::Tab, true),
+        key_item(
+            "m",
+            "Load older comments",
+            KeyCode::Char('m'),
+            state.can_load_older_comments(),
+        ),
+        key_item("q", "Back to Gist manager", KeyCode::Char('q'), true),
+        key_item("?", "Help", KeyCode::Char('?'), true),
+    ]
+}
+
+fn revisions_palette_items(state: &AppState) -> Vec<PaletteItem> {
+    let entries_len = state
+        .revision
+        .entries
+        .as_ref()
+        .map(|e| e.len())
+        .unwrap_or(0);
+    let has_entries = entries_len > 0;
+    let not_head = state.revision.index > 0;
+    let gist_id = state.revision.gist_id.clone();
+    let owned = gist_id
+        .as_deref()
+        .map(|id| state.gist_is_owned(id))
+        .unwrap_or(false);
+    let file = state.revision.target_file.clone();
+    let previewable = gist_id
+        .as_ref()
+        .is_some_and(|id| state.gist_file_is_text_previewable(id, &file));
+    vec![
+        key_item(
+            "Enter",
+            "Diff parent → revision",
+            KeyCode::Enter,
+            has_entries && previewable,
+        ),
+        key_item(
+            "D",
+            "Diff revision vs head",
+            KeyCode::Char('D'),
+            has_entries && not_head && previewable,
+        ),
+        key_item(
+            "r",
+            "Restore revision",
+            KeyCode::Char('r'),
+            entries_len > 1 && not_head && owned,
+        ),
+        key_item("F", "Cycle target file", KeyCode::Char('F'), has_entries),
+        key_item("q", "Back", KeyCode::Char('q'), true),
+        key_item("?", "Help", KeyCode::Char('?'), true),
+    ]
+}
+
+fn diff_palette_items(state: &AppState) -> Vec<PaletteItem> {
+    let sync = state.diff_allows_sync() && !state.diff_identical;
+    vec![
+        key_item("d", "Download", KeyCode::Char('d'), sync),
+        key_item("u", "Upload", KeyCode::Char('u'), sync),
+        key_item("c", "Toggle full diff context", KeyCode::Char('c'), true),
+        key_item("w", "Toggle line wrap", KeyCode::Char('w'), true),
+        key_item("q", "Back", KeyCode::Char('q'), true),
+    ]
+}
+
+fn preview_palette_items(_state: &AppState) -> Vec<PaletteItem> {
+    vec![
+        key_item("R", "Refresh content", KeyCode::Char('R'), true),
+        key_item("w", "Toggle line wrap", KeyCode::Char('w'), true),
+        key_item("y", "Copy gist URL", KeyCode::Char('y'), true),
+        key_item("Y", "Copy file content", KeyCode::Char('Y'), true),
+        key_item("q", "Back", KeyCode::Char('q'), true),
+    ]
+}
+
+fn help_palette_items() -> Vec<PaletteItem> {
+    vec![
+        key_item("Tab", "Browse topic index", KeyCode::Tab, true),
+        key_item("q", "Close Help", KeyCode::Char('q'), true),
+    ]
+}
+
+fn diff_pair_previewable(
+    state: &AppState,
+    gist_id: &str,
+    filename: &str,
+    local_path: Option<&std::path::Path>,
+) -> bool {
+    if !state.gist_file_is_text_previewable(gist_id, filename) {
+        return false;
+    }
+    if let Some(path) = local_path {
+        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+            if !crate::domain::gist_file_is_text_previewable(name, None) {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// Subsequence fuzzy match: every query char must appear in order in `target`.
+/// Returns a higher score for tighter matches (used to sort command-mode results).
+pub(crate) fn fuzzy_match(query: &str, target: &str) -> Option<u32> {
+    let q = query.trim().to_ascii_lowercase();
+    if q.is_empty() {
+        return Some(0);
+    }
+    let t = target.to_ascii_lowercase();
+    let q_chars: Vec<char> = q.chars().collect();
+    let mut qi = 0usize;
+    let mut score = 0u32;
+    let mut prev_match: Option<usize> = None;
+    for (ti, tc) in t.chars().enumerate() {
+        if qi < q_chars.len() && tc == q_chars[qi] {
+            score += 10;
+            if ti > 0 && prev_match == Some(ti - 1) {
+                score += 5;
+            }
+            if ti == 0 || t.chars().nth(ti.saturating_sub(1)) == Some(' ') {
+                score += 3;
+            }
+            prev_match = Some(ti);
+            qi += 1;
+        }
+    }
+    if qi == q_chars.len() {
+        Some(score)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fuzzy_match_empty_query_matches_all() {
+        assert_eq!(fuzzy_match("", "download gist"), Some(0));
+    }
+
+    #[test]
+    fn fuzzy_match_subsequence() {
+        assert!(fuzzy_match("dl", "d download gist").is_some());
+        assert!(fuzzy_match("xyz", "download gist").is_none());
+    }
+}

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -20,6 +20,7 @@ pub(super) fn render(frame: &mut Frame, state: &AppState, layout: &mut MouseLayo
         frame.area(),
     );
     match state.screen {
+        Screen::Palette => render_palette(frame, state, layout),
         Screen::List => render_list(frame, state, layout),
         Screen::Diff => render_diff(frame, state, layout),
         Screen::Confirm => render_confirm(frame, state, layout),
@@ -180,7 +181,9 @@ Mouse (on by default; disable with mouse = false in config or --no-mouse)
   Dbl-click  open the clicked row (diff / detail / pin diff / preview)
   Tab click  switch Files / Comments on the Gist details screen
   [✕] btn    close / go back on any pop-up screen
-  Top bar    click (G)ists / (P)ins / (?)Help (top-right, every screen) to jump there"
+  Top bar    click (G)ists / (P)ins / (?)Help (top-right, every screen) to jump there
+  Right-click  open the context menu at the click (same as ;)
+  ; / Ctrl+p   open the menu / command palette from the keyboard (see General)"
         }
         HelpTopic::Pins => {
             "\
@@ -286,6 +289,8 @@ Mouse (on by default; disable with mouse = false in config or --no-mouse)
             "\
   Esc / q    close an overlay; from the list, press twice to quit the app
   ?          show this help
+  ;          context menu (actions valid for the current screen + selection)
+  Ctrl+p     command palette (all actions + cross-screen navigation; type to filter)
   T          toggle light/dark colour theme (saved to config)
   Up/Down    scroll this help text
   NO_COLOR   set this env var to disable syntax highlighting (preview + diff)"
@@ -1348,11 +1353,8 @@ pub(super) fn render_gist_comments(
     render_text_scrollbar(frame, area, total_lines, state.detail.scroll as usize);
 }
 
-/// The default (idle) footer hint. Empty in Phase 1: the `(?)Help` shortcut in the
-/// top bar (see `render_top_bar`) already covers Help discoverability, so repeating it
-/// here would be a duplicate. Phase 3/4 of the TUI UX redesign will populate this with
-/// `; Menu` and `Ctrl+p Palette` once those features exist.
-pub(super) const MINIMAL_HINT: &str = "";
+/// The default (idle) footer hint on screens that used to show a long per-screen key dump.
+pub(super) const MINIMAL_HINT: &str = "; Menu · Ctrl+p Palette";
 
 /// Footer text + whether to colourise it: a one-shot `state.status` message (shown plain) when
 /// present, else the colourised key `hints`. Shared by every screen so action results/errors
@@ -2592,6 +2594,120 @@ const SPINNER_FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "�
 /// frame count.
 pub(super) fn spinner_glyph(frame: usize) -> &'static str {
     SPINNER_FRAMES[frame % SPINNER_FRAMES.len()]
+}
+
+/// The unified context menu / command palette drawn over the screen it was opened from.
+fn render_palette(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout) {
+    let mut bg_layout = MouseLayout::default();
+    match state.palette.origin_screen {
+        Screen::List => render_list(frame, state, &mut bg_layout),
+        Screen::Diff => render_diff(frame, state, &mut bg_layout),
+        Screen::Preview => render_preview(frame, state, &mut bg_layout),
+        Screen::Help => render_help(frame, state, &mut bg_layout),
+        Screen::Pins => render_pins(frame, state, &mut bg_layout),
+        Screen::Gists => render_gists(frame, state, &mut bg_layout),
+        Screen::GistDetail => render_gist_detail(frame, state, &mut bg_layout),
+        Screen::Revisions => render_revisions(frame, state, &mut bg_layout),
+        Screen::Confirm | Screen::Palette => {}
+    }
+
+    let area = frame.area();
+    let visible = state.palette_visible_items();
+    let has_query = state.palette.mode == PaletteMode::Command;
+    let title = match state.palette.mode {
+        PaletteMode::Menu => "Menu",
+        PaletteMode::Command => "Command palette",
+    };
+    let row_texts: Vec<String> = if visible.is_empty() {
+        vec!["  (no matches)".to_string()]
+    } else {
+        visible
+            .iter()
+            .map(|item| format!("  {:<3} {}", item.key_hint, item.label))
+            .collect()
+    };
+    let body_lines = row_texts.len() + usize::from(has_query);
+    let width = if has_query {
+        (area.width * 70 / 100).clamp(28, area.width.saturating_sub(2).max(1))
+    } else {
+        (area.width * 45 / 100).clamp(24, area.width.saturating_sub(2).max(1))
+    };
+    let max_h = area.height.saturating_sub(2).max(1) as usize;
+    let height = (body_lines + 2).clamp(3, max_h) as u16;
+    let (x, y) = match (state.palette.mode, state.palette.anchor) {
+        (PaletteMode::Menu, Some((col, row))) => (
+            col.saturating_sub(width / 2)
+                .min(area.width.saturating_sub(width)),
+            row.saturating_sub(1)
+                .min(area.height.saturating_sub(height)),
+        ),
+        _ => (
+            area.width.saturating_sub(width) / 2,
+            area.height.saturating_sub(height).saturating_sub(1),
+        ),
+    };
+    let rect = Rect::new(x, y, width, height);
+
+    frame.render_widget(Clear, rect);
+
+    layout.palette_rows.clear();
+    let dim = Style::default().fg(state.theme.dim);
+    let active = Style::default()
+        .fg(state.theme.fg_on_accent)
+        .bg(state.theme.accent)
+        .add_modifier(Modifier::BOLD);
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    if has_query {
+        lines.push(input_line("> ", &state.palette.query, ""));
+    }
+    if visible.is_empty() {
+        lines.push(Line::from(Span::styled("  (no matches)", dim)));
+    } else {
+        for (i, item) in visible.iter().enumerate() {
+            let row_style = if i == state.palette.selected {
+                active
+            } else if item.enabled {
+                state.theme.base_style()
+            } else {
+                Style::default().fg(state.theme.dim)
+            };
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("  {:<3}", item.key_hint),
+                    Style::default().fg(action_color(&item.label, &state.theme)),
+                ),
+                Span::styled(item.label.clone(), row_style),
+            ]));
+        }
+    }
+    frame.render_widget(
+        Paragraph::new(lines).style(state.theme.base_style()).block(
+            Block::default()
+                .title(title)
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(Style::default().fg(state.theme.accent))
+                .style(state.theme.base_style()),
+        ),
+        rect,
+    );
+
+    let inner = rect.inner(Margin::new(1, 1));
+    let mut y = inner.y + u16::from(has_query);
+    for item in visible.iter() {
+        if y >= inner.bottom() {
+            break;
+        }
+        if state.mouse_enabled && item.enabled {
+            layout
+                .palette_rows
+                .push(Rect::new(inner.x, y, inner.width, 1));
+        }
+        y = y.saturating_add(1);
+    }
+    if state.mouse_enabled {
+        layout.palette_close = Some(render_close_button(frame, rect, &state.theme));
+    }
 }
 
 /// A centered "Working…" box shown while a blocking `gh` action runs.

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -477,7 +477,7 @@ pub(super) fn render_preview(frame: &mut Frame, state: &AppState, layout: &mut M
     let footer_lines = wrap_line_count(&footer, area.width.saturating_sub(2)).max(1);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Min(5), Constraint::Length(footer_lines + 1)])
+        .constraints([Constraint::Min(5), Constraint::Length(footer_lines)])
         .split(area);
 
     // When wrapping, horizontal scroll is meaningless — pin the x offset to 0 so long lines
@@ -950,7 +950,7 @@ pub(super) fn render_revisions(frame: &mut Frame, state: &AppState, layout: &mut
     let footer_lines = wrap_line_count(&footer, area.width.saturating_sub(2)).max(1);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Min(3), Constraint::Length(footer_lines + 1)])
+        .constraints([Constraint::Min(3), Constraint::Length(footer_lines)])
         .split(area);
 
     let gist_id = state.revision.gist_id.as_deref().unwrap_or("");
@@ -1565,15 +1565,14 @@ pub(super) fn wrap_line_count(text: &str, width: u16) -> u16 {
 }
 
 /// Height to reserve for a screen's footer `Layout` row: `0` when `text` is empty (the footer
-/// fully collapses — no divider, no blank row — reclaiming the space for content above it) or
-/// the wrapped line count plus one (for the divider) otherwise. Screens whose footer always has
-/// real content (Diff, Preview) don't need this — only the ones whose idle state can be
-/// genuinely empty (`MINIMAL_HINT`) call it.
+/// fully collapses, reclaiming the space for content above it) or the wrapped line count
+/// otherwise. Screens whose footer always has real content (Diff, Preview) inline the same
+/// `wrap_line_count` math in their layout constraints.
 pub(super) fn footer_height(text: &str, width: u16) -> u16 {
     if text.is_empty() {
         0
     } else {
-        wrap_line_count(text, width.saturating_sub(2)).max(1) + 1
+        wrap_line_count(text, width.saturating_sub(2)).max(1)
     }
 }
 
@@ -1634,22 +1633,14 @@ pub(super) fn hint_line(text: &str, theme: &Theme) -> Line<'static> {
     Line::from(spans)
 }
 
-/// The shared footer block: a dim top divider that carries the left `title` (the filter-input
-/// label while filtering; empty otherwise), shown only when there's something to divide from
-/// (`show_divider`) — an idle footer with no status/hint text renders with no border at all,
-/// rather than a stray horizontal rule above nothing. The repo URL, app version, and
-/// update-check status used to live here (via `title` and a right-aligned repo span) but have
-/// moved to the Help → About topic (see `about_topic_lines`).
-pub(super) fn footer_block(title: &str, theme: &Theme, show_divider: bool) -> Block<'static> {
-    let borders = if show_divider {
-        Borders::TOP
-    } else {
-        Borders::NONE
-    };
+/// The shared footer block: plain text with horizontal padding, no border (the old dim top
+/// divider was removed to reclaim a row and keep the chrome minimal). The repo URL, app
+/// version, and update-check status used to live in the footer but have moved to Help → About
+/// (see `about_topic_lines`).
+pub(super) fn footer_block(title: &str, theme: &Theme) -> Block<'static> {
     Block::default()
         .title(title.to_string())
-        .borders(borders)
-        .border_style(Style::default().fg(theme.dim))
+        .borders(Borders::NONE)
         .style(theme.base_style())
         .padding(Padding::horizontal(1))
 }
@@ -1673,14 +1664,13 @@ pub(super) fn render_footer(
     frame.render_widget(
         para.style(theme.base_style())
             .wrap(Wrap { trim: true })
-            .block(footer_block(title, theme, !text.is_empty())),
+            .block(footer_block(title, theme)),
         area,
     );
 }
 
 /// Like [`render_footer`] but draws a prebuilt styled `line`, used for active text inputs
-/// so the cursor can be reverse-highlighted at its real position. Always shows the divider —
-/// unlike `render_footer`'s idle case, an active text input is never blank.
+/// so the cursor can be reverse-highlighted at its real position.
 pub(super) fn render_footer_line(
     frame: &mut Frame,
     area: Rect,
@@ -1693,7 +1683,7 @@ pub(super) fn render_footer_line(
         Paragraph::new(line)
             .style(theme.base_style())
             .wrap(Wrap { trim: true })
-            .block(footer_block(title, theme, true)),
+            .block(footer_block(title, theme)),
         area,
     );
 }
@@ -2460,7 +2450,7 @@ pub(super) fn render_diff(frame: &mut Frame, state: &AppState, layout: &mut Mous
     let footer_lines = wrap_line_count(&footer, area.width.saturating_sub(2)).max(1);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Min(5), Constraint::Length(footer_lines + 1)])
+        .constraints([Constraint::Min(5), Constraint::Length(footer_lines)])
         .split(area);
 
     render_diff_pane(frame, chunks[0], state);

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -541,7 +541,7 @@ pub(super) fn render_pins(frame: &mut Frame, state: &AppState, layout: &mut Mous
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Min(3),
-            Constraint::Length(footer_height(&footer, area.width)),
+            Constraint::Length(footer_height(&footer, area.width, &ftitle)),
         ])
         .split(area);
 
@@ -756,7 +756,7 @@ pub(super) fn render_gists(frame: &mut Frame, state: &AppState, layout: &mut Mou
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Min(3),
-            Constraint::Length(footer_height(&footer, area.width)),
+            Constraint::Length(footer_height(&footer, area.width, &ftitle)),
         ])
         .split(area);
 
@@ -1412,7 +1412,7 @@ pub(super) fn render_gist_detail(frame: &mut Frame, state: &AppState, layout: &m
         .constraints([
             Constraint::Length(4),
             Constraint::Min(3),
-            Constraint::Length(footer_height(&footer, area.width)),
+            Constraint::Length(footer_height(&footer, area.width, "")),
         ])
         .split(area);
     if let Some(id) = state.detail.gist_id.as_deref() {
@@ -1564,16 +1564,19 @@ pub(super) fn wrap_line_count(text: &str, width: u16) -> u16 {
     lines
 }
 
-/// Height to reserve for a screen's footer `Layout` row: `0` when `text` is empty (the footer
-/// fully collapses, reclaiming the space for content above it) or the wrapped line count
-/// otherwise. Screens whose footer always has real content (Diff, Preview) inline the same
-/// `wrap_line_count` math in their layout constraints.
-pub(super) fn footer_height(text: &str, width: u16) -> u16 {
-    if text.is_empty() {
+/// Height to reserve for a screen's footer `Layout` row: `0` when both `text` and `title` are
+/// empty (the footer fully collapses), else the wrapped line count for `text` plus one row when
+/// `title` is non-empty (ratatui's [`Block::title`] always consumes a row, even without borders).
+pub(super) fn footer_height(text: &str, width: u16, title: &str) -> u16 {
+    if text.is_empty() && title.is_empty() {
+        return 0;
+    }
+    let content = if text.is_empty() {
         0
     } else {
         wrap_line_count(text, width.saturating_sub(2)).max(1)
-    }
+    };
+    content + u16::from(!title.is_empty())
 }
 
 /// Colour a command key by what its action does, so destructive and mutating keys stand apart
@@ -1638,11 +1641,16 @@ pub(super) fn hint_line(text: &str, theme: &Theme) -> Line<'static> {
 /// version, and update-check status used to live in the footer but have moved to Help → About
 /// (see `about_topic_lines`).
 pub(super) fn footer_block(title: &str, theme: &Theme) -> Block<'static> {
-    Block::default()
-        .title(title.to_string())
+    let mut block = Block::default()
         .borders(Borders::NONE)
         .style(theme.base_style())
-        .padding(Padding::horizontal(1))
+        .padding(Padding::horizontal(1));
+    // ratatui treats even an empty `.title("")` as a top title row, which would leave zero
+    // inner height when the footer chunk is only one row tall — see `Block::inner`.
+    if !title.is_empty() {
+        block = block.title(title.to_string());
+    }
+    block
 }
 
 /// Render a command footer into `area`. `colored` accents the command keys; pass `false` for
@@ -1739,7 +1747,7 @@ pub(super) fn render_list(frame: &mut Frame, state: &AppState, layout: &mut Mous
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Min(5),
-            Constraint::Length(footer_height(&footer_body, area.width)),
+            Constraint::Length(footer_height(&footer_body, area.width, "")),
         ])
         .split(area);
     let columns = Layout::default()

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -2594,6 +2594,32 @@ pub(super) fn spinner_glyph(frame: usize) -> &'static str {
     SPINNER_FRAMES[frame % SPINNER_FRAMES.len()]
 }
 
+/// Column width for palette key hints: at least one char, wide enough for the longest
+/// visible key (`Enter`, `Ctrl+p`, …) so labels never run into the hint.
+pub(super) fn palette_key_width(items: &[&PaletteItem]) -> usize {
+    items
+        .iter()
+        .map(|item| item.key_hint.chars().count())
+        .max()
+        .unwrap_or(1)
+}
+
+/// One palette row: indented key column + gap + label. Pure for unit tests.
+pub(super) fn palette_row_line(
+    item: &PaletteItem,
+    key_width: usize,
+    theme: &Theme,
+    row_style: Style,
+) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            format!("  {:<key_width$}  ", item.key_hint, key_width = key_width),
+            Style::default().fg(action_color(&item.label, theme)),
+        ),
+        Span::styled(item.label.clone(), row_style),
+    ])
+}
+
 /// The unified context menu / command palette drawn over the screen it was opened from.
 fn render_palette(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout) {
     let mut bg_layout = MouseLayout::default();
@@ -2616,19 +2642,22 @@ fn render_palette(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout)
         PaletteMode::Menu => "Menu",
         PaletteMode::Command => "Command palette",
     };
-    let row_texts: Vec<String> = if visible.is_empty() {
-        vec!["  (no matches)".to_string()]
-    } else {
-        visible
-            .iter()
-            .map(|item| format!("  {:<3} {}", item.key_hint, item.label))
-            .collect()
-    };
-    let body_lines = row_texts.len() + usize::from(has_query);
+    let key_width = palette_key_width(&visible);
+    let body_lines = visible.len() + usize::from(has_query);
+    let longest_row = visible
+        .iter()
+        .map(|item| 2 + key_width + 2 + item.label.chars().count());
+    let content_width = longest_row.max().unwrap_or(20) as u16;
     let width = if has_query {
-        (area.width * 70 / 100).clamp(28, area.width.saturating_sub(2).max(1))
+        (area.width * 70 / 100).clamp(
+            content_width.saturating_add(4),
+            area.width.saturating_sub(2).max(1),
+        )
     } else {
-        (area.width * 45 / 100).clamp(24, area.width.saturating_sub(2).max(1))
+        (area.width * 45 / 100).clamp(
+            content_width.saturating_add(4),
+            area.width.saturating_sub(2).max(1),
+        )
     };
     let max_h = area.height.saturating_sub(2).max(1) as usize;
     let height = (body_lines + 2).clamp(3, max_h) as u16;
@@ -2669,13 +2698,7 @@ fn render_palette(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout)
             } else {
                 Style::default().fg(state.theme.dim)
             };
-            lines.push(Line::from(vec![
-                Span::styled(
-                    format!("  {:<3}", item.key_hint),
-                    Style::default().fg(action_color(&item.label, &state.theme)),
-                ),
-                Span::styled(item.label.clone(), row_style),
-            ]));
+            lines.push(palette_row_line(item, key_width, &state.theme, row_style));
         }
     }
     frame.render_widget(

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -103,6 +103,12 @@ pub(super) fn run_loop(
                         last_click = Some((m.column, m.row, std::time::Instant::now()));
                         Some(classified)
                     }
+                    MouseEventKind::Down(MouseButton::Right) => {
+                        Some(super::MouseInput::RightClick {
+                            col: m.column,
+                            row: m.row,
+                        })
+                    }
                     _ => None,
                 };
                 match input {

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1322,10 +1322,10 @@ fn wrap_line_count_is_responsive_to_width() {
 }
 
 #[test]
-fn footer_height_collapses_to_zero_when_empty_else_wraps_plus_divider() {
+fn footer_height_collapses_to_zero_when_empty_else_wraps() {
     assert_eq!(footer_height("", 100), 0);
-    assert_eq!(footer_height("? Help", 100), 2); // 1 wrapped line + 1 divider row
-    assert_eq!(footer_height("aaa bbb ccc", 9), 3); // 2 wrapped lines (width-2=7) + 1 divider row
+    assert_eq!(footer_height("? Help", 100), 1);
+    assert_eq!(footer_height("aaa bbb ccc", 9), 2); // 2 wrapped lines at inner width 7
 }
 
 #[test]

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crossterm::event::KeyCode;
+use crossterm::event::{KeyCode, KeyModifiers};
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier};
 use std::path::PathBuf;
@@ -1329,10 +1329,10 @@ fn footer_height_collapses_to_zero_when_empty_else_wraps_plus_divider() {
 }
 
 #[test]
-fn minimal_hint_is_empty_when_idle() {
-    assert_eq!(MINIMAL_HINT, "");
+fn minimal_hint_shows_menu_and_palette_shortcuts() {
+    assert_eq!(MINIMAL_HINT, "; Menu · Ctrl+p Palette");
     let (hint, colored) = footer_with_status(None, MINIMAL_HINT);
-    assert_eq!(hint, "");
+    assert_eq!(hint, "; Menu · Ctrl+p Palette");
     assert!(colored);
     let (status, colored) = footer_with_status(Some("Downloaded file.txt"), MINIMAL_HINT);
     assert_eq!(status, "Downloaded file.txt");
@@ -5473,4 +5473,92 @@ fn m_key_noop_when_at_oldest_page() {
     );
     let out = s.handle_key(KeyCode::Char('m'));
     assert!(matches!(out, KeyOutcome::None));
+}
+
+// ── palette tests ─────────────────────────────────────────────────────────────
+
+#[test]
+fn semicolon_opens_menu_palette() {
+    let mut state = crate::tui::initial_state();
+    state.handle_key(KeyCode::Char(';'));
+    assert_eq!(state.screen, Screen::Palette);
+    assert_eq!(state.palette.mode, crate::tui::palette::PaletteMode::Menu);
+    assert_eq!(state.palette.origin_screen, Screen::List);
+}
+
+#[test]
+fn ctrl_p_opens_command_palette() {
+    let mut state = crate::tui::initial_state();
+    state.handle_key_with(KeyCode::Char('p'), KeyModifiers::CONTROL);
+    assert_eq!(state.screen, Screen::Palette);
+    assert_eq!(
+        state.palette.mode,
+        crate::tui::palette::PaletteMode::Command
+    );
+}
+
+#[test]
+fn palette_esc_returns_to_origin() {
+    let mut state = crate::tui::initial_state();
+    state.screen = Screen::Pins;
+    state.open_palette_menu(None);
+    assert_eq!(state.screen, Screen::Palette);
+    state.handle_key(KeyCode::Esc);
+    assert_eq!(state.screen, Screen::Pins);
+}
+
+#[test]
+fn menu_palette_hides_disabled_actions() {
+    let mut state = crate::tui::initial_state();
+    state.open_palette_menu(None);
+    let labels: Vec<_> = state
+        .palette_visible_items()
+        .iter()
+        .map(|i| i.label.as_str())
+        .collect();
+    assert!(!labels.iter().any(|l| l.contains("Upload")));
+}
+
+#[test]
+fn command_palette_includes_cross_screen_quit() {
+    let mut state = crate::tui::initial_state();
+    state.open_palette_command();
+    assert!(state
+        .palette_visible_items()
+        .iter()
+        .any(|i| i.label == "Quit"));
+}
+
+#[test]
+fn command_palette_fuzzy_filter_narrows_items() {
+    let mut state = crate::tui::initial_state();
+    state.open_palette_command();
+    let before = state.palette_visible_items().len();
+    state.palette.query.set("quit");
+    let after = state.palette_visible_items().len();
+    assert!(after < before);
+    assert!(state
+        .palette_visible_items()
+        .iter()
+        .all(|i| i.label.to_ascii_lowercase().contains("quit")));
+}
+
+#[test]
+fn right_click_opens_menu_palette() {
+    let mut state = crate::tui::initial_state();
+    let out = state.handle_mouse(
+        MouseInput::RightClick { col: 10, row: 5 },
+        &MouseLayout::default(),
+    );
+    assert_eq!(out, KeyOutcome::None);
+    assert_eq!(state.screen, Screen::Palette);
+    assert_eq!(state.palette.anchor, Some((10, 5)));
+}
+
+#[test]
+fn palette_blocked_during_confirm() {
+    let mut state = crate::tui::initial_state();
+    state.screen = Screen::Confirm;
+    state.handle_key(KeyCode::Char(';'));
+    assert_eq!(state.screen, Screen::Confirm);
 }

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1323,9 +1323,10 @@ fn wrap_line_count_is_responsive_to_width() {
 
 #[test]
 fn footer_height_collapses_to_zero_when_empty_else_wraps() {
-    assert_eq!(footer_height("", 100), 0);
-    assert_eq!(footer_height("? Help", 100), 1);
-    assert_eq!(footer_height("aaa bbb ccc", 9), 2); // 2 wrapped lines at inner width 7
+    assert_eq!(footer_height("", 100, ""), 0);
+    assert_eq!(footer_height("? Help", 100, ""), 1);
+    assert_eq!(footer_height("aaa bbb ccc", 9, ""), 2); // 2 wrapped lines at inner width 7
+    assert_eq!(footer_height("/x_", 100, "Filter"), 2); // title row + 1 content line
 }
 
 #[test]

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crossterm::event::{KeyCode, KeyModifiers};
 use ratatui::layout::Rect;
-use ratatui::style::{Color, Modifier};
+use ratatui::style::{Color, Modifier, Style};
 use std::path::PathBuf;
 
 fn state_with_gists() -> AppState {
@@ -5554,6 +5554,26 @@ fn right_click_opens_menu_palette() {
     assert_eq!(out, KeyOutcome::None);
     assert_eq!(state.screen, Screen::Palette);
     assert_eq!(state.palette.anchor, Some((10, 5)));
+}
+
+#[test]
+fn palette_row_line_aligns_long_keys() {
+    let item = PaletteItem {
+        key_hint: "Enter".to_string(),
+        label: "Diff local ↔ gist".to_string(),
+        exec: crate::tui::palette::PaletteExec::Key(KeyCode::Enter, KeyModifiers::NONE),
+        enabled: true,
+        search: String::new(),
+    };
+    let line = palette_row_line(
+        &item,
+        palette_key_width(&[&item]),
+        &Theme::DARK,
+        Style::default(),
+    );
+    let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+    assert!(text.starts_with("  Enter  Diff"));
+    assert!(!text.contains("EnterDiff"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Completes **#216** phases 3 and 4: a unified `Screen::Palette` overlay with two entry points.

- **`;` / right-click** — context menu (menu mode): pre-filtered to actions valid for the current screen + selection, anchored near the click.
- **`Ctrl+p`** — command palette (command mode): all action verbs for the current screen plus cross-screen navigation (`Go to Pins`, `Go to Gists`, `Toggle theme`, `Quit`, …) with fuzzy-filter search.
- Idle footer now hints `; Menu · Ctrl+p Palette`.

Keyboard shortcuts are unchanged; palette/menu layers are additive discoverability only. `mouse = false` / `--no-mouse` remains fully usable via `;` and `Ctrl+p`.

Closes #216 (phases 3–4).

## Test plan

- [x] `mise run check` (fmt, clippy, 487 unit tests, cargo check)
- [x] `;` opens menu on List; disabled actions (e.g. Upload with no selection) hidden
- [x] `Ctrl+p` opens command palette; typing `quit` narrows to Quit
- [x] Right-click opens menu at click position
- [x] `Esc` closes palette and returns to origin screen
- [x] Palette blocked on `Screen::Confirm` and during filter/description input

## Docs

- `README.md` (Actions / Mouse)
- `?` Help (General + List mouse)
- `CHANGELOG.md` `[Unreleased]`