### PR TITLE
refactor: introduce pure view-model seam for TUI render

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,9 +40,11 @@ If `cargo fmt --check` fails, run `cargo fmt` and confirm only formatting change
 
 Pure, testable domain logic is kept separate from impure shell/filesystem adapters:
 
-- Pure modules (unit-tested): `domain`, `config`, `ranking`, `local`, `diff`, and the command-planning/guard parts of `actions`.
+- Pure modules (unit-tested): `domain`, `config`, `ranking`, `local`, `diff`, the command-planning/guard parts of `actions`, and `tui::view_model` (`build_view_model`: `AppState` + pin-sync cache → presentation facts).
 - Thin IO boundaries (not unit-tested by design): `gh` (`gh` subprocess calls), the `actions` execute helpers, and the IO helper fns in `tui::run_loop`.
-- `tui.rs` is a screen state machine (`Screen::{List, Diff, Confirm, Preview, Help, Pins, Gists}`; `Gists` is the gist-level manager). `AppState::handle_key` is **pure** — it mutates state and returns a `KeyOutcome` intent; `run_loop` performs the IO (fetch/download/upload/create/delete/remove-file/edit-description). Keep new key logic in `handle_key` (testable) and new IO in `run_loop` helpers.
+- `tui` is a screen state machine (`Screen::{List, Diff, Confirm, Preview, Help, Pins, Gists, …}`; `Gists` is the gist-level manager). `AppState::handle_key` is **pure** — it mutates state and returns a `KeyOutcome` intent; `run_loop` performs the IO (fetch/download/upload/create/delete/remove-file/edit-description). Keep new key logic in `handle_key` (testable) and new IO in `run_loop` helpers.
+- **View-model seam (issue #241):** each frame builds a pure `ViewModel` (`ChromeVm` + `ScreenVm`) at the draw entry. First-batch bodies (Pins, Confirm modal, Help) paint from the VM only; other screens are `ScreenVm::Legacy` and may still read `AppState` for body paint. Do **not** put business rules or FS/network work in paint helpers.
+- **Pin sync presentation:** `refresh_pin_sync_cache` (impure: may stat/read/hash local files) fills `AppState::pin_sync_cache`. Refresh on enter/return to Pins, when the pin list changes, after successful pin sync absorb, or when the dirty flag / length mismatch requires it — **not** every frame and not from the pure builder. Action dispatch may call `compute_pin_sync_status` for a one-shot decision; paint uses only `cached_pin_sync_status` / the VM. While staying on Pins, external editor edits may leave badges temporarily stale until the next refresh (no mtime watch).
 - `run()` wraps `run_loop()` so terminal teardown (raw mode / alternate screen) ALWAYS runs, even on error — keep fallible startup/IO inside `run_loop`, never between `enable_raw_mode` and the teardown.
 
 ## Non-Obvious Rules

--- a/src/tui/bg.rs
+++ b/src/tui/bg.rs
@@ -589,6 +589,7 @@ pub(super) fn record_pin_sync(
                 direction,
             ) {
                 state.pinned = updated.pinned;
+                state.mark_pin_sync_cache_dirty();
             }
         }
     }
@@ -1064,6 +1065,7 @@ pub(super) fn pin_selected(state: &mut AppState) {
             state.pinned = config.pinned;
             state.skip_dirs = config.skip_dirs;
             state.scan_depth = config.scan_depth;
+            state.mark_pin_sync_cache_dirty();
             state.set_status(format!(
                 "Pinned {} <-> {}",
                 local.path.display(),
@@ -1087,6 +1089,7 @@ pub(super) fn unpin_selected(state: &mut AppState) {
             state.pinned = config.pinned;
             state.skip_dirs = config.skip_dirs;
             state.scan_depth = config.scan_depth;
+            state.mark_pin_sync_cache_dirty();
             state.set_status(format!(
                 "Unpinned {}",
                 crate::config::display_path(&local.path)
@@ -1111,6 +1114,7 @@ pub(super) fn unpin_at_pin_index(state: &mut AppState) {
             state.pinned = config.pinned;
             state.skip_dirs = config.skip_dirs;
             state.scan_depth = config.scan_depth;
+            state.mark_pin_sync_cache_dirty();
             state.pins.index = state
                 .pins
                 .index
@@ -1357,11 +1361,11 @@ pub(super) fn absorb_background_results(
                                     // A pin diff that turns out identical confirms the cached
                                     // last_seen_hash is (still) accurate — refresh it for free
                                     // using the content we already fetched, so the Pins list's
-                                    // content-hash check (AppState::pin_sync_status) stays
+                                    // content-hash check (AppState::compute_pin_sync_status) stays
                                     // correct even if the gist changed elsewhere since the last
                                     // real sync. Hash the LOCAL content's raw bytes (not the
                                     // trailing-newline-normalized `identical` comparison), so
-                                    // this matches the raw-byte hashing pin_sync_status does.
+                                    // this matches the raw-byte hashing compute_pin_sync_status does.
                                     if identical {
                                         if let (Some(gid), Some(fname)) = (
                                             state.download_gist_id.clone(),

--- a/src/tui/dispatch.rs
+++ b/src/tui/dispatch.rs
@@ -511,7 +511,7 @@ pub(super) fn dispatch_outcome(
                 return Ok(LoopFlow::Proceed);
             };
             let m = state.pinned[idx].clone();
-            match state.pin_sync_status(idx) {
+            match state.compute_pin_sync_status(idx) {
                 crate::domain::SyncStatus::Push => spawn_pin_push(state, &mut channels.bg, &m),
                 crate::domain::SyncStatus::Pull => spawn_pin_pull(state, &mut channels.bg, &m),
                 crate::domain::SyncStatus::InSync => state.set_status("already in sync"),
@@ -538,12 +538,12 @@ pub(super) fn dispatch_outcome(
                 return Ok(LoopFlow::Proceed);
             };
             let m = state.pinned[pin_idx].clone();
-            match state.pin_sync_status(pin_idx) {
+            match state.compute_pin_sync_status(pin_idx) {
                 crate::domain::SyncStatus::InSync => state.set_status("already in sync"),
                 crate::domain::SyncStatus::Pull => spawn_pin_pull(state, &mut channels.bg, &m),
-                // The content-hash no-op check now happens upstream in
-                // AppState::pin_sync_status (a matching hash is already reclassified to
-                // InSync above), so a genuine Push here always means a real change.
+                // The content-hash no-op check lives in `compute_pin_sync_status` (a matching
+                // hash is already reclassified to InSync above), so a genuine Push here always
+                // means a real change. Presentation uses the pin_sync_cache instead (#241).
                 crate::domain::SyncStatus::Push => spawn_pin_push(state, &mut channels.bg, &m),
                 crate::domain::SyncStatus::Missing => {
                     state.set_status("local file is missing — use d to pull it back")

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -746,6 +746,30 @@ pub struct AppState {
     pub theme: Theme,
     pub revision: RevisionState,
     pub palette: PaletteState,
+    /// Presentation cache for the Pins list: sync status + mtimes, filled by
+    /// [`Self::refresh_pin_sync_cache`] (impure). The pure view-model builder and Pins paint
+    /// read only this cache — never `fs::read` / hash on the draw path (issue #241).
+    pub pin_sync_cache: Vec<PinSyncCacheEntry>,
+    /// When true, the next Pins draw (or explicit refresh) must rebuild [`Self::pin_sync_cache`].
+    pub pin_sync_cache_dirty: bool,
+}
+
+/// One pin's presentation-derived sync facts, computed off the draw path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PinSyncCacheEntry {
+    pub status: crate::domain::SyncStatus,
+    pub local_ts: Option<u64>,
+    pub remote_ts: Option<u64>,
+}
+
+impl Default for PinSyncCacheEntry {
+    fn default() -> Self {
+        Self {
+            status: crate::domain::SyncStatus::Unknown,
+            local_ts: None,
+            remote_ts: None,
+        }
+    }
 }
 
 fn unranked_gists(gists: Vec<GistFile>) -> Vec<RankedGistFile> {
@@ -1771,6 +1795,8 @@ pub fn initial_state() -> AppState {
             ..Default::default()
         },
         palette: PaletteState::default(),
+        pin_sync_cache: Vec::new(),
+        pin_sync_cache_dirty: true,
     }
 }
 
@@ -1781,6 +1807,7 @@ pub fn load_startup_state(no_mouse: bool, no_update_check: bool) -> Result<AppSt
     let cwd = std::env::current_dir()?;
 
     state.pinned = config.pinned;
+    state.mark_pin_sync_cache_dirty();
     state.skip_dirs = config.skip_dirs;
     state.scan_depth = config.scan_depth;
     state.diff_context = config.diff_context;
@@ -1899,12 +1926,11 @@ impl AppState {
         (local_ts, remote_ts)
     }
 
-    /// Derive the [`SyncStatus`] for `pinned[index]` from in-memory mtimes, with a
-    /// content-hash fallback: when the timestamps disagree (`Push`/`Pull`) but the local
-    /// file's current content still hashes to the pin's `last_seen_hash` baseline, report
-    /// `InSync` instead — the timestamp drifted but nothing actually changed. The extra
-    /// file read only happens for this ambiguous, has-a-baseline case, not on every pin.
-    pub fn pin_sync_status(&self, index: usize) -> crate::domain::SyncStatus {
+    /// Impure single-pin status: in-memory mtimes plus a content-hash fallback when
+    /// timestamps disagree (`Push`/`Pull`) but the local file still matches `last_seen_hash`.
+    /// Used by [`Self::refresh_pin_sync_cache`] and by action dispatch (smart-sync); **not**
+    /// for paint — presentation reads [`Self::cached_pin_sync_status`] (issue #241).
+    pub(crate) fn compute_pin_sync_status(&self, index: usize) -> crate::domain::SyncStatus {
         let (local_ts, remote_ts) = self.pin_mtimes(index);
         let status = crate::domain::sync_status(local_ts, remote_ts);
         if !matches!(
@@ -1926,6 +1952,42 @@ impl AppState {
             }
             _ => status,
         }
+    }
+
+    /// Rebuild [`Self::pin_sync_cache`] for every pin (may stat / read local files). Clears
+    /// the dirty flag. Call from run_loop before drawing Pins, after pin-list changes, and
+    /// after successful pin sync absorb — not from pure `handle_key` or the view-model builder.
+    pub fn refresh_pin_sync_cache(&mut self) {
+        self.pin_sync_cache = (0..self.pinned.len())
+            .map(|i| {
+                let (local_ts, remote_ts) = self.pin_mtimes(i);
+                PinSyncCacheEntry {
+                    status: self.compute_pin_sync_status(i),
+                    local_ts,
+                    remote_ts,
+                }
+            })
+            .collect();
+        self.pin_sync_cache_dirty = false;
+    }
+
+    /// Mark the pin presentation cache dirty so the next Pins draw refreshes it.
+    pub fn mark_pin_sync_cache_dirty(&mut self) {
+        self.pin_sync_cache_dirty = true;
+    }
+
+    /// Pure read of cached pin sync status. Missing / short cache → [`SyncStatus::Unknown`]
+    /// (refresh invariant should have filled the cache before Pins paint).
+    pub fn cached_pin_sync_status(&self, index: usize) -> crate::domain::SyncStatus {
+        self.pin_sync_cache
+            .get(index)
+            .map(|e| e.status)
+            .unwrap_or(crate::domain::SyncStatus::Unknown)
+    }
+
+    /// Pure read of a full cache entry; default [`PinSyncCacheEntry`] when missing.
+    pub fn cached_pin_sync_entry(&self, index: usize) -> PinSyncCacheEntry {
+        self.pin_sync_cache.get(index).copied().unwrap_or_default()
     }
 }
 
@@ -2041,6 +2103,8 @@ mod text_input;
 pub use text_input::{EditResult, TextInput};
 mod theme;
 pub use theme::Theme;
+mod view_model;
+pub(crate) use view_model::{build_view_model, ScreenVm};
 
 #[cfg(test)]
 mod tests;

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -19,21 +19,32 @@ pub(super) fn render(frame: &mut Frame, state: &AppState, layout: &mut MouseLayo
         Block::default().style(state.theme.base_style()),
         frame.area(),
     );
-    match state.screen {
-        Screen::Palette => render_palette(frame, state, layout),
-        Screen::List => render_list(frame, state, layout),
-        Screen::Diff => render_diff(frame, state, layout),
-        Screen::Confirm => render_confirm(frame, state, layout),
-        Screen::Preview => render_preview(frame, state, layout),
-        Screen::Help => render_help(frame, state, layout),
-        Screen::Pins => render_pins(frame, state, layout),
-        Screen::Gists => render_gists(frame, state, layout),
-        Screen::GistDetail => render_gist_detail(frame, state, layout),
-        Screen::Revisions => render_revisions(frame, state, layout),
-        Screen::Config => render_config(frame, state, layout),
+    // Pure presentation seam (issue #241): first-batch screens paint from the view model;
+    // Legacy bodies still read `AppState`. Pin sync IO is never done here — only cache reads.
+    let vm = super::build_view_model(state);
+    match &vm.screen {
+        super::ScreenVm::Pins(pins) => render_pins_vm(frame, state, pins, &vm.chrome, layout),
+        super::ScreenVm::Confirm(confirm) => {
+            render_confirm_vm(frame, state, confirm, &vm.chrome, layout)
+        }
+        super::ScreenVm::Help(help) => render_help_vm(frame, state, help, &vm.chrome, layout),
+        super::ScreenVm::Legacy => match state.screen {
+            Screen::Palette => render_palette(frame, state, layout),
+            Screen::List => render_list(frame, state, layout),
+            Screen::Diff => render_diff(frame, state, layout),
+            Screen::Preview => render_preview(frame, state, layout),
+            Screen::Gists => render_gists(frame, state, layout),
+            Screen::GistDetail => render_gist_detail(frame, state, layout),
+            Screen::Revisions => render_revisions(frame, state, layout),
+            Screen::Config => render_config(frame, state, layout),
+            // First-batch screens should not land in Legacy; fall back safely.
+            Screen::Confirm => render_confirm(frame, state, layout),
+            Screen::Help => render_help(frame, state, layout),
+            Screen::Pins => render_pins(frame, state, layout),
+        },
     }
-    if let Some(ref msg) = state.bg_task_msg {
-        render_loading_overlay(frame, msg, state.spinner_frame, &state.theme);
+    if let Some(ref msg) = vm.chrome.bg_task_msg {
+        render_loading_overlay(frame, msg, vm.chrome.spinner_frame, &state.theme);
     }
 }
 
@@ -136,7 +147,7 @@ pub(super) fn count_label(shown: usize, total: usize) -> String {
     }
 }
 
-fn help_topic_body(topic: HelpTopic) -> &'static str {
+pub(super) fn help_topic_body(topic: HelpTopic) -> &'static str {
     match topic {
         HelpTopic::List => {
             "\
@@ -330,37 +341,25 @@ Fields
 /// Fixed row (0-indexed, within the topic body) of the clickable repo-URL line — used to
 /// place `MouseLayout::repo_link`'s hit-rect. Kept stable regardless of update-check state
 /// (see `about_topic_lines`) so this constant never has to change.
-const ABOUT_REPO_LINE: u16 = 2;
+pub(super) const ABOUT_REPO_LINE: usize = 2;
 
-/// The `About` topic's body: version, the clickable repo link (relocated from the old
-/// per-screen footer — see `render_footer`), and the update-check status if a newer release
-/// is available. Unlike every other topic's `&'static str` (`help_topic_body`), this one
-/// needs `state`, so it returns owned `Line`s instead.
-fn about_topic_lines(state: &AppState) -> Vec<Line<'static>> {
+/// Plain-text About topic lines for the pure view-model (issue #241). Paint re-applies the
+/// underlined repo style from [`ABOUT_REPO_LINE`].
+pub(super) fn about_topic_lines_plain(state: &AppState) -> Vec<String> {
     let repo = env!("CARGO_PKG_REPOSITORY")
         .trim_start_matches("https://")
         .trim_start_matches("http://");
     let mut lines = vec![
-        Line::from(format!("gistui v{}", env!("CARGO_PKG_VERSION"))),
-        Line::from(""),
-        // The leading indent is a plain (unstyled) span so only the repo URL itself is
-        // underlined — not the whitespace in front of it.
-        Line::from(vec![
-            Span::raw("  "),
-            Span::styled(
-                repo.to_string(),
-                Style::default()
-                    .fg(state.theme.fg)
-                    .add_modifier(Modifier::UNDERLINED),
-            ),
-        ]),
-        Line::from(""),
+        format!("gistui v{}", env!("CARGO_PKG_VERSION")),
+        String::new(),
+        format!("  {repo}"),
+        String::new(),
     ];
     if let Some(latest) = &state.update_available {
-        lines.push(Line::from(crate::update_check::update_hint(
+        lines.push(crate::update_check::update_hint(
             latest,
             &state.install_method,
-        )));
+        ));
     }
     lines
 }
@@ -421,89 +420,111 @@ pub(super) fn render_config(frame: &mut Frame, state: &AppState, layout: &mut Mo
 }
 
 pub(super) fn render_help(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout) {
+    let vm = super::build_view_model(state);
+    if let super::ScreenVm::Help(help) = &vm.screen {
+        render_help_vm(frame, state, help, &vm.chrome, layout);
+    }
+}
+
+fn render_help_vm(
+    frame: &mut Frame,
+    state: &AppState,
+    help: &super::view_model::HelpVm,
+    chrome: &super::view_model::ChromeVm,
+    layout: &mut MouseLayout,
+) {
     let area = frame.area();
-    let area = render_top_bar(frame, area, &state.theme, state.mouse_enabled, layout);
-    if state.help.index_open {
-        let items: Vec<ListItem> = HelpTopic::all()
-            .iter()
-            .enumerate()
-            .map(|(i, t)| {
-                // `0` marks About; otherwise 1-based index (1–9, then 10+).
-                let key = if *t == HelpTopic::About {
-                    "0".to_string()
-                } else {
-                    (i + 1).to_string()
-                };
-                ListItem::new(format!("  {}  {}", key, t.title()))
-            })
-            .collect();
-        let list = List::new(items)
-            .block(
-                Block::default()
-                    .title("Help — pick a topic (1-9,0 / ↑↓ Enter · Esc back)")
-                    .borders(Borders::ALL)
-                    .border_type(BorderType::Rounded)
-                    .style(state.theme.base_style())
-                    .padding(Padding::horizontal(1)),
-            )
-            .style(state.theme.base_style())
-            .highlight_style(
-                Style::default()
-                    .bg(state.theme.accent)
-                    .fg(state.theme.fg_on_accent)
-                    .add_modifier(Modifier::BOLD),
-            )
-            .highlight_symbol("▶ ");
-        let mut list_state = ListState::default();
-        list_state.select(Some(state.help.index_sel));
-        frame.render_stateful_widget(list, area, &mut list_state);
-        if state.mouse_enabled {
-            layout.list = Some(PaneHit {
-                rect: area,
-                offset: list_state.offset(),
-            });
-        }
-    } else {
-        let title = format!(
-            "Help · {} — Tab topics · ↑↓ scroll · Esc back",
-            state.help.topic.title()
-        );
-        let body: Text = if state.help.topic == HelpTopic::About {
-            Text::from(about_topic_lines(state))
-        } else {
-            Text::from(help_topic_body(state.help.topic))
-        };
-        frame.render_widget(
-            Paragraph::new(body)
-                .style(state.theme.base_style())
-                .scroll((state.help.scroll, 0))
+    let area = render_top_bar(frame, area, &state.theme, chrome.mouse_enabled, layout);
+    match &help.mode {
+        super::view_model::HelpModeVm::Index { items, selected } => {
+            let list_items: Vec<ListItem> = items
+                .iter()
+                .map(|item| ListItem::new(format!("  {}  {}", item.key, item.title)))
+                .collect();
+            let list = List::new(list_items)
                 .block(
                     Block::default()
-                        .title(title)
+                        .title("Help — pick a topic (1-9,0 / ↑↓ Enter · Esc back)")
                         .borders(Borders::ALL)
                         .border_type(BorderType::Rounded)
                         .style(state.theme.base_style())
                         .padding(Padding::horizontal(1)),
-                ),
-            area,
-        );
-        // The repo-link line only gets a click target while it's actually the About topic and
-        // currently scrolled into view — if the user has scrolled it off-screen, the hit-rect
-        // is simply omitted this frame rather than tracked at a stale position.
-        if state.help.topic == HelpTopic::About && state.mouse_enabled {
-            let visible_row = ABOUT_REPO_LINE as i32 - state.help.scroll as i32;
-            let inner_height = area.height.saturating_sub(2);
-            if visible_row >= 0 && (visible_row as u16) < inner_height {
-                layout.repo_link = Some(Rect::new(
-                    area.x + 1,
-                    area.y + 1 + visible_row as u16,
-                    area.width.saturating_sub(2),
-                    1,
-                ));
+                )
+                .style(state.theme.base_style())
+                .highlight_style(
+                    Style::default()
+                        .bg(state.theme.accent)
+                        .fg(state.theme.fg_on_accent)
+                        .add_modifier(Modifier::BOLD),
+                )
+                .highlight_symbol("▶ ");
+            let mut list_state = ListState::default();
+            list_state.select(Some(*selected));
+            frame.render_stateful_widget(list, area, &mut list_state);
+            if chrome.mouse_enabled {
+                layout.list = Some(PaneHit {
+                    rect: area,
+                    offset: list_state.offset(),
+                });
+            }
+        }
+        super::view_model::HelpModeVm::Topic {
+            title,
+            lines,
+            scroll,
+            about_repo_line,
+        } => {
+            let body_lines: Vec<Line<'static>> = lines
+                .iter()
+                .enumerate()
+                .map(|(i, text)| {
+                    if about_repo_line == &Some(i) {
+                        let repo = text.trim_start();
+                        let indent_len = text.len() - repo.len();
+                        let indent = text[..indent_len].to_string();
+                        Line::from(vec![
+                            Span::raw(indent),
+                            Span::styled(
+                                repo.to_string(),
+                                Style::default()
+                                    .fg(state.theme.fg)
+                                    .add_modifier(Modifier::UNDERLINED),
+                            ),
+                        ])
+                    } else {
+                        Line::from(text.clone())
+                    }
+                })
+                .collect();
+            frame.render_widget(
+                Paragraph::new(Text::from(body_lines))
+                    .style(state.theme.base_style())
+                    .scroll((*scroll, 0))
+                    .block(
+                        Block::default()
+                            .title(title.clone())
+                            .borders(Borders::ALL)
+                            .border_type(BorderType::Rounded)
+                            .style(state.theme.base_style())
+                            .padding(Padding::horizontal(1)),
+                    ),
+                area,
+            );
+            if let (Some(repo_line), true) = (*about_repo_line, chrome.mouse_enabled) {
+                let visible_row = repo_line as i32 - *scroll as i32;
+                let inner_height = area.height.saturating_sub(2);
+                if visible_row >= 0 && (visible_row as u16) < inner_height {
+                    layout.repo_link = Some(Rect::new(
+                        area.x + 1,
+                        area.y + 1 + visible_row as u16,
+                        area.width.saturating_sub(2),
+                        1,
+                    ));
+                }
             }
         }
     }
-    if state.mouse_enabled {
+    if chrome.mouse_enabled {
         layout.close_button = Some(render_close_button(frame, area, &state.theme));
     }
 }
@@ -603,92 +624,59 @@ pub(super) fn render_preview(frame: &mut Frame, state: &AppState, layout: &mut M
 }
 
 pub(super) fn render_pins(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout) {
+    let vm = super::build_view_model(state);
+    if let super::ScreenVm::Pins(pins) = &vm.screen {
+        render_pins_vm(frame, state, pins, &vm.chrome, layout);
+    }
+}
+
+fn render_pins_vm(
+    frame: &mut Frame,
+    state: &AppState,
+    pins: &super::view_model::PinsVm,
+    chrome: &super::view_model::ChromeVm,
+    layout: &mut MouseLayout,
+) {
     let area = frame.area();
-    let area = render_top_bar(frame, area, &state.theme, state.mouse_enabled, layout);
-    // Sync feedback (e.g. "already in sync", "can't tell which side is newer") is set via
-    // state.status while staying on this screen, so the footer must surface it (see #72).
-    let (ftitle, footer, colored) = if state.pins.filtering {
-        (
-            "Filter (↑↓ move · Enter apply · Esc clear)".to_string(),
-            format!("/{}_", state.pins.filter_query),
-            false,
-        )
-    } else {
-        let (footer, colored) = footer_with_status(state.status.as_deref(), MINIMAL_HINT);
-        (String::new(), footer, colored)
-    };
+    let area = render_top_bar(frame, area, &state.theme, chrome.mouse_enabled, layout);
+    // Sync feedback (e.g. "already in sync") is carried in the Pins VM footer (see #72 / #241).
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Min(3),
-            Constraint::Length(footer_height(&footer, area.width, &ftitle)),
+            Constraint::Length(footer_height(&pins.footer, area.width, &pins.footer_title)),
         ])
         .split(area);
 
-    let visible = state.visible_pin_indices();
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0);
-    let items: Vec<ListItem> = if state.pinned.is_empty() {
-        vec![
-            ListItem::new("  📌 No pinned mappings found (use p to pin a pair)")
-                .style(Style::default().fg(state.theme.dim)),
-        ]
-    } else if visible.is_empty() {
-        vec![ListItem::new("  🔍 No pins match the filter")
-            .style(Style::default().fg(state.theme.dim))]
-    } else {
-        visible
+    let items: Vec<ListItem> = match pins.empty {
+        super::view_model::PinsEmptyKind::NoMappings => {
+            vec![
+                ListItem::new("  📌 No pinned mappings found (use p to pin a pair)")
+                    .style(Style::default().fg(state.theme.dim)),
+            ]
+        }
+        super::view_model::PinsEmptyKind::NoFilterMatch => {
+            vec![ListItem::new("  🔍 No pins match the filter")
+                .style(Style::default().fg(state.theme.dim))]
+        }
+        super::view_model::PinsEmptyKind::HasRows => pins
+            .rows
             .iter()
-            .map(|&i| {
-                let m = &state.pinned[i];
-                let (lts, rts) = state.pin_mtimes(i);
-                let age = |ts: Option<u64>| {
-                    ts.map(|t| crate::domain::humanize_age(now - t as i64))
-                        .unwrap_or_else(|| "?".to_string())
-                };
-                let status = state.pin_sync_status(i);
-                let local_age = if status == crate::domain::SyncStatus::Missing {
-                    "missing".to_string()
-                } else {
-                    age(lts)
-                };
-                let item = ListItem::new(hscroll_str(
-                    &pin_row_label(
-                        status.icon(),
-                        &m.local_path,
-                        &m.gist_id,
-                        &m.gist_filename,
-                        &local_age,
-                        &age(rts),
-                    ),
-                    state.pins.hscroll,
-                ));
-                if status == crate::domain::SyncStatus::Missing {
+            .map(|row| {
+                let item = ListItem::new(hscroll_str(&row.label, pins.hscroll));
+                if row.status == crate::domain::SyncStatus::Missing {
                     item.style(Style::default().fg(state.theme.del_color))
                 } else {
                     item
                 }
             })
-            .collect()
+            .collect(),
     };
 
-    let selected = (!visible.is_empty()).then_some(state.pins.index);
-    let mut title = format!(
-        "Pinned Mappings {}",
-        count_label(visible.len(), state.pinned.len())
-    );
-    if !state.pins.filter_query.is_empty() {
-        title.push_str(&format!(" · /{}", state.pins.filter_query));
-    }
-    if state.pins.sort != crate::tui::PinSort::Default {
-        title.push_str(&format!(" · sort:{}", state.pins.sort.label()));
-    }
     let list = List::new(items)
         .block(
             Block::default()
-                .title(title)
+                .title(pins.title.clone())
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
                 .border_style(Style::default().fg(state.theme.accent))
@@ -705,20 +693,20 @@ pub(super) fn render_pins(frame: &mut Frame, state: &AppState, layout: &mut Mous
         .highlight_symbol("▶ ");
 
     let mut list_state = ListState::default();
-    list_state.select(selected);
+    list_state.select(pins.selected);
     frame.render_stateful_widget(list, chunks[0], &mut list_state);
-    if state.mouse_enabled {
+    if chrome.mouse_enabled {
         layout.list = Some(PaneHit {
             rect: chunks[0],
             offset: list_state.offset(),
         });
     }
 
-    if state.pins.filtering {
+    if pins.filtering {
         render_footer_line(
             frame,
             chunks[1],
-            &ftitle,
+            &pins.footer_title,
             input_line("/", &state.pins.filter_query, ""),
             &state.theme,
             layout,
@@ -727,14 +715,14 @@ pub(super) fn render_pins(frame: &mut Frame, state: &AppState, layout: &mut Mous
         render_footer(
             frame,
             chunks[1],
-            &ftitle,
-            &footer,
-            colored,
+            &pins.footer_title,
+            &pins.footer,
+            pins.footer_colored,
             &state.theme,
             layout,
         );
     }
-    if state.mouse_enabled {
+    if chrome.mouse_enabled {
         layout.close_button = Some(render_close_button(frame, area, &state.theme));
     }
 }
@@ -2556,32 +2544,50 @@ pub(super) fn render_diff(frame: &mut Frame, state: &AppState, layout: &mut Mous
 /// #72 audit: this modal intentionally does not surface `state.status`. It is a transient y/n
 /// gate — confirming executes the action and transitions to `List`/`Gists`, where the result
 /// status is shown; cancelling returns to the launching screen without setting a status here.
+/// Modal chrome comes from the pure view model; background still reads `AppState` (#241).
 pub(super) fn render_confirm(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout) {
+    let vm = super::build_view_model(state);
+    if let super::ScreenVm::Confirm(confirm) = &vm.screen {
+        render_confirm_vm(frame, state, confirm, &vm.chrome, layout);
+    }
+}
+
+fn render_confirm_vm(
+    frame: &mut Frame,
+    state: &AppState,
+    confirm: &super::view_model::ConfirmVm,
+    chrome: &super::view_model::ChromeVm,
+    layout: &mut MouseLayout,
+) {
     match &state.pending_action {
         Some(PendingAction::CompactGist { gist_id, .. }) => {
             render_gist_info_and_files(frame, frame.area(), state, gist_id);
         }
         _ => render_diff_pane(frame, frame.area(), state),
     }
-    let (title, border) = confirm_modal_style(state);
-    // The create flow's description step is an active text input, so it needs the
-    // reverse-video cursor; every other confirm prompt is static text.
-    let modal = if matches!(state.pending_action, Some(PendingAction::Create { .. }))
-        && state.editing_description
-    {
-        render_centered_modal_input(
-            frame,
-            title,
-            CREATE_DESC_PREFIX,
-            &state.description_input,
-            CREATE_DESC_SUFFIX,
-            border,
-            &state.theme,
-        )
-    } else {
-        render_centered_modal(frame, title, &confirm_prompt(state), border, &state.theme)
+    let modal = match &confirm.kind {
+        super::view_model::ConfirmModalKind::DescriptionInput {
+            prefix,
+            value: _,
+            suffix,
+        } => {
+            // Cursor-aware paint still uses live `TextInput` from state (same buffer the VM
+            // snapshot was built from this frame).
+            render_centered_modal_input(
+                frame,
+                confirm.title,
+                prefix,
+                &state.description_input,
+                suffix,
+                confirm.border,
+                &state.theme,
+            )
+        }
+        super::view_model::ConfirmModalKind::Prompt { text } => {
+            render_centered_modal(frame, confirm.title, text, confirm.border, &state.theme)
+        }
     };
-    if state.mouse_enabled {
+    if chrome.mouse_enabled {
         // Put the close button on the modal box itself, not the full-screen corner.
         layout.close_button = Some(render_close_button(frame, modal, &state.theme));
     }

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -48,8 +48,22 @@ pub(super) fn run_loop(
         upload_edit_watch: None,
         bg: None,
     };
+    // Pins presentation cache: refresh on enter/return to Pins (or Pins-as-palette-bg) and
+    // whenever the dirty flag is set — never every frame while already on Pins (#241).
+    let mut pin_sync_screen_active = false;
 
     loop {
+        let pins_active = state.screen == Screen::Pins
+            || (state.screen == Screen::Palette && state.palette.origin_screen == Screen::Pins);
+        if pins_active
+            && (state.pin_sync_cache_dirty
+                || !pin_sync_screen_active
+                || state.pin_sync_cache.len() != state.pinned.len())
+        {
+            state.refresh_pin_sync_cache();
+        }
+        pin_sync_screen_active = pins_active;
+
         terminal.draw(|frame| render(frame, &state, &mut mouse_layout))?;
         if state.detail.comments_scroll_to_bottom {
             if let Some(max) = mouse_layout.comments_max_scroll {

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -4625,7 +4625,10 @@ fn pin_sync_status_is_missing_when_local_file_absent() {
     }];
 
     assert_eq!(
-        state.pin_sync_status(0),
+        {
+            state.refresh_pin_sync_cache();
+            state.cached_pin_sync_status(0)
+        },
         crate::domain::SyncStatus::Missing,
         "a pin whose local file doesn't exist must report Missing even though \
          the gist side has a known mtime"
@@ -4660,7 +4663,10 @@ fn pin_sync_status_upgrades_to_in_sync_when_content_hash_matches_baseline() {
     }];
 
     assert_eq!(
-        state.pin_sync_status(0),
+        {
+            state.refresh_pin_sync_cache();
+            state.cached_pin_sync_status(0)
+        },
         crate::domain::SyncStatus::InSync,
         "a matching content hash must override a stale-timestamp Push into InSync"
     );
@@ -4689,7 +4695,10 @@ fn pin_sync_status_keeps_push_when_content_hash_does_not_match_baseline() {
     }];
 
     assert_eq!(
-        state.pin_sync_status(0),
+        {
+            state.refresh_pin_sync_cache();
+            state.cached_pin_sync_status(0)
+        },
         crate::domain::SyncStatus::Push,
         "a non-matching baseline hash must not mask a real content change"
     );
@@ -4717,7 +4726,11 @@ fn pin_sync_status_keeps_push_when_no_baseline_hash_recorded() {
         ..GistFile::for_sync("g1".into(), "settings.json".into(), None)
     }];
 
-    assert_eq!(state.pin_sync_status(0), crate::domain::SyncStatus::Push);
+    state.refresh_pin_sync_cache();
+    assert_eq!(
+        state.cached_pin_sync_status(0),
+        crate::domain::SyncStatus::Push
+    );
 }
 
 #[test]

--- a/src/tui/view_model.rs
+++ b/src/tui/view_model.rs
@@ -1,0 +1,455 @@
+//! Pure presentation seam: `AppState` (+ pin-sync cache) → immutable view models.
+//!
+//! The draw path builds a [`ViewModel`] once per frame and paints from it for the first-batch
+//! screens (Pins, Confirm modal, Help). Other screens use [`ScreenVm::Legacy`] and may still
+//! read `AppState` for their body. Builders never touch the filesystem or network (issue #241).
+
+use super::render::{
+    about_topic_lines_plain, confirm_modal_style, confirm_prompt, count_label, footer_with_status,
+    help_topic_body, pin_row_label, CREATE_DESC_PREFIX, CREATE_DESC_SUFFIX, MINIMAL_HINT,
+};
+use super::{AppState, HelpTopic, PendingAction, Screen};
+use crate::domain::SyncStatus;
+use ratatui::style::Color;
+
+/// Full-frame presentation contract produced by [`build_view_model`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct ViewModel {
+    pub chrome: ChromeVm,
+    pub screen: ScreenVm,
+}
+
+/// Cross-screen chrome facts shared by every body (top bar / overlays).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChromeVm {
+    /// Whether mouse hit targets (close button, list hits) should be recorded.
+    pub mouse_enabled: bool,
+    /// Background task overlay message, if any.
+    pub bg_task_msg: Option<String>,
+    pub spinner_frame: usize,
+}
+
+/// Per-screen body. First-batch screens carry structured data; the rest are [`Legacy`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum ScreenVm {
+    Pins(PinsVm),
+    Confirm(ConfirmVm),
+    Help(HelpVm),
+    /// Body still painted from `AppState` directly (transition).
+    Legacy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PinsVm {
+    pub title: String,
+    pub empty: PinsEmptyKind,
+    pub rows: Vec<PinRowVm>,
+    /// Selected index into [`Self::rows`] (not the raw pin index).
+    pub selected: Option<usize>,
+    pub filtering: bool,
+    pub filter_query: String,
+    pub footer_title: String,
+    pub footer: String,
+    pub footer_colored: bool,
+    pub hscroll: u16,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PinsEmptyKind {
+    /// Has rows to show.
+    HasRows,
+    NoMappings,
+    NoFilterMatch,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PinRowVm {
+    pub pin_index: usize,
+    pub status: SyncStatus,
+    /// Full row label before horizontal scroll (paint and hscroll share this string).
+    pub label: String,
+}
+
+/// Confirm **modal** contract only — background diff/gist still reads `AppState`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConfirmVm {
+    pub title: &'static str,
+    pub border: Color,
+    pub kind: ConfirmModalKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfirmModalKind {
+    /// Static y/n (or multi-key) prompt body.
+    Prompt { text: String },
+    /// Create-flow description editor.
+    DescriptionInput {
+        prefix: &'static str,
+        value: String,
+        suffix: &'static str,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HelpVm {
+    pub mode: HelpModeVm,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HelpModeVm {
+    Index {
+        items: Vec<HelpIndexItemVm>,
+        selected: usize,
+    },
+    Topic {
+        title: String,
+        /// Plain lines for the topic body (About is pre-formatted without ratatui spans).
+        lines: Vec<String>,
+        scroll: u16,
+        /// Repo-link row index in About body lines, when this is the About topic.
+        about_repo_line: Option<usize>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HelpIndexItemVm {
+    pub key: String,
+    pub title: String,
+}
+
+/// Pure: map app state (+ pin sync cache) into a view model. No FS / network / mutation.
+pub fn build_view_model(state: &AppState) -> ViewModel {
+    let chrome = ChromeVm {
+        mouse_enabled: state.mouse_enabled,
+        bg_task_msg: state.bg_task_msg.clone(),
+        spinner_frame: state.spinner_frame,
+    };
+    let screen = match state.screen {
+        Screen::Pins => ScreenVm::Pins(build_pins_vm(state)),
+        Screen::Confirm => ScreenVm::Confirm(build_confirm_vm(state)),
+        Screen::Help => ScreenVm::Help(build_help_vm(state)),
+        _ => ScreenVm::Legacy,
+    };
+    ViewModel { chrome, screen }
+}
+
+fn build_pins_vm(state: &AppState) -> PinsVm {
+    let (footer_title, footer, footer_colored) = if state.pins.filtering {
+        (
+            "Filter (↑↓ move · Enter apply · Esc clear)".to_string(),
+            format!("/{}_", state.pins.filter_query),
+            false,
+        )
+    } else {
+        let (footer, colored) = footer_with_status(state.status.as_deref(), MINIMAL_HINT);
+        (String::new(), footer, colored)
+    };
+
+    let visible = state.visible_pin_indices();
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+
+    let (empty, rows) = if state.pinned.is_empty() {
+        (PinsEmptyKind::NoMappings, Vec::new())
+    } else if visible.is_empty() {
+        (PinsEmptyKind::NoFilterMatch, Vec::new())
+    } else {
+        let rows = visible
+            .iter()
+            .map(|&i| {
+                let m = &state.pinned[i];
+                let entry = state.cached_pin_sync_entry(i);
+                let status = entry.status;
+                let age = |ts: Option<u64>| {
+                    ts.map(|t| crate::domain::humanize_age(now - t as i64))
+                        .unwrap_or_else(|| "?".to_string())
+                };
+                let local_age = if status == SyncStatus::Missing {
+                    "missing".to_string()
+                } else {
+                    age(entry.local_ts)
+                };
+                let label = pin_row_label(
+                    status.icon(),
+                    &m.local_path,
+                    &m.gist_id,
+                    &m.gist_filename,
+                    &local_age,
+                    &age(entry.remote_ts),
+                );
+                PinRowVm {
+                    pin_index: i,
+                    status,
+                    label,
+                }
+            })
+            .collect();
+        (PinsEmptyKind::HasRows, rows)
+    };
+
+    let mut title = format!(
+        "Pinned Mappings {}",
+        count_label(visible.len(), state.pinned.len())
+    );
+    if !state.pins.filter_query.is_empty() {
+        title.push_str(&format!(" · /{}", state.pins.filter_query));
+    }
+    if state.pins.sort != crate::tui::PinSort::Default {
+        title.push_str(&format!(" · sort:{}", state.pins.sort.label()));
+    }
+
+    PinsVm {
+        title,
+        empty,
+        rows,
+        selected: (!visible.is_empty()).then_some(state.pins.index),
+        filtering: state.pins.filtering,
+        filter_query: state.pins.filter_query.to_string(),
+        footer_title,
+        footer,
+        footer_colored,
+        hscroll: state.pins.hscroll,
+    }
+}
+
+fn build_confirm_vm(state: &AppState) -> ConfirmVm {
+    let (title, border) = confirm_modal_style(state);
+    let kind = if matches!(state.pending_action, Some(PendingAction::Create { .. }))
+        && state.editing_description
+    {
+        ConfirmModalKind::DescriptionInput {
+            prefix: CREATE_DESC_PREFIX,
+            value: state.description_input.to_string(),
+            suffix: CREATE_DESC_SUFFIX,
+        }
+    } else {
+        ConfirmModalKind::Prompt {
+            text: confirm_prompt(state),
+        }
+    };
+    ConfirmVm {
+        title,
+        border,
+        kind,
+    }
+}
+
+fn build_help_vm(state: &AppState) -> HelpVm {
+    let mode = if state.help.index_open {
+        let items = HelpTopic::all()
+            .iter()
+            .enumerate()
+            .map(|(i, t)| {
+                let key = if *t == HelpTopic::About {
+                    "0".to_string()
+                } else {
+                    (i + 1).to_string()
+                };
+                HelpIndexItemVm {
+                    key,
+                    title: t.title().to_string(),
+                }
+            })
+            .collect();
+        HelpModeVm::Index {
+            items,
+            selected: state.help.index_sel,
+        }
+    } else {
+        let title = format!(
+            "Help · {} — Tab topics · ↑↓ scroll · Esc back",
+            state.help.topic.title()
+        );
+        let (lines, about_repo_line) = if state.help.topic == HelpTopic::About {
+            (
+                about_topic_lines_plain(state),
+                Some(super::render::ABOUT_REPO_LINE),
+            )
+        } else {
+            (
+                help_topic_body(state.help.topic)
+                    .lines()
+                    .map(str::to_string)
+                    .collect(),
+                None,
+            )
+        };
+        HelpModeVm::Topic {
+            title,
+            lines,
+            scroll: state.help.scroll,
+            about_repo_line,
+        }
+    };
+    HelpVm { mode }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{PinnedMapping, SyncStatus};
+    use crate::tui::initial_state;
+    use std::path::PathBuf;
+
+    #[test]
+    fn pins_vm_reads_cache_not_requiring_disk_for_status() {
+        let mut state = initial_state();
+        state.screen = Screen::Pins;
+        state.pinned = vec![PinnedMapping {
+            local_path: PathBuf::from("notes.txt"),
+            gist_id: "g1".into(),
+            gist_filename: "notes.txt".into(),
+            direction: None,
+            last_seen_hash: None,
+        }];
+        // Hand-populate cache — builder must not need a real file.
+        state.pin_sync_cache = vec![crate::tui::PinSyncCacheEntry {
+            status: SyncStatus::InSync,
+            local_ts: Some(100),
+            remote_ts: Some(100),
+        }];
+        state.pin_sync_cache_dirty = false;
+
+        let vm = build_view_model(&state);
+        match vm.screen {
+            ScreenVm::Pins(pins) => {
+                assert_eq!(pins.empty, PinsEmptyKind::HasRows);
+                assert_eq!(pins.rows.len(), 1);
+                assert_eq!(pins.rows[0].status, SyncStatus::InSync);
+                assert!(pins.rows[0].label.contains('✓'));
+                assert!(pins.rows[0].label.contains("notes.txt"));
+            }
+            other => panic!("expected Pins, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pins_vm_unknown_when_cache_missing() {
+        let mut state = initial_state();
+        state.screen = Screen::Pins;
+        state.pinned = vec![PinnedMapping {
+            local_path: PathBuf::from("a.txt"),
+            gist_id: "g1".into(),
+            gist_filename: "a.txt".into(),
+            direction: None,
+            last_seen_hash: None,
+        }];
+        state.pin_sync_cache.clear();
+        let vm = build_view_model(&state);
+        match vm.screen {
+            ScreenVm::Pins(pins) => {
+                assert_eq!(pins.rows[0].status, SyncStatus::Unknown);
+                assert!(pins.rows[0].label.starts_with('?'));
+            }
+            other => panic!("expected Pins, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pins_vm_empty_states() {
+        let mut state = initial_state();
+        state.screen = Screen::Pins;
+        let vm = build_view_model(&state);
+        match vm.screen {
+            ScreenVm::Pins(pins) => assert_eq!(pins.empty, PinsEmptyKind::NoMappings),
+            other => panic!("expected Pins, got {other:?}"),
+        }
+
+        state.pinned = vec![PinnedMapping {
+            local_path: PathBuf::from("a.txt"),
+            gist_id: "g1".into(),
+            gist_filename: "a.txt".into(),
+            direction: None,
+            last_seen_hash: None,
+        }];
+        state.pins.filter_query = crate::tui::TextInput::from("zzz-no-match");
+        state.pin_sync_cache = vec![crate::tui::PinSyncCacheEntry::default()];
+        let vm = build_view_model(&state);
+        match vm.screen {
+            ScreenVm::Pins(pins) => assert_eq!(pins.empty, PinsEmptyKind::NoFilterMatch),
+            other => panic!("expected Pins, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn confirm_vm_prompt_identity() {
+        let mut state = initial_state();
+        state.screen = Screen::Confirm;
+        state.pending_action = Some(PendingAction::Upload {
+            gist_id: "g1".into(),
+            filename: "notes.txt".into(),
+            local_path: PathBuf::from("notes.txt"),
+        });
+        let vm = build_view_model(&state);
+        match vm.screen {
+            ScreenVm::Confirm(c) => {
+                assert_eq!(c.title, "Upload");
+                match c.kind {
+                    ConfirmModalKind::Prompt { text } => {
+                        assert!(text.contains("Upload notes.txt to gist g1"));
+                    }
+                    other => panic!("expected Prompt, got {other:?}"),
+                }
+            }
+            other => panic!("expected Confirm, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn confirm_vm_overwrite_download() {
+        let mut state = initial_state();
+        state.screen = Screen::Confirm;
+        state.pending_action = Some(PendingAction::Download);
+        state.download_target = PathBuf::from("notes.txt");
+        let vm = build_view_model(&state);
+        match vm.screen {
+            ScreenVm::Confirm(c) => {
+                assert_eq!(c.title, "Overwrite");
+                match c.kind {
+                    ConfirmModalKind::Prompt { text } => {
+                        assert!(text.contains("Overwrite notes.txt"));
+                    }
+                    other => panic!("expected Prompt, got {other:?}"),
+                }
+            }
+            other => panic!("expected Confirm, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn help_vm_index_lists_topics() {
+        let mut state = initial_state();
+        state.screen = Screen::Help;
+        state.help.index_open = true;
+        let vm = build_view_model(&state);
+        match vm.screen {
+            ScreenVm::Help(h) => match h.mode {
+                HelpModeVm::Index { items, selected } => {
+                    assert!(!items.is_empty());
+                    assert_eq!(selected, 0);
+                    assert!(items.iter().any(|i| i.title.contains("List")));
+                }
+                other => panic!("expected Index, got {other:?}"),
+            },
+            other => panic!("expected Help, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn legacy_for_list_screen() {
+        let state = initial_state();
+        assert!(matches!(build_view_model(&state).screen, ScreenVm::Legacy));
+    }
+
+    #[test]
+    fn chrome_carries_bg_task() {
+        let mut state = initial_state();
+        state.bg_task_msg = Some("Working…".into());
+        state.spinner_frame = 3;
+        let vm = build_view_model(&state);
+        assert_eq!(vm.chrome.bg_task_msg.as_deref(), Some("Working…"));
+        assert_eq!(vm.chrome.spinner_frame, 3);
+    }
+}


### PR DESCRIPTION
## Summary

- Introduce pure `build_view_model` (`ChromeVm` + `ScreenVm`) so first-batch screens (Pins, Confirm modal, Help) paint from presentation facts instead of ad hoc `AppState` reads.
- Move pin sync presentation off the render hot path: `refresh_pin_sync_cache` (impure) fills `AppState::pin_sync_cache`; paint/VM only use cached status; action dispatch still uses `compute_pin_sync_status` for one-shot decisions.
- Document the pure/IO boundary in `AGENTS.md`. Keymap and overwrite safety are unchanged.

Closes #241

## Test plan

- [x] `mise run check` (fmt, clippy `-D warnings`, full test suite)
- [x] New view-model unit tests (Pins cache/unknown/empty, Confirm prompt identity, Help index, Legacy List)
- [x] Existing pin sync hash-behaviour tests retargeted at refresh + cache
- [ ] Manual smoke (optional): open Pins, confirm overwrite, Help — badges/prompts look unchanged