### PR TITLE
feat(tui): clickable (C)onfig in top bar next to Help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- The top-right shortcut bar now includes `(C)onfig` immediately left of `(?)Help` (click or press `C`, same as duodiff).
 - Settings screen (`C`, or Ctrl+p → Open settings): toggle theme, mouse, update checks, trailing-newline ignore, and adjust scan depth / diff context without hand-editing `config.toml` (saved only after a change).
 - List navigation, palette enablement, and the dual-pane render build each ranked file list at most once per action (smoother with large gist/local sets).
 - Cancelled or superseded background tasks (and overlapping local file scans) no longer apply their results if they finish late.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ without resetting order. Pinned pairs show `📌`; same-filename candidates are 
 Press **`?`** anytime for the **full, contextual keymap** — it opens the current screen's
 topic; `Tab` browses all topics (List, Pins, Gist manager, Settings, …).
 The idle footer shows `; Menu · Ctrl+p Palette`; every screen also shows a
-`(G)ists (P)ins (?)Help` shortcut bar in the top-right corner (click, or use the
+`(G)ists (P)ins (C)onfig (?)Help` shortcut bar in the top-right corner (click, or use the
 underlying key). Press `;` (or right-click) for a context menu of actions valid on
 the current screen and selection; press `Ctrl+p` for the full command palette with
 fuzzy-filter search and cross-screen navigation (`Go to Pins`, `Open settings`, `Toggle theme`, `Quit`, …).
@@ -94,7 +94,7 @@ The app version, the GitHub repo link, and update-check status live in `?` Help'
 | Double-click a row | open it — List diff, gist detail, pin diff, revision diff, file preview, or Help topic (same as `Enter`) |
 | Click a tab (Gist details) | switch between Files / Comments (newest 30 comments load first; `m` or clicking the top line loads 30 older comments) |
 | Click `[✕]` button (pop-up screens) | close / go back |
-| Click `(G)ists` / `(P)ins` / `(?)Help` (top bar) | jump to that screen, from anywhere — same as pressing `g` / `P` / `?` |
+| Click `(G)ists` / `(P)ins` / `(C)onfig` / `(?)Help` (top bar) | jump to that screen, from anywhere — same as pressing `g` / `P` / `C` / `?` |
 | Right-click | open the context menu at the click (same as `;`) |
 | Click a menu / palette row | run that action (same as selecting it and pressing `Enter`) |
 | Click the repository URL (`?` Help → About) | open the GitHub repository in the system's default browser |

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -1146,8 +1146,8 @@ impl AppState {
                         return KeyOutcome::OpenRepoUrl;
                     }
                 }
-                // Top-bar (G)ists / (P)ins / (?)Help — same effect as pressing the key,
-                // from any screen (not just wherever that key happens to be bound).
+                // Top-bar (G)ists / (P)ins / (C)onfig / (?)Help — same effect as pressing
+                // the key, from any screen (not just wherever that key happens to be bound).
                 if let Some(rect) = layout.top_bar_gists {
                     if point_in(rect, col, row) {
                         self.open_gist_manager();
@@ -1157,6 +1157,12 @@ impl AppState {
                 if let Some(rect) = layout.top_bar_pins {
                     if point_in(rect, col, row) {
                         self.open_pins();
+                        return KeyOutcome::None;
+                    }
+                }
+                if let Some(rect) = layout.top_bar_config {
+                    if point_in(rect, col, row) {
+                        self.open_config();
                         return KeyOutcome::None;
                     }
                 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -469,10 +469,11 @@ pub struct MouseLayout {
     /// to honour a one-shot scroll-to-bottom after the newest page loads).
     pub comments_max_scroll: Option<u16>,
     pub repo_link: Option<Rect>,
-    /// Cross-screen top-bar shortcut hit-rects — `(G)ists`, `(P)ins`, `(?)Help`. Set by
-    /// `render_top_bar` on every screen except the transient `Confirm` y/n modal.
+    /// Cross-screen top-bar shortcut hit-rects — `(G)ists`, `(P)ins`, `(C)onfig`, `(?)Help`.
+    /// Set by `render_top_bar` on every screen except the transient `Confirm` y/n modal.
     pub top_bar_gists: Option<Rect>,
     pub top_bar_pins: Option<Rect>,
+    pub top_bar_config: Option<Rect>,
     pub top_bar_help: Option<Rect>,
     /// Palette overlay: one hit-rect per visible row, plus the `[✕]` close button.
     pub palette_rows: Vec<Rect>,

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -52,19 +52,23 @@ fn render_close_button(frame: &mut Frame, outer: Rect, theme: &Theme) -> Rect {
     rect
 }
 
-/// The three cross-screen top-bar shortcuts: bracketed hotkey letter + label. Kept in one
-/// place so the click hit-rect math and the rendered text can never drift apart.
-const TOP_BAR_ITEMS: [(&str, &str); 3] = [("G", "ists"), ("P", "ins"), ("?", "Help")];
+/// Cross-screen top-bar shortcuts: bracketed hotkey letter + label. Kept in one place so the
+/// click hit-rect math and the rendered text can never drift apart. Order matches the
+/// right-aligned strip: Gists · Pins · Config · Help (Config sits immediately left of Help,
+/// same as duodiff).
+const TOP_BAR_ITEMS: [(&str, &str); 4] =
+    [("G", "ists"), ("P", "ins"), ("C", "onfig"), ("?", "Help")];
 
 /// Height of the persistent top bar rendered on every screen except the transient `Confirm`
 /// y/n modal (which keeps its full-bleed diff/gist-info background — see `render_confirm`).
 const TOP_BAR_HEIGHT: u16 = 1;
 
-/// Renders the cross-screen top bar — ` gistui` on the left, `(G)ists (P)ins (?)Help`
-/// right-aligned — into the top row of `area`, then returns the remaining rect below it for
-/// the caller's existing content/footer layout (otherwise unchanged). The icons render as
-/// plain text even with the mouse disabled, so the shortcuts stay visible; their hit-rects are
-/// only recorded in `layout` when `mouse_enabled`, matching every other clickable region.
+/// Renders the cross-screen top bar — ` gistui` on the left,
+/// `(G)ists (P)ins (C)onfig (?)Help` right-aligned — into the top row of `area`, then returns
+/// the remaining rect below it for the caller's existing content/footer layout (otherwise
+/// unchanged). The icons render as plain text even with the mouse disabled, so the shortcuts
+/// stay visible; their hit-rects are only recorded in `layout` when `mouse_enabled`, matching
+/// every other clickable region.
 pub(super) fn render_top_bar(
     frame: &mut Frame,
     area: Rect,
@@ -111,6 +115,7 @@ pub(super) fn render_top_bar(
             match i {
                 0 => layout.top_bar_gists = Some(rect),
                 1 => layout.top_bar_pins = Some(rect),
+                2 => layout.top_bar_config = Some(rect),
                 _ => layout.top_bar_help = Some(rect),
             }
         }
@@ -182,7 +187,7 @@ Mouse (on by default; disable with mouse = false in config or --no-mouse)
   Dbl-click  open the clicked row (diff / detail / pin diff / preview)
   Tab click  switch Files / Comments on the Gist details screen
   [✕] btn    close / go back on any pop-up screen
-  Top bar    click (G)ists / (P)ins / (?)Help (top-right, every screen) to jump there
+  Top bar    click (G)ists / (P)ins / (C)onfig / (?)Help (top-right, every screen)
   Right-click  open the context menu at the click (same as ;)
   ; / Ctrl+p   open the menu / command palette from the keyboard (see General)"
         }
@@ -288,7 +293,7 @@ Mouse (on by default; disable with mouse = false in config or --no-mouse)
         }
         HelpTopic::Config => {
             "\
-Settings (C from List, or Ctrl+p → Open settings)
+Settings (C, top-bar (C)onfig, or Ctrl+p → Open settings)
   Up/Down    move between fields (also j / k)
   Enter/Space  toggle a boolean, or increase a number
   h / l      decrease / increase (also ← / →)

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -3510,6 +3510,42 @@ fn top_bar_pins_click_opens_pins_from_any_screen() {
 }
 
 #[test]
+fn top_bar_config_click_opens_settings_from_any_screen() {
+    let mut state = state_with_gists();
+    state.screen = Screen::Preview;
+    let layout = MouseLayout {
+        top_bar_config: Some(Rect::new(28, 0, 8, 1)),
+        ..Default::default()
+    };
+    let out = state.handle_mouse(MouseInput::Click { col: 30, row: 0 }, &layout);
+    assert_eq!(state.screen, Screen::Config);
+    assert_eq!(state.config.return_screen, Screen::Preview);
+    assert_eq!(out, KeyOutcome::None);
+}
+
+#[test]
+fn top_bar_config_click_while_already_on_config_does_not_trap_keyboard_exit() {
+    let mut state = state_with_gists();
+    state.screen = Screen::Preview;
+    let layout = MouseLayout {
+        top_bar_config: Some(Rect::new(28, 0, 8, 1)),
+        ..Default::default()
+    };
+    state.handle_mouse(MouseInput::Click { col: 30, row: 0 }, &layout);
+    assert_eq!(state.screen, Screen::Config);
+    assert_eq!(state.config.return_screen, Screen::Preview);
+
+    // Second click on Config while already there must not overwrite return_screen.
+    let out = state.handle_mouse(MouseInput::Click { col: 30, row: 0 }, &layout);
+    assert_eq!(state.screen, Screen::Config);
+    assert_eq!(state.config.return_screen, Screen::Preview);
+    assert_eq!(out, KeyOutcome::None);
+
+    state.handle_key(KeyCode::Esc);
+    assert_eq!(state.screen, Screen::Preview);
+}
+
+#[test]
 fn top_bar_help_click_opens_help_and_remembers_return_screen_from_any_screen() {
     let mut state = state_with_gists();
     state.screen = Screen::Preview;


### PR DESCRIPTION
## Summary

Mirrors **duodiff** top-right chrome: `(C)onfig` sits immediately left of `(?)Help`.

- `TOP_BAR_ITEMS` → Gists · Pins · Config · Help
- `MouseLayout::top_bar_config` + click handler → `open_config()`
- No-op when already on Settings (Esc still returns to origin)
- README / Help / CHANGELOG updated

## Test plan

- [x] `top_bar_config_click_*` tests
- [x] clippy `-D warnings`
- [ ] CI green