### PR TITLE
perf(tui): compute ranked lists once per list action (#224)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- List navigation, palette enablement, and the dual-pane render build each ranked file list at most once per action (smoother with large gist/local sets).
 - Cancelled or superseded background tasks (and overlapping local file scans) no longer apply their results if they finish late.
 - Preview, diff, and upload refuse text larger than 10 MiB with a status message instead of loading the whole buffer into memory.
 - Startup fetches for owned gists, starred gists, and the current user run in parallel, so cold start is faster on large accounts.

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -1181,19 +1181,28 @@ impl AppState {
             KeyCode::Char('P') => self.open_pins(),
             KeyCode::Char('S') => return KeyOutcome::SyncSelectedPair,
             KeyCode::Char('g') => self.open_gist_manager(),
-            KeyCode::Char('H') if self.gist_index < self.ranked_gists().len() => {
-                if self.open_revisions(Screen::List) {
+            KeyCode::Char('H') => {
+                let (_, ranked) = self.list_pane_snapshots();
+                if ranked.get(self.gist_index).is_none() {
+                    self.status = Some("select a gist file to view revision history".into());
+                } else if self.open_revisions(Screen::List) {
                     return KeyOutcome::FetchRevisions;
+                } else {
+                    self.status = Some("select a gist file to view revision history".into());
                 }
-                self.status = Some("select a gist file to view revision history".into());
             }
             KeyCode::Char('e') => {
-                if self.selected_local().is_some() {
+                let (locals, _) = self.list_pane_snapshots();
+                if locals.get(self.local_index).is_some() {
                     return KeyOutcome::EditLocal;
                 }
                 self.status = Some("select a local file to edit".into());
             }
-            KeyCode::Char(' ') if let Some(gist) = self.selected_gist() => {
+            KeyCode::Char(' ') => {
+                let (_, ranked) = self.list_pane_snapshots();
+                let Some(gist) = ranked.get(self.gist_index) else {
+                    return KeyOutcome::None;
+                };
                 if self.block_if_non_previewable_gist_file(&gist.file.gist_id, &gist.file.filename)
                 {
                     return KeyOutcome::None;
@@ -1201,22 +1210,21 @@ impl AppState {
                 self.preview_return = Screen::List;
                 return KeyOutcome::PreviewContent;
             }
-            KeyCode::Char('d')
-                if self.focus == FocusPane::Gist && self.gist_index < self.ranked_gists().len() =>
-            {
-                return KeyOutcome::DownloadGist;
+            KeyCode::Char('d') if self.focus == FocusPane::Gist => {
+                let (_, ranked) = self.list_pane_snapshots();
+                if ranked.get(self.gist_index).is_some() {
+                    return KeyOutcome::DownloadGist;
+                }
             }
             // Enter works from either pane: it diffs the selected local file against the
             // selected gist (the top match when focus is on the local pane). Snapshot both
-            // ranked lists once here instead of recomputing them through the bounds guard plus
-            // `selected_gist`/`selected_local` (perf-1, #154).
+            // ranked lists once (issue #224 / #154 shape #1).
             KeyCode::Enter => {
-                let ranked = self.ranked_gists();
+                let (locals, ranked) = self.list_pane_snapshots();
                 let Some(gist) = ranked.get(self.gist_index) else {
                     return KeyOutcome::None;
                 };
-                let local_path = self
-                    .visible_locals()
+                let local_path = locals
                     .get(self.local_index)
                     .map(|r| r.candidate.path.clone());
                 if self.block_if_non_previewable_diff(
@@ -1255,9 +1263,12 @@ impl AppState {
     /// Page the focused list-pane selection by [`PAGE_SCROLL`] rows (clamped at bounds).
     fn list_page_focused(&mut self, forward: bool) {
         let step = PAGE_SCROLL as usize;
+        // One snapshot for the focused pane length (issue #224) — selection-index
+        // changes do not alter list length, so this is safe.
+        let (locals, ranked) = self.list_pane_snapshots();
         match self.focus {
             FocusPane::Local => {
-                let len = self.visible_locals().len();
+                let len = locals.len();
                 if len == 0 {
                     return;
                 }
@@ -1273,7 +1284,7 @@ impl AppState {
                 }
             }
             FocusPane::Gist => {
-                let len = self.ranked_gists().len();
+                let len = ranked.len();
                 if len == 0 {
                     return;
                 }
@@ -1296,9 +1307,11 @@ impl AppState {
     /// reset the horizontal scroll, and re-rank the opposite pane when the focused pane is the
     /// ranking anchor.
     fn list_move_focused(&mut self, forward: bool) {
+        // Length-only snapshot once per move (issue #224).
+        let (locals, ranked) = self.list_pane_snapshots();
         match self.focus {
             FocusPane::Local => {
-                let len = self.visible_locals().len();
+                let len = locals.len();
                 if forward {
                     if self.local_index + 1 >= len {
                         return;
@@ -1316,8 +1329,9 @@ impl AppState {
                 }
             }
             FocusPane::Gist => {
+                let len = ranked.len();
                 if forward {
-                    if self.gist_index + 1 >= self.ranked_gists().len() {
+                    if self.gist_index + 1 >= len {
                         return;
                     }
                     self.gist_index += 1;
@@ -1386,7 +1400,11 @@ impl AppState {
     /// pair is already pinned, otherwise [`KeyOutcome::Pin`]. Requires a selection in both
     /// panes; otherwise it just sets a status hint.
     fn pin_toggle_intent(&mut self) -> KeyOutcome {
-        let (Some(local), Some(gist)) = (self.selected_local(), self.selected_gist()) else {
+        let (locals, ranked) = self.list_pane_snapshots();
+        let (Some(local), Some(gist)) = (
+            locals.get(self.local_index).map(|r| &r.candidate),
+            ranked.get(self.gist_index),
+        ) else {
             self.status = Some("select a local file and a gist to pin".into());
             return KeyOutcome::None;
         };

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -987,10 +987,11 @@ impl AppState {
         true
     }
 
-    pub fn ranked_gists(&self) -> Vec<RankedGistFile> {
+    /// Filtered owned/starred gist file rows (no ranking/sort). Shared by
+    /// [`Self::ranked_gists`] and [`Self::list_pane_snapshots`].
+    fn filtered_gist_files(&self) -> Vec<GistFile> {
         let query = self.filter_query.to_lowercase();
-        let gists: Vec<GistFile> = self
-            .list_gist_source()
+        self.list_gist_source()
             .iter()
             .filter(|g| self.gist_type_filter.matches_file(g))
             .filter(|g| {
@@ -999,39 +1000,27 @@ impl AppState {
                     || g.description.to_lowercase().contains(&query)
             })
             .cloned()
-            .collect();
-        // Anchor-driven ranking: the gist pane is ranked against the selected local file
-        // only while the LOCAL pane is the anchor (anchor == Local). When the gist pane
-        // is the anchor it uses its own sort (no ranking), which also breaks the
-        // otherwise-mutual dependency with `visible_locals`.
-        // NOTE: only evaluate `selected_local()` inside the anchor==Local branch. Computing
-        // it eagerly (e.g. in the match scrutinee) would recurse: selected_local ->
-        // visible_locals -> selected_gist -> ranked_gists.
-        let mut ranked = if self.anchor == FocusPane::Local {
-            match self.selected_local() {
-                Some(local) => rank_gist_files(&local.path, &gists, &self.pinned),
-                None => unranked_gists(gists),
-            }
-        } else {
-            unranked_gists(gists)
+            .collect()
+    }
+
+    /// Rank/sort gist files for a known local path (or unranked when `local_path` is
+    /// `None` / anchor is Gist). Does **not** call `selected_local` / `visible_locals`.
+    fn rank_gist_files_for(&self, local_path: Option<&std::path::Path>) -> Vec<RankedGistFile> {
+        let gists = self.filtered_gist_files();
+        let mut ranked = match local_path {
+            Some(path) => rank_gist_files(path, &gists, &self.pinned),
+            None => unranked_gists(gists),
         };
         self.gist_sort.apply(&mut ranked);
         ranked
     }
 
-    /// The local file list after sorting (and, while the gist pane drives, reverse ranking
-    /// against the selected gist). Single source of truth for the local pane's order,
-    /// selection, and rendering — mirrors `ranked_gists`.
-    pub fn visible_locals(&self) -> Vec<RankedLocal> {
-        // Mirror of `ranked_gists`: only evaluate `selected_gist()` in the anchor==Gist
-        // branch to avoid recursing back through `ranked_gists` -> `selected_local`.
-        let mut ranked = if self.anchor == FocusPane::Gist {
-            match self.selected_gist() {
-                Some(gist) => rank_local_files(&gist.file, &self.locals, &self.pinned),
-                None => unranked_locals(&self.locals),
-            }
-        } else {
-            unranked_locals(&self.locals)
+    /// Local rows with optional reverse-rank against a known gist file. Does **not**
+    /// call `selected_gist` / `ranked_gists`.
+    fn rank_local_files_for(&self, gist: Option<&GistFile>) -> Vec<RankedLocal> {
+        let mut ranked = match gist {
+            Some(file) => rank_local_files(file, &self.locals, &self.pinned),
+            None => unranked_locals(&self.locals),
         };
         let query = self.local_filter_query.to_lowercase();
         if !query.is_empty() {
@@ -1043,6 +1032,70 @@ impl AppState {
         }
         self.local_sort.apply(&mut ranked);
         ranked
+    }
+
+    pub fn ranked_gists(&self) -> Vec<RankedGistFile> {
+        // Anchor-driven ranking: the gist pane is ranked against the selected local file
+        // only while the LOCAL pane is the anchor (anchor == Local). When the gist pane
+        // is the anchor it uses its own sort (no ranking), which also breaks the
+        // otherwise-mutual dependency with `visible_locals`.
+        // NOTE: only evaluate the local selection inside the anchor==Local branch.
+        // Computing it eagerly would recurse: selected_local -> visible_locals ->
+        // selected_gist -> ranked_gists.
+        let local_path = if self.anchor == FocusPane::Local {
+            self.rank_local_files_for(None)
+                .get(self.local_index)
+                .map(|r| r.candidate.path.clone())
+        } else {
+            None
+        };
+        self.rank_gist_files_for(local_path.as_deref())
+    }
+
+    /// The local file list after sorting (and, while the gist pane drives, reverse ranking
+    /// against the selected gist). Single source of truth for the local pane's order,
+    /// selection, and rendering — mirrors `ranked_gists`.
+    pub fn visible_locals(&self) -> Vec<RankedLocal> {
+        // Mirror of `ranked_gists`: only evaluate the gist selection in the anchor==Gist
+        // branch to avoid recursing back through `ranked_gists` -> `selected_local`.
+        let gist = if self.anchor == FocusPane::Gist {
+            self.rank_gist_files_for(None)
+                .into_iter()
+                .nth(self.gist_index)
+                .map(|r| r.file)
+        } else {
+            None
+        };
+        self.rank_local_files_for(gist.as_ref())
+    }
+
+    /// Build both list-pane orderings with **one** construction of each list (issue #224 /
+    /// shape #1 from #154). Prefer this when a key/palette/render path needs both sides or
+    /// multiple selected rows — avoids N full filter+rank+sort passes per call site.
+    ///
+    /// Expansion order follows the anchor so the mutual recursion is not entered:
+    /// - `Local` anchor: locals (driver) first, then gists ranked on the selected local
+    /// - `Gist` anchor: gists (driver) first, then locals reverse-ranked on the selected gist
+    ///
+    /// Public `ranked_gists` / `visible_locals` / `selected_*` stay pure recomputes so unit
+    /// tests keep the no-stale-cache contract; hot handlers should call this instead.
+    pub fn list_pane_snapshots(&self) -> (Vec<RankedLocal>, Vec<RankedGistFile>) {
+        match self.anchor {
+            FocusPane::Local => {
+                let locals = self.rank_local_files_for(None);
+                let path = locals
+                    .get(self.local_index)
+                    .map(|r| r.candidate.path.as_path());
+                let gists = self.rank_gist_files_for(path);
+                (locals, gists)
+            }
+            FocusPane::Gist => {
+                let gists = self.rank_gist_files_for(None);
+                let gist = gists.get(self.gist_index).map(|r| &r.file);
+                let locals = self.rank_local_files_for(gist);
+                (locals, gists)
+            }
+        }
     }
 
     pub fn selected_local(&self) -> Option<LocalCandidate> {

--- a/src/tui/palette.rs
+++ b/src/tui/palette.rs
@@ -300,18 +300,20 @@ fn build_palette_items(state: &AppState, screen: Screen, mode: PaletteMode) -> V
 }
 
 fn list_palette_items(state: &AppState) -> Vec<PaletteItem> {
-    let has_gist = state.gist_index < state.ranked_gists().len();
-    let has_local = state.selected_local().is_some();
-    let gist_id = state.selected_gist().map(|g| g.file.gist_id.clone());
+    // One dual-pane snapshot for all enablement checks (issue #224).
+    let (visible_locals, ranked) = state.list_pane_snapshots();
+    let has_gist = ranked.get(state.gist_index).is_some();
+    let has_local = visible_locals.get(state.local_index).is_some();
+    let gist = ranked.get(state.gist_index);
+    let gist_id = gist.map(|g| g.file.gist_id.clone());
     let owned = gist_id
         .as_deref()
         .map(|id| state.gist_is_owned(id))
         .unwrap_or(false);
-    let gist_file = state.selected_gist().map(|g| g.file.clone());
+    let gist_file = gist.map(|g| g.file.clone());
     let previewable = gist_file
         .as_ref()
         .is_some_and(|f| state.gist_file_is_text_previewable(&f.gist_id, &f.filename));
-    let visible_locals = state.visible_locals();
     let diffable = gist_file.as_ref().is_some_and(|f| {
         let local_path = visible_locals
             .get(state.local_index)
@@ -322,16 +324,17 @@ fn list_palette_items(state: &AppState) -> Vec<PaletteItem> {
         .as_deref()
         .map(|id| state.gist_file_count(id) > 1)
         .unwrap_or(false);
-    let pinned_pair = state
-        .selected_local()
-        .zip(state.selected_gist())
-        .is_some_and(|(local, gist)| {
-            state.pinned.iter().any(|m| {
-                m.local_path == local.path
-                    && m.gist_id == gist.file.gist_id
-                    && m.gist_filename == gist.file.filename
-            })
-        });
+    let pinned_pair =
+        visible_locals
+            .get(state.local_index)
+            .zip(gist)
+            .is_some_and(|(local, gist)| {
+                state.pinned.iter().any(|m| {
+                    m.local_path == local.candidate.path
+                        && m.gist_id == gist.file.gist_id
+                        && m.gist_filename == gist.file.filename
+                })
+            });
 
     vec![
         key_item("Enter", "Diff local ↔ gist", KeyCode::Enter, diffable),

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1757,7 +1757,9 @@ pub(super) fn render_list(frame: &mut Frame, state: &AppState, layout: &mut Mous
 
     // Show each candidate's path relative to cwd; in flat mode this is just the filename,
     // in recursive mode it includes the subdirectory (e.g. src/utils/helpers.rs).
-    let visible_locals = state.visible_locals();
+    // Dual snapshot once for both panes (issue #224) — avoids a second full recompute
+    // when building the gist pane from `ranked_gists()` below.
+    let (visible_locals, ranked) = state.list_pane_snapshots();
     let local_items: Vec<ListItem> = if state.local_scanning && state.locals.is_empty() {
         vec![ListItem::new(format!(
             "  {} Scanning files…",
@@ -1815,7 +1817,6 @@ pub(super) fn render_list(frame: &mut Frame, state: &AppState, layout: &mut Mous
         });
     }
 
-    let ranked = state.ranked_gists();
     let gist_items: Vec<ListItem> = if state.loading && ranked.is_empty() {
         vec![ListItem::new(format!(
             "  {} Loading gists…",

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1689,12 +1689,11 @@ fn local_selection_changes_ranked_gists() {
     assert_eq!(state.ranked_gists()[0].file.filename, "statusline.sh");
 }
 
-/// `ranked_gists` / `visible_locals` are recomputed from current state on every call —
-/// there is intentionally NO cache for them (see #154, closed by-design: a content-hash /
-/// epoch memo could silently render a stale ordering the unit suite would not catch).
-/// `selected_gist` / `selected_local` are defined as `list[index]`, so they must stay
-/// identical to a fresh recompute even after an earlier read and an input mutation. This
-/// test pins that invariant: a future stale cache would break it loudly here.
+/// Public `ranked_gists` / `visible_locals` / `selected_*` stay pure recomputes (no
+/// content-hash / epoch memo — #154 closed that approach). Hot paths use
+/// `list_pane_snapshots()` (#224 shape #1) which builds each list once without caching
+/// across mutations. `selected_gist` / `selected_local` must still equal `list[index]`
+/// after an earlier read and an input mutation — a future silent cache would break here.
 #[test]
 fn selected_accessors_track_recomputed_lists_with_no_cache() {
     let mut state = initial_state();
@@ -1781,6 +1780,80 @@ fn selected_accessors_track_recomputed_lists_with_no_cache() {
             .nth(state.local_index)
             .map(|r| r.candidate.path),
     );
+}
+
+#[test]
+fn list_pane_snapshots_match_public_accessors() {
+    let mut state = initial_state();
+    state.locals = vec![
+        LocalCandidate {
+            path: PathBuf::from("/tmp/settings.json"),
+            pinned: false,
+            modified: None,
+        },
+        LocalCandidate {
+            path: PathBuf::from("/tmp/statusline.sh"),
+            pinned: false,
+            modified: None,
+        },
+    ];
+    state.gists = vec![
+        GistFile {
+            gist_id: "a".into(),
+            description: "settings".into(),
+            filename: "settings.json".into(),
+            public: false,
+            updated_at: "x".into(),
+            created_at: "x".into(),
+            owner_login: String::new(),
+            fork_of_id: None,
+            raw_url: None,
+            content_type: None,
+            node_id: None,
+        },
+        GistFile {
+            gist_id: "b".into(),
+            description: "status".into(),
+            filename: "statusline.sh".into(),
+            public: false,
+            updated_at: "x".into(),
+            created_at: "x".into(),
+            owner_login: String::new(),
+            fork_of_id: None,
+            raw_url: None,
+            content_type: None,
+            node_id: None,
+        },
+    ];
+
+    for anchor in [FocusPane::Local, FocusPane::Gist] {
+        state.anchor = anchor;
+        let (locals, gists) = state.list_pane_snapshots();
+        assert_eq!(
+            locals
+                .iter()
+                .map(|r| r.candidate.path.clone())
+                .collect::<Vec<_>>(),
+            state
+                .visible_locals()
+                .into_iter()
+                .map(|r| r.candidate.path)
+                .collect::<Vec<_>>(),
+            "locals mismatch for {anchor:?}"
+        );
+        assert_eq!(
+            gists
+                .iter()
+                .map(|g| g.file.filename.clone())
+                .collect::<Vec<_>>(),
+            state
+                .ranked_gists()
+                .into_iter()
+                .map(|g| g.file.filename)
+                .collect::<Vec<_>>(),
+            "gists mismatch for {anchor:?}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes **#224** (P2): safe once-per-action ranked list construction without a content-hash memo.

- New `AppState::list_pane_snapshots()` builds locals + gists once, expanding mutual recursion by anchor order
- List keys (move/page, Enter, Space, pin, download, …), palette enablement, and `render_list` use the snapshot
- Public `ranked_gists` / `visible_locals` / `selected_*` stay pure recomputes (no stale-cache risk); unit test updated + snapshot equivalence test added

## Test plan

- [x] `cargo test --locked` + clippy `-D warnings`
- [ ] CI green (incl. multi-OS)

Closes #224