### PR TITLE
fix: allow full hscroll on starred gist rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Starred gist rows can fully horizontal-scroll again: the scroll limit now uses the same display string as painting (including the `★ ` prefix), so the trailing characters are reachable.
+
 ## [0.17.0] — 2026-07-09
 
 - The top-right shortcut bar now includes `(C)onfig` immediately left of `(?)Help` (click or press `C`, same as duodiff).

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1207,41 +1207,31 @@ impl AppState {
     /// Highest horizontal-scroll offset for the gist-level view, based on its longest
     /// visible row (mirrors `focused_hscroll_max` for the main panes).
     fn gists_hscroll_max(&self) -> u16 {
-        self.visible_gist_groups()
-            .iter()
-            .map(|g| {
-                gist_group_row_label(
-                    g,
-                    unix_now(),
-                    self.gist_manager.sort,
-                    (
-                        self.gist_comment_counts.get(&g.id).copied().unwrap_or(0),
-                        self.gist_star_counts.get(&g.id).copied().unwrap_or(0),
-                        self.gist_fork_counts.get(&g.id).copied().unwrap_or(0),
-                    ),
-                    self.gist_is_starred(&g.id),
-                    self.current_user_login.as_deref(),
-                )
-                .chars()
-                .count()
-            })
-            .max()
-            .unwrap_or(0)
-            .saturating_sub(1)
-            .min(u16::MAX as usize) as u16
+        hscroll_max_among(self.visible_gist_groups().iter().map(|g| {
+            gist_group_row_label(
+                g,
+                unix_now(),
+                self.gist_manager.sort,
+                (
+                    self.gist_comment_counts.get(&g.id).copied().unwrap_or(0),
+                    self.gist_star_counts.get(&g.id).copied().unwrap_or(0),
+                    self.gist_fork_counts.get(&g.id).copied().unwrap_or(0),
+                ),
+                self.gist_is_starred(&g.id),
+                self.current_user_login.as_deref(),
+            )
+        }))
     }
 
     /// Highest horizontal-scroll offset for the Pins screen, bounded by the longest
     /// displayed local path (the only variable-length, overflow-prone field in a pin row).
     /// Pure helper modeled on `gists_hscroll_max`.
     fn pins_hscroll_max(&self) -> u16 {
-        self.pinned
-            .iter()
-            .map(|m| crate::config::display_path(&m.local_path).chars().count())
-            .max()
-            .unwrap_or(0)
-            .saturating_sub(1)
-            .min(u16::MAX as usize) as u16
+        hscroll_max_among(
+            self.pinned
+                .iter()
+                .map(|m| crate::config::display_path(&m.local_path)),
+        )
     }
 
     /// Indices into `self.pinned` that match the Pins-screen text filter, in sort order.
@@ -1544,23 +1534,26 @@ impl AppState {
 
     /// Highest horizontal-scroll offset for the focused pane, based on its longest row
     /// (viewport width is unknown to the pure key logic, mirroring the diff scroll cap).
+    ///
+    /// Must measure the **same** string the list paint path draws (`gist_row_display` /
+    /// local label + pin mark), not a star-less or mark-less variant — otherwise starred
+    /// or pinned rows cannot scroll far enough to reveal their trailing characters (#247).
     fn focused_hscroll_max(&self) -> u16 {
-        let longest = match self.focus {
-            FocusPane::Local => self
-                .locals
-                .iter()
-                .map(|c| local_row_label(&c.path, &self.cwd).chars().count())
-                .max(),
-            FocusPane::Gist => self
-                .ranked_gists()
-                .iter()
-                .map(|g| gist_row_label(g, self.gist_view).chars().count())
-                .max(),
-        };
-        longest
-            .unwrap_or(0)
-            .saturating_sub(1)
-            .min(u16::MAX as usize) as u16
+        let (visible_locals, ranked) = self.list_pane_snapshots();
+        match self.focus {
+            FocusPane::Local => hscroll_max_among(visible_locals.iter().map(|r| {
+                marked_row_text(
+                    local_row_label(&r.candidate.path, &self.cwd),
+                    row_mark(&r.reasons),
+                )
+            })),
+            FocusPane::Gist => hscroll_max_among(ranked.iter().map(|g| {
+                marked_row_text(
+                    gist_row_display(g, self.gist_view, self),
+                    row_mark(&g.reasons),
+                )
+            })),
+        }
     }
 
     fn scroll_focused_right(&mut self) {
@@ -1669,14 +1662,7 @@ impl AppState {
     }
 
     pub fn scroll_diff_right(&mut self) {
-        let max = self
-            .diff_text
-            .lines()
-            .map(|line| line.chars().count())
-            .max()
-            .unwrap_or(0)
-            .saturating_sub(1)
-            .min(u16::MAX as usize) as u16;
+        let max = hscroll_max_among(self.diff_text.lines());
         if self.diff_hscroll < max {
             self.diff_hscroll += 1;
         }
@@ -2045,7 +2031,7 @@ use palette::{PaletteItem, PaletteMode, PaletteState};
 mod render;
 use render::*;
 mod text;
-use text::{comment_lines_count, local_row_label};
+use text::{comment_lines_count, hscroll_max_among, local_row_label};
 mod bg;
 mod dispatch;
 mod keys;

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1534,9 +1534,7 @@ pub(super) fn render_gist_detail(frame: &mut Frame, state: &AppState, layout: &m
     }
 }
 
-pub(super) fn hscroll_str(text: &str, offset: u16) -> String {
-    text.chars().skip(offset as usize).collect()
-}
+pub(super) use super::text::hscroll_str;
 
 /// Builds a single Pins-screen row. The local path is rendered with `display_path`
 /// (home → `~`) so it stays readable; the full row is horizontally scrollable. Pure so
@@ -1578,17 +1576,27 @@ pub(super) fn row_mark(reasons: &[MatchReason]) -> RowMark {
     }
 }
 
-/// Build a file-list row from its base text and match mark: 📌 prefix for a pinned pair,
-/// bold for a same-name match, plain otherwise. Shared by both panes in `render_list`.
-pub(super) fn marked_item(base: String, mark: RowMark, hscroll: u16) -> ListItem<'static> {
+/// Compose the full list-row string (including pin mark) that paint and hscroll max must share.
+pub(super) fn marked_row_text(base: String, mark: RowMark) -> String {
     match mark {
-        RowMark::Pinned => ListItem::new(hscroll_str(&format!("📌 {base}"), hscroll)),
-        RowMark::SameName => ListItem::new(hscroll_str(&base, hscroll))
-            .style(Style::default().add_modifier(Modifier::BOLD)),
-        RowMark::None => ListItem::new(hscroll_str(&base, hscroll)),
+        RowMark::Pinned => format!("📌 {base}"),
+        RowMark::SameName | RowMark::None => base,
     }
 }
 
+/// Build a file-list row from its base text and match mark: 📌 prefix for a pinned pair,
+/// bold for a same-name match, plain otherwise. Shared by both panes in `render_list`.
+pub(super) fn marked_item(base: String, mark: RowMark, hscroll: u16) -> ListItem<'static> {
+    let text = marked_row_text(base, mark);
+    let item = ListItem::new(hscroll_str(&text, hscroll));
+    match mark {
+        RowMark::SameName => item.style(Style::default().add_modifier(Modifier::BOLD)),
+        RowMark::Pinned | RowMark::None => item,
+    }
+}
+
+/// Gist file-list row **without** the live star mark (fork badge still applied). Used as the
+/// shared base for paint/hscroll; star is layered in [`gist_row_display`] so both stay aligned.
 pub(super) fn gist_row_label(g: &RankedGistFile, view: GistView) -> String {
     let base = match view {
         GistView::Description => {
@@ -1603,22 +1611,15 @@ pub(super) fn gist_row_label(g: &RankedGistFile, view: GistView) -> String {
     format!("{}{}", gist_badge_prefix(false, g.file.is_fork()), base)
 }
 
+/// Full gist file-list row as painted — [`gist_row_label`] plus `★ ` when the gist is starred.
+/// Hscroll max must measure this string (or [`marked_row_text`] of it), not the star-less label.
 pub(super) fn gist_row_display(g: &RankedGistFile, view: GistView, state: &AppState) -> String {
-    let base = match view {
-        GistView::Description => {
-            if g.file.description.trim().is_empty() {
-                g.file.filename.clone()
-            } else {
-                format!("{} — {}", g.file.filename, g.file.description)
-            }
-        }
-        GistView::Id => format!("{} / {}", g.file.gist_id, g.file.filename),
-    };
-    format!(
-        "{}{}",
-        gist_badge_prefix(state.gist_is_starred(&g.file.gist_id), g.file.is_fork()),
-        base
-    )
+    let label = gist_row_label(g, view);
+    if state.gist_is_starred(&g.file.gist_id) {
+        format!("★ {label}")
+    } else {
+        label
+    }
 }
 
 /// Greedy word-wrap line count, matching how `Paragraph` with `Wrap { trim: true }` breaks

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1507,12 +1507,68 @@ fn gist_hscroll_caps_at_longest_row() {
         node_id: None,
     }];
     state.focus = FocusPane::Gist;
-    let row = gist_row_label(&state.ranked_gists()[0], state.gist_view);
-    let max = (row.chars().count() - 1) as u16;
+    // Cap must use the painted display string (star / pin prefixes included), not the
+    // star-less label helper — see issue #247.
+    let ranked = state.ranked_gists();
+    let row = marked_row_text(
+        gist_row_display(&ranked[0], state.gist_view, &state),
+        row_mark(&ranked[0].reasons),
+    );
+    let max = super::text::hscroll_max_for_text(&row);
     for _ in 0..200 {
         state.handle_key(KeyCode::Right);
     }
     assert_eq!(state.gist_hscroll, max);
+}
+
+#[test]
+fn gist_hscroll_caps_include_star_prefix() {
+    let mut state = initial_state();
+    state.gists = vec![GistFile {
+        gist_id: "starred-id".into(),
+        description: "tiny".into(),
+        filename: "f".into(),
+        public: false,
+        updated_at: "x".into(),
+        created_at: "x".into(),
+        owner_login: String::new(),
+        fork_of_id: None,
+        raw_url: None,
+        content_type: None,
+        node_id: None,
+    }];
+    state.starred_gist_ids.insert("starred-id".into());
+    state.focus = FocusPane::Gist;
+
+    let ranked = state.ranked_gists();
+    let display = gist_row_display(&ranked[0], state.gist_view, &state);
+    assert!(
+        display.starts_with("★ "),
+        "display must include star prefix, got {display:?}"
+    );
+    let label = gist_row_label(&ranked[0], state.gist_view);
+    assert!(
+        !label.starts_with('★'),
+        "label helper stays star-less for pure text tests"
+    );
+    // Regression: measuring the label (no star) under-scrolled by 2 chars.
+    assert_eq!(
+        super::text::text_len(&display),
+        super::text::text_len(&label) + 2
+    );
+
+    let row = marked_row_text(display, row_mark(&ranked[0].reasons));
+    let max = super::text::hscroll_max_for_text(&row);
+    let label_only_max = super::text::hscroll_max_for_text(&label);
+    assert!(max > label_only_max, "star must raise the hscroll cap");
+
+    for _ in 0..200 {
+        state.handle_key(KeyCode::Right);
+    }
+    assert_eq!(
+        state.gist_hscroll, max,
+        "Right must reach the display-string max, not the star-less label max"
+    );
 }
 
 #[test]

--- a/src/tui/text.rs
+++ b/src/tui/text.rs
@@ -1,8 +1,51 @@
 //! Pure display/format helpers shared by the state layer (`AppState`) and the render layer,
 //! kept out of `render` so `AppState` logic does not depend on the presentation module.
+//!
+//! # Horizontal scroll units (issue #247)
+//!
+//! List-row hscroll measures and advances in **Unicode scalar values** (`char`s), matching
+//! [`hscroll_str`] which skips with `chars().skip`. That keeps max and paint on the same
+//! unit. Display-column width (East Asian width / `unicode-width`) is intentionally **not**
+//! used here: mixing column widths with char-based skip would reintroduce drift. A future
+//! change may switch both measure and skip together.
 
 use crate::domain::GistComment;
 use std::path::Path;
+
+/// Length of `s` in the units used by list horizontal scroll (Unicode scalars).
+pub(super) fn text_len(s: &str) -> usize {
+    s.chars().count()
+}
+
+/// Drop the first `offset` characters of `text` for horizontal scrolling.
+pub(super) fn hscroll_str(text: &str, offset: u16) -> String {
+    text.chars().skip(offset as usize).collect()
+}
+
+/// Highest scroll offset so the last character of a string of `len` can become the first
+/// visible character (same formula used across list / gists / pins / diff panes).
+pub(super) fn hscroll_max_for_len(len: usize) -> u16 {
+    len.saturating_sub(1).min(u16::MAX as usize) as u16
+}
+
+/// [`hscroll_max_for_len`] for a concrete display string.
+pub(super) fn hscroll_max_for_text(text: &str) -> u16 {
+    hscroll_max_for_len(text_len(text))
+}
+
+/// Max hscroll over many display strings (empty iterator → 0).
+pub(super) fn hscroll_max_among<I, S>(texts: I) -> u16
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    // Monotonic in length: max of per-string caps == cap of the longest string.
+    texts
+        .into_iter()
+        .map(|s| hscroll_max_for_text(s.as_ref()))
+        .max()
+        .unwrap_or(0)
+}
 
 /// A local file path shortened relative to `cwd` for list-row display.
 pub(super) fn local_row_label(path: &Path, cwd: &Path) -> String {
@@ -18,4 +61,42 @@ pub(super) fn comment_lines_count(comments: &[GistComment]) -> u16 {
         .map(|c| 2 + c.body.lines().count())
         .sum::<usize>()
         .min(u16::MAX as usize) as u16
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn text_len_counts_scalars_not_bytes() {
+        assert_eq!(text_len(""), 0);
+        assert_eq!(text_len("ab"), 2);
+        assert_eq!(text_len("★ f"), 3);
+        assert_eq!(text_len("📌 x"), 3);
+    }
+
+    #[test]
+    fn hscroll_str_skips_scalars() {
+        assert_eq!(hscroll_str("★ long-name", 0), "★ long-name");
+        assert_eq!(hscroll_str("★ long-name", 2), "long-name");
+        assert_eq!(hscroll_str("★ long-name", 100), "");
+    }
+
+    #[test]
+    fn hscroll_max_allows_last_char_first() {
+        assert_eq!(hscroll_max_for_text(""), 0);
+        assert_eq!(hscroll_max_for_text("a"), 0);
+        assert_eq!(hscroll_max_for_text("ab"), 1);
+        // Star prefix is two scalars ("★" + space); max must include them.
+        assert_eq!(hscroll_max_for_text("★ ab"), 3);
+    }
+
+    #[test]
+    fn hscroll_max_among_picks_longest() {
+        assert_eq!(hscroll_max_among(std::iter::empty::<&str>()), 0);
+        assert_eq!(
+            hscroll_max_among(["a", "★★ longer", "bb"]),
+            hscroll_max_for_text("★★ longer")
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Fix list horizontal scroll so starred (and pinned-mark) gist/local rows can scroll to the end of the painted text.
- Centralize char-based hscroll helpers in `tui::text` (`text_len`, `hscroll_str`, `hscroll_max_*`); paint and scroll caps share `gist_row_display` + `marked_row_text`.
- Unicode policy for this change: measure/skip by Unicode scalars (`char`), matching existing `chars().skip` hscroll — not `unicode-width`.

Closes #247.

## Test plan

- [x] `mise run check` (fmt, test, check, clippy `-D warnings`)
- [x] Unit: `gist_hscroll_caps_include_star_prefix`, `gist_hscroll_caps_at_longest_row`, `tui::text` hscroll helpers
- [ ] Manual (optional): open List, focus a starred gist with a long description, Right-arrow until the trailing characters are visible