### PR TITLE
feat(tui): in-app Settings screen for config preferences (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Settings screen (`C`, or Ctrl+p → Open settings): toggle theme, mouse, update checks, trailing-newline ignore, and adjust scan depth / diff context without hand-editing `config.toml` (saved only after a change).
 - List navigation, palette enablement, and the dual-pane render build each ranked file list at most once per action (smoother with large gist/local sets).
 - Cancelled or superseded background tasks (and overlapping local file scans) no longer apply their results if they finish late.
 - Preview, diff, and upload refuse text larger than 10 MiB with a status message instead of loading the whole buffer into memory.

--- a/README.md
+++ b/README.md
@@ -73,14 +73,15 @@ without resetting order. Pinned pairs show `📌`; same-filename candidates are 
 | `p` / `P` | pin pair / open Pins view |
 | `g` | gist manager (per-gist view; `Enter` for detail, `v` visibility, `*` star) |
 | `a` | flip anchor pane · `/` filter focused pane · `?` help |
+| `C` | open Settings (theme, mouse, update check, scan depth, …) |
 
 Press **`?`** anytime for the **full, contextual keymap** — it opens the current screen's
-topic; `Tab` browses all topics (List, Pins, Gist manager, Gist detail, Diff, Preview, …).
+topic; `Tab` browses all topics (List, Pins, Gist manager, Settings, …).
 The idle footer shows `; Menu · Ctrl+p Palette`; every screen also shows a
 `(G)ists (P)ins (?)Help` shortcut bar in the top-right corner (click, or use the
 underlying key). Press `;` (or right-click) for a context menu of actions valid on
 the current screen and selection; press `Ctrl+p` for the full command palette with
-fuzzy-filter search and cross-screen navigation (`Go to Pins`, `Toggle theme`, `Quit`, …).
+fuzzy-filter search and cross-screen navigation (`Go to Pins`, `Open settings`, `Toggle theme`, `Quit`, …).
 The app version, the GitHub repo link, and update-check status live in `?` Help's
 **About** topic (press `0` from the Help index, or `Tab` then scroll to it).
 
@@ -115,9 +116,11 @@ Full rules: **[docs/SAFETY.md](docs/SAFETY.md)**.
 
 ## Configuration
 
-The config file lives at `~/.config/gistui/config.toml` (or
-`$XDG_CONFIG_HOME/gistui/config.toml` if that variable is set). It is created
-automatically the first time you pin a file. All fields are optional.
+Most preferences can be changed in-app with **`C`** (Settings) or **Ctrl+p → Open settings**
+— values are written only after you change a field (opening Settings alone does not create
+the file). The config file lives at `~/.config/gistui/config.toml` (or
+`$XDG_CONFIG_HOME/gistui/config.toml` if that variable is set). It is also created when you
+pin a file or toggle the theme with `T`. All fields are optional.
 
 | Field | Type | Description |
 |-------|------|-------------|

--- a/src/tui/bg.rs
+++ b/src/tui/bg.rs
@@ -998,6 +998,36 @@ pub(super) fn persist_diff_context(state: &mut AppState) {
     }
 }
 
+/// Persist Settings-screen fields after a user change (issue #227). Creates config.toml
+/// only when a value actually changed (opening Config never calls this).
+pub(super) fn persist_settings(state: &mut AppState) {
+    let result = crate::config::config_path().and_then(|path| {
+        let mut config = crate::config::load_config(&path)?;
+        config.theme = state.theme_choice;
+        config.mouse = state.config_mouse;
+        config.check_updates = state.config_check_updates;
+        config.ignore_trailing_newline = state.ignore_trailing_newline;
+        config.scan_depth = state.scan_depth;
+        config.diff_context = state.diff_context;
+        crate::config::save_config(&path, &config)?;
+        Ok(())
+    });
+    match result {
+        Ok(()) => {
+            let field = ConfigField::ALL
+                .get(state.config.index)
+                .copied()
+                .unwrap_or(ConfigField::Theme);
+            state.set_status(format!(
+                "{}: {}",
+                field.label(),
+                state.config_field_value(field)
+            ));
+        }
+        Err(error) => state.set_status(format!("save config failed: {error}")),
+    }
+}
+
 pub(super) fn pin_selected(state: &mut AppState) {
     let (Some(local), Some(gist)) = (state.selected_local(), state.selected_gist()) else {
         return;

--- a/src/tui/dispatch.rs
+++ b/src/tui/dispatch.rs
@@ -560,6 +560,7 @@ pub(super) fn dispatch_outcome(
             }
         }
         KeyOutcome::PersistDiffContext => persist_diff_context(state),
+        KeyOutcome::PersistSettings => persist_settings(state),
         KeyOutcome::ThemeToggle => persist_theme(state),
         KeyOutcome::FetchRevisions => {
             let Some(gist_id) = state.revision.gist_id.clone() else {

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -94,6 +94,7 @@ impl AppState {
             Screen::Gists => self.handle_key_gists(code),
             Screen::GistDetail => self.handle_key_detail(code),
             Screen::Revisions => self.handle_key_revisions(code),
+            Screen::Config => self.handle_key_config(code),
             Screen::Palette => KeyOutcome::None,
         }
     }
@@ -111,6 +112,141 @@ impl AppState {
         self.help.index_open = false;
         self.help.scroll = 0;
         self.screen = Screen::Help;
+    }
+
+    /// Open the flat Settings screen (`C` or palette). Opening alone does not write config.
+    pub(crate) fn open_config(&mut self) {
+        if self.screen == Screen::Config {
+            return;
+        }
+        self.config.return_screen = self.screen;
+        self.config.index = 0;
+        self.screen = Screen::Config;
+    }
+
+    /// Value string shown for a Config field row.
+    pub(crate) fn config_field_value(&self, field: ConfigField) -> String {
+        match field {
+            ConfigField::Theme => match self.theme_choice {
+                crate::config::ThemeChoice::Dark => "dark".into(),
+                crate::config::ThemeChoice::Light => "light".into(),
+            },
+            ConfigField::Mouse => {
+                if self.config_mouse {
+                    "on".into()
+                } else {
+                    "off".into()
+                }
+            }
+            ConfigField::CheckUpdates => {
+                if self.config_check_updates {
+                    "on".into()
+                } else {
+                    "off".into()
+                }
+            }
+            ConfigField::IgnoreTrailingNewline => {
+                if self.ignore_trailing_newline {
+                    "on".into()
+                } else {
+                    "off".into()
+                }
+            }
+            ConfigField::ScanDepth => self.scan_depth.to_string(),
+            ConfigField::DiffContext => self.diff_context.to_string(),
+        }
+    }
+
+    /// Toggle or nudge the selected Config field. Returns true when a value changed
+    /// (caller should persist). Pure aside from mutating `self`.
+    pub(crate) fn adjust_config_field(&mut self, forward: bool) -> bool {
+        let field = ConfigField::ALL
+            .get(self.config.index)
+            .copied()
+            .unwrap_or(ConfigField::Theme);
+        match field {
+            ConfigField::Theme => {
+                self.theme_choice = match self.theme_choice {
+                    crate::config::ThemeChoice::Dark => crate::config::ThemeChoice::Light,
+                    crate::config::ThemeChoice::Light => crate::config::ThemeChoice::Dark,
+                };
+                self.theme = Theme::for_choice(self.theme_choice);
+                true
+            }
+            ConfigField::Mouse => {
+                self.config_mouse = !self.config_mouse;
+                self.mouse_enabled =
+                    crate::config::resolve_mouse_enabled(self.config_mouse, self.no_mouse_cli);
+                true
+            }
+            ConfigField::CheckUpdates => {
+                self.config_check_updates = !self.config_check_updates;
+                self.update_check_enabled = crate::config::resolve_update_check(
+                    self.config_check_updates,
+                    self.no_update_check_cli,
+                );
+                true
+            }
+            ConfigField::IgnoreTrailingNewline => {
+                self.ignore_trailing_newline = !self.ignore_trailing_newline;
+                true
+            }
+            ConfigField::ScanDepth => {
+                let next = if forward {
+                    self.scan_depth.saturating_add(1).min(20)
+                } else {
+                    self.scan_depth.saturating_sub(1)
+                };
+                if next == self.scan_depth {
+                    return false;
+                }
+                self.scan_depth = next;
+                true
+            }
+            ConfigField::DiffContext => {
+                let next = if forward {
+                    self.diff_context.saturating_add(1).min(50)
+                } else {
+                    self.diff_context.saturating_sub(1)
+                };
+                if next == self.diff_context {
+                    return false;
+                }
+                self.diff_context = next;
+                true
+            }
+        }
+    }
+
+    fn handle_key_config(&mut self, code: KeyCode) -> KeyOutcome {
+        let n = ConfigField::ALL.len();
+        match code {
+            KeyCode::Char('q') | KeyCode::Esc => {
+                self.screen = self.config.return_screen;
+                self.config.return_screen = Screen::List;
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.config.index = self.config.index.saturating_sub(1);
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                if self.config.index + 1 < n {
+                    self.config.index += 1;
+                }
+            }
+            KeyCode::Enter | KeyCode::Char(' ') | KeyCode::Right | KeyCode::Char('l') => {
+                if self.adjust_config_field(true) {
+                    return KeyOutcome::PersistSettings;
+                }
+            }
+            KeyCode::Left | KeyCode::Char('h') => {
+                if self.adjust_config_field(false) {
+                    return KeyOutcome::PersistSettings;
+                }
+            }
+            KeyCode::Char('?') => self.open_help(),
+            _ => {}
+        }
+        KeyOutcome::None
     }
 
     /// Arrow / hjkl / Ctrl+b/f navigation. Returns true when the key was consumed.
@@ -300,6 +436,25 @@ impl AppState {
                 }
                 true
             }
+            Screen::Config => {
+                let n = ConfigField::ALL.len();
+                match action {
+                    NavAction::Up => {
+                        self.config.index = self.config.index.saturating_sub(1);
+                    }
+                    NavAction::Down => {
+                        if self.config.index + 1 < n {
+                            self.config.index += 1;
+                        }
+                    }
+                    NavAction::Left | NavAction::Right => {
+                        // Adjust is handled in handle_key_config (needs PersistSettings).
+                        return false;
+                    }
+                    _ => return false,
+                }
+                true
+            }
             // Diff, Preview and Confirm all scroll the same diff/preview buffer identically.
             Screen::Diff | Screen::Preview | Screen::Confirm => {
                 match action {
@@ -346,8 +501,9 @@ impl AppState {
                     self.help.index_open = false;
                     self.help.scroll = 0;
                 }
-                KeyCode::Char('0') if topics.len() > 9 => {
-                    self.help.topic = topics[9];
+                // `0` always jumps to About (last topic), independent of total count.
+                KeyCode::Char('0') if topics.contains(&HelpTopic::About) => {
+                    self.help.topic = HelpTopic::About;
                     self.help.index_open = false;
                     self.help.scroll = 0;
                 }
@@ -371,8 +527,8 @@ impl AppState {
                     self.help.topic = topics[(c as u8 - b'1') as usize];
                     self.help.scroll = 0;
                 }
-                KeyCode::Char('0') if topics.len() > 9 => {
-                    self.help.topic = topics[9];
+                KeyCode::Char('0') if topics.contains(&HelpTopic::About) => {
+                    self.help.topic = HelpTopic::About;
                     self.help.scroll = 0;
                 }
                 KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => {
@@ -830,6 +986,17 @@ impl AppState {
                 }
                 false
             }
+            Screen::Config => {
+                if let Some(hit) = layout.list {
+                    if point_in(hit.rect, col, row) {
+                        if let Some(idx) = hit.index_at(row, ConfigField::ALL.len()) {
+                            self.config.index = idx;
+                            return true;
+                        }
+                    }
+                }
+                false
+            }
             Screen::GistDetail => {
                 if let Some(hit) = layout.detail_files {
                     if point_in(hit.rect, col, row) {
@@ -1179,6 +1346,7 @@ impl AppState {
             KeyCode::Char('y') => return KeyOutcome::CopyGistUrl,
             KeyCode::Char('?') => self.open_help(),
             KeyCode::Char('P') => self.open_pins(),
+            KeyCode::Char('C') => self.open_config(),
             KeyCode::Char('S') => return KeyOutcome::SyncSelectedPair,
             KeyCode::Char('g') => self.open_gist_manager(),
             KeyCode::Char('H') => {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -34,6 +34,51 @@ pub enum Screen {
     Revisions,
     /// Unified context menu / command palette overlay (`;` or right-click / `Ctrl+p`).
     Palette,
+    /// Flat settings list (issue #227); opened with `C` or the command palette.
+    Config,
+}
+
+/// Fields shown on [`Screen::Config`] in order (issue #227).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigField {
+    Theme,
+    Mouse,
+    CheckUpdates,
+    IgnoreTrailingNewline,
+    ScanDepth,
+    DiffContext,
+}
+
+impl ConfigField {
+    pub const ALL: [ConfigField; 6] = [
+        ConfigField::Theme,
+        ConfigField::Mouse,
+        ConfigField::CheckUpdates,
+        ConfigField::IgnoreTrailingNewline,
+        ConfigField::ScanDepth,
+        ConfigField::DiffContext,
+    ];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            ConfigField::Theme => "Theme",
+            ConfigField::Mouse => "Mouse support",
+            ConfigField::CheckUpdates => "Check for updates",
+            ConfigField::IgnoreTrailingNewline => "Ignore trailing newline",
+            ConfigField::ScanDepth => "Recursive scan depth",
+            ConfigField::DiffContext => "Diff context lines",
+        }
+    }
+
+    pub fn is_numeric(self) -> bool {
+        matches!(self, ConfigField::ScanDepth | ConfigField::DiffContext)
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ConfigState {
+    pub index: usize,
+    pub return_screen: Screen,
 }
 
 /// A help topic — one per key-dense area, plus `About` (version/repo/update info, not tied
@@ -51,11 +96,12 @@ pub enum HelpTopic {
     Revisions,
     General,
     About,
+    Config,
 }
 
 impl HelpTopic {
     /// All topics in index / quick-jump order.
-    pub fn all() -> [HelpTopic; 10] {
+    pub fn all() -> [HelpTopic; 11] {
         use HelpTopic::*;
         [
             List,
@@ -66,6 +112,7 @@ impl HelpTopic {
             Diff,
             Preview,
             Upload,
+            Config,
             General,
             About,
         ]
@@ -82,6 +129,7 @@ impl HelpTopic {
             HelpTopic::Diff => "Diff view",
             HelpTopic::Preview => "Preview",
             HelpTopic::Upload => "Upload confirmation",
+            HelpTopic::Config => "Settings",
             HelpTopic::General => "General",
             HelpTopic::About => "About",
         }
@@ -95,6 +143,7 @@ impl HelpTopic {
             Screen::Gists => HelpTopic::GistManager,
             Screen::GistDetail => HelpTopic::GistDetail,
             Screen::Revisions => HelpTopic::Revisions,
+            Screen::Config => HelpTopic::Config,
             _ => HelpTopic::List,
         }
     }
@@ -360,6 +409,8 @@ pub enum KeyOutcome {
     CopyPreviewContent,
     /// Toggle the colour theme between dark and light and persist to config (`T`, global).
     ThemeToggle,
+    /// Persist settings changed on [`Screen::Config`] (creates config.toml only after a change).
+    PersistSettings,
     /// Fetch the revision list for the gist opened on `Screen::Revisions`.
     FetchRevisions,
     /// Diff the target file: parent revision → selected revision (incremental).
@@ -619,12 +670,22 @@ pub struct AppState {
     /// Syntax-highlight file content in the preview and diff-context lines (issue #69).
     /// Defaults on; `load_startup_state` turns it off when `NO_COLOR` is set in the environment.
     pub syntax_highlight: bool,
+    /// Config preference for mouse (before CLI force-off). Edited on [`Screen::Config`].
+    pub config_mouse: bool,
     /// Whether mouse capture is active this session (config `mouse` AND-NOT `--no-mouse`).
     /// Gates the `Event::Mouse` branch and the close-button rendering.
     pub mouse_enabled: bool,
+    /// CLI `--no-mouse` for the process (re-applied when config mouse toggles).
+    pub no_mouse_cli: bool,
+    /// Config preference for daily update checks. Edited on [`Screen::Config`].
+    pub config_check_updates: bool,
     /// Whether the startup update check runs this session (config `check_updates` AND-NOT
     /// `--no-update-check`).
     pub update_check_enabled: bool,
+    /// CLI `--no-update-check` for the process.
+    pub no_update_check_cli: bool,
+    /// Config screen navigation state.
+    pub config: ConfigState,
     /// Newer release version found by the background check, if any (footer hint on the List).
     pub update_available: Option<String>,
     /// How this binary was installed — resolved once at startup so the update hint can show
@@ -1676,8 +1737,13 @@ pub fn initial_state() -> AppState {
         preview_title: String::new(),
         preview_wrap: false,
         syntax_highlight: true,
+        config_mouse: true,
         mouse_enabled: true,
+        no_mouse_cli: false,
+        config_check_updates: true,
         update_check_enabled: true,
+        no_update_check_cli: false,
+        config: ConfigState::default(),
         update_available: None,
         install_method: crate::upgrade::InstallMethod::Standalone,
         preview_gist_key: None,
@@ -1737,7 +1803,11 @@ pub fn load_startup_state(no_mouse: bool, no_update_check: bool) -> Result<AppSt
     state.theme = Theme::for_choice(config.theme);
     // Honour NO_COLOR for the syntax-highlight feature only (existing semantic colours stay).
     state.syntax_highlight = std::env::var_os("NO_COLOR").is_none();
+    state.config_mouse = config.mouse;
+    state.no_mouse_cli = no_mouse;
     state.mouse_enabled = crate::config::resolve_mouse_enabled(config.mouse, no_mouse);
+    state.config_check_updates = config.check_updates;
+    state.no_update_check_cli = no_update_check;
     state.update_check_enabled =
         crate::config::resolve_update_check(config.check_updates, no_update_check);
     // Surface a previously-seen newer release immediately (even when the daily check is

--- a/src/tui/palette.rs
+++ b/src/tui/palette.rs
@@ -21,6 +21,7 @@ pub enum CrossAction {
     GoToGists,
     GoToPins,
     OpenHelp,
+    OpenConfig,
     ToggleTheme,
     Quit,
 }
@@ -203,6 +204,10 @@ impl AppState {
                 self.open_help();
                 KeyOutcome::None
             }
+            PaletteExec::Cross(CrossAction::OpenConfig) => {
+                self.open_config();
+                KeyOutcome::None
+            }
             PaletteExec::Cross(CrossAction::ToggleTheme) => {
                 self.theme_choice = match self.theme_choice {
                     crate::config::ThemeChoice::Dark => crate::config::ThemeChoice::Light,
@@ -252,6 +257,7 @@ fn key_item(key: &str, label: &str, code: KeyCode, enabled: bool) -> PaletteItem
 }
 
 fn cross_items() -> Vec<PaletteItem> {
+    // includes Open settings
     vec![
         palette_item(
             "g",
@@ -269,6 +275,12 @@ fn cross_items() -> Vec<PaletteItem> {
             "?",
             "Go to Help",
             PaletteExec::Cross(CrossAction::OpenHelp),
+            true,
+        ),
+        palette_item(
+            "C",
+            "Open settings",
+            PaletteExec::Cross(CrossAction::OpenConfig),
             true,
         ),
         palette_item(
@@ -291,6 +303,7 @@ fn build_palette_items(state: &AppState, screen: Screen, mode: PaletteMode) -> V
         Screen::Diff => diff_palette_items(state),
         Screen::Preview => preview_palette_items(state),
         Screen::Help => help_palette_items(),
+        Screen::Config => config_palette_items(),
         Screen::Confirm | Screen::Palette => Vec::new(),
     };
     if mode == PaletteMode::Command {
@@ -566,6 +579,14 @@ fn preview_palette_items(_state: &AppState) -> Vec<PaletteItem> {
         key_item("y", "Copy gist URL", KeyCode::Char('y'), true),
         key_item("Y", "Copy file content", KeyCode::Char('Y'), true),
         key_item("q", "Back", KeyCode::Char('q'), true),
+    ]
+}
+
+fn config_palette_items() -> Vec<PaletteItem> {
+    vec![
+        key_item("Enter", "Toggle / increase value", KeyCode::Enter, true),
+        key_item("h/l", "Decrease / increase value", KeyCode::Char('l'), true),
+        key_item("Esc", "Close settings", KeyCode::Esc, true),
     ]
 }
 

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -30,6 +30,7 @@ pub(super) fn render(frame: &mut Frame, state: &AppState, layout: &mut MouseLayo
         Screen::Gists => render_gists(frame, state, layout),
         Screen::GistDetail => render_gist_detail(frame, state, layout),
         Screen::Revisions => render_revisions(frame, state, layout),
+        Screen::Config => render_config(frame, state, layout),
     }
     if let Some(ref msg) = state.bg_task_msg {
         render_loading_overlay(frame, msg, state.spinner_frame, &state.theme);
@@ -285,10 +286,28 @@ Mouse (on by default; disable with mouse = false in config or --no-mouse)
   p          (JSON only) toggle pretty-print formatting
   s          (JSON only) toggle recursive key sorting"
         }
+        HelpTopic::Config => {
+            "\
+Settings (C from List, or Ctrl+p → Open settings)
+  Up/Down    move between fields (also j / k)
+  Enter/Space  toggle a boolean, or increase a number
+  h / l      decrease / increase (also ← / →)
+  Esc / q    close (opening Settings never writes config by itself —
+             values are saved only after you change a field)
+
+Fields
+  Theme                  dark / light (also global T)
+  Mouse support          on / off (session still respects --no-mouse)
+  Check for updates      on / off (session still respects --no-update-check)
+  Ignore trailing newline  on / off (diff + overwrite confirm)
+  Recursive scan depth   0–20 (r recursive discovery)
+  Diff context lines     0–50 (c in Diff still toggles full vs this radius)"
+        }
         HelpTopic::General => {
             "\
   Esc / q    close an overlay; from the list, press twice to quit the app
   ?          show this help
+  C          open Settings (flat list of preferences; also Ctrl+p)
   ;          context menu (actions valid for the current screen + selection)
   Ctrl+p     command palette (all actions + cross-screen navigation; type to filter)
   T          toggle light/dark colour theme (saved to config)
@@ -341,6 +360,61 @@ fn about_topic_lines(state: &AppState) -> Vec<Line<'static>> {
     lines
 }
 
+pub(super) fn render_config(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout) {
+    let area = frame.area();
+    let area = render_top_bar(frame, area, &state.theme, state.mouse_enabled, layout);
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(3), Constraint::Length(1)])
+        .split(area);
+    let items: Vec<ListItem> = ConfigField::ALL
+        .iter()
+        .map(|field| {
+            let label = field.label();
+            let value = state.config_field_value(*field);
+            let hint = if field.is_numeric() {
+                "←/→"
+            } else {
+                "Enter"
+            };
+            ListItem::new(format!("  {label:<28} {value:<8}  ({hint})"))
+        })
+        .collect();
+    let mut list_state = ListState::default().with_selected(Some(state.config.index));
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .title(" Settings ")
+        .title_bottom(Line::from(
+            " Esc close · Enter/←/→ change · saved on change ",
+        ))
+        .style(state.theme.base_style())
+        .border_style(Style::default().fg(state.theme.accent));
+    let list = List::new(items)
+        .block(block)
+        .highlight_style(
+            Style::default()
+                .bg(state.theme.accent)
+                .fg(state.theme.fg_on_accent)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▸ ");
+    frame.render_stateful_widget(list, chunks[0], &mut list_state);
+    if state.mouse_enabled {
+        layout.close_button = Some(render_close_button(frame, chunks[0], &state.theme));
+        layout.list = Some(PaneHit {
+            rect: chunks[0],
+            offset: 0,
+        });
+    }
+    if let Some(ref status) = state.status {
+        frame.render_widget(
+            Paragraph::new(status.as_str()).style(Style::default().fg(state.theme.accent)),
+            chunks[1],
+        );
+    }
+}
+
 pub(super) fn render_help(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout) {
     let area = frame.area();
     let area = render_top_bar(frame, area, &state.theme, state.mouse_enabled, layout);
@@ -349,7 +423,8 @@ pub(super) fn render_help(frame: &mut Frame, state: &AppState, layout: &mut Mous
             .iter()
             .enumerate()
             .map(|(i, t)| {
-                let key = if i == 9 {
+                // `0` marks About; otherwise 1-based index (1–9, then 10+).
+                let key = if *t == HelpTopic::About {
                     "0".to_string()
                 } else {
                     (i + 1).to_string()
@@ -2633,6 +2708,7 @@ fn render_palette(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout)
         Screen::Gists => render_gists(frame, state, &mut bg_layout),
         Screen::GistDetail => render_gist_detail(frame, state, &mut bg_layout),
         Screen::Revisions => render_revisions(frame, state, &mut bg_layout),
+        Screen::Config => render_config(frame, state, &mut bg_layout),
         Screen::Confirm | Screen::Palette => {}
     }
 

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -4024,12 +4024,14 @@ fn pins_filter_input_behaviors() {
 #[test]
 fn help_topic_all_is_ordered_and_titled() {
     let all = HelpTopic::all();
-    assert_eq!(all.len(), 10);
+    assert_eq!(all.len(), 11);
     assert_eq!(all[0], HelpTopic::List);
     assert_eq!(all[4], HelpTopic::Revisions);
-    assert_eq!(all[8], HelpTopic::General);
-    assert_eq!(all[9], HelpTopic::About);
+    assert_eq!(all[8], HelpTopic::Config);
+    assert_eq!(all[9], HelpTopic::General);
+    assert_eq!(all[10], HelpTopic::About);
     assert_eq!(HelpTopic::Pins.title(), "Pinned Mappings");
+    assert_eq!(HelpTopic::Config.title(), "Settings");
     assert_eq!(HelpTopic::About.title(), "About");
 }
 
@@ -5713,4 +5715,87 @@ fn local_scan_generation_ignores_stale_results() {
     ));
     assert_eq!(state.locals[0].path, PathBuf::from("/tmp/fresh.txt"));
     assert!(!state.local_scanning);
+}
+
+#[test]
+fn open_config_does_not_write_config_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    assert!(!path.exists());
+    let mut state = initial_state();
+    state.screen = Screen::List;
+    state.open_config();
+    assert_eq!(state.screen, Screen::Config);
+    // Opening alone must not create the file — persist only after a field change.
+    assert!(!path.exists());
+}
+
+#[test]
+fn config_adjust_theme_returns_persist_settings() {
+    let mut state = initial_state();
+    state.open_config();
+    // Theme is index 0
+    state.config.index = 0;
+    assert_eq!(state.theme_choice, crate::config::ThemeChoice::Dark);
+    assert!(state.adjust_config_field(true));
+    assert_eq!(state.theme_choice, crate::config::ThemeChoice::Light);
+    // Space on config screen yields PersistSettings
+    let outcome = state.handle_key(KeyCode::Char(' '));
+    assert_eq!(outcome, KeyOutcome::PersistSettings);
+}
+
+#[test]
+fn config_adjust_scan_depth_clamps_and_reports_change() {
+    let mut state = initial_state();
+    state.open_config();
+    state.config.index = ConfigField::ALL
+        .iter()
+        .position(|f| *f == ConfigField::ScanDepth)
+        .unwrap();
+    state.scan_depth = 0;
+    assert!(!state.adjust_config_field(false)); // already min
+    assert!(state.adjust_config_field(true));
+    assert_eq!(state.scan_depth, 1);
+}
+
+#[test]
+fn config_field_values_round_trip_via_save_config() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+    let mut state = initial_state();
+    state.theme_choice = crate::config::ThemeChoice::Light;
+    state.config_mouse = false;
+    state.config_check_updates = false;
+    state.ignore_trailing_newline = false;
+    state.scan_depth = 5;
+    state.diff_context = 7;
+    // Simulate persist_settings write path using shipped save/load.
+    let config = crate::config::AppConfig {
+        theme: state.theme_choice,
+        mouse: state.config_mouse,
+        check_updates: state.config_check_updates,
+        ignore_trailing_newline: state.ignore_trailing_newline,
+        scan_depth: state.scan_depth,
+        diff_context: state.diff_context,
+        ..crate::config::AppConfig::default()
+    };
+    crate::config::save_config(&path, &config).unwrap();
+    assert!(path.exists());
+    let loaded = crate::config::load_config(&path).unwrap();
+    assert_eq!(loaded.theme, crate::config::ThemeChoice::Light);
+    assert!(!loaded.mouse);
+    assert!(!loaded.check_updates);
+    assert!(!loaded.ignore_trailing_newline);
+    assert_eq!(loaded.scan_depth, 5);
+    assert_eq!(loaded.diff_context, 7);
+}
+
+#[test]
+fn config_c_key_opens_settings_from_list() {
+    let mut state = initial_state();
+    state.screen = Screen::List;
+    state.handle_key(KeyCode::Char('C'));
+    assert_eq!(state.screen, Screen::Config);
+    state.handle_key(KeyCode::Esc);
+    assert_eq!(state.screen, Screen::List);
 }


### PR DESCRIPTION
## Summary

Closes **#227**:

- `C` or Ctrl+p → **Open settings** opens a flat Settings list
- Fields: theme, mouse, check_updates, ignore_trailing_newline, scan_depth, diff_context
- **Persist only after a field change** (no silent first write on open)
- Help topic + README + CHANGELOG Unreleased
- Unit tests for open-without-write, PersistSettings outcome, save/load round-trip, `C` key

## Test plan

- [x] `cargo test` + clippy `-D warnings`
- [ ] CI green

Closes #227