### PR TITLE
refactor(tui): introduce nav_stack for screen return targets

### DIFF
--- a/src/tui/bg.rs
+++ b/src/tui/bg.rs
@@ -431,15 +431,15 @@ pub(super) fn pin_local_abs(state: &AppState, m: &crate::domain::PinnedMapping) 
     }
 }
 
-/// Park the current Pins payload on `diff_return` so pin diffs/confirm restore list state.
-fn park_pins_on_diff_return(state: &mut AppState) {
-    if let Screen::Pins(p) = &state.screen {
-        state.diff_return = Screen::Pins(p.clone());
-    } else if let Some(p) = state.pins() {
-        state.diff_return = Screen::Pins(Box::new(p.clone()));
-    } else {
-        state.diff_return = Screen::Pins(Box::default());
-    }
+/// Stage the current Pins payload as `pending_return` so the pin diff/confirm entered once this
+/// (async) flow's background fetch lands restores list state, not wherever the user has since
+/// navigated to.
+pub(super) fn park_pins_on_diff_return(state: &mut AppState) {
+    let pins = match &state.screen {
+        Screen::Pins(p) => p.as_ref().clone(),
+        _ => state.pins().cloned().unwrap_or_default(),
+    };
+    state.pending_return = Some(Screen::Pins(Box::new(pins)));
 }
 
 /// Spawn the push (upload local → gist) flow for a pin: lands in the existing
@@ -882,15 +882,6 @@ pub(super) fn download(state: &mut AppState, mode: crate::actions::DownloadMode)
             (Some(g), Some(f)) => Some((g.clone(), f.clone())),
             _ => None,
         });
-    // Prefer Confirm's nested Diff return (download overwrite gate) or Diff payload return.
-    let return_screen = match &state.screen {
-        Screen::Confirm(c) => match &c.return_screen {
-            Screen::Diff(d) => d.return_screen.clone(),
-            other => other.clone(),
-        },
-        Screen::Diff(d) => d.return_screen.clone(),
-        _ => state.diff_return.clone(),
-    };
     match crate::actions::execute_download(&target, &content, mode) {
         Ok(()) => {
             state.set_status(format!(
@@ -910,8 +901,16 @@ pub(super) fn download(state: &mut AppState, mode: crate::actions::DownloadMode)
                     Some(crate::domain::SyncDirection::Download),
                 );
             }
-            state.back_to_list();
-            state.screen = return_screen;
+            // Diff pairing identity lives on the payload; leaving drops it.
+            state.staged_diff_gist = None;
+            // Skip past the download overwrite gate's Confirm (if any) and its parked Diff to
+            // land on whatever was behind them.
+            if state.screen.is_confirm() {
+                state.leave();
+            }
+            if state.screen.is_diff() {
+                state.leave();
+            }
             refresh_locals(state);
         }
         Err(error) => {
@@ -1592,12 +1591,8 @@ fn absorb_background_results_body(
                             }
                             // Return to wherever this upload was initiated from (List, or Pins
                             // for a pin push) instead of always snapping to List.
-                            let return_screen = state
-                                .confirm()
-                                .map(|c| c.return_screen.clone())
-                                .unwrap_or_else(|| state.diff_return.clone());
-                            state.back_to_list();
-                            state.screen = return_screen;
+                            state.staged_diff_gist = None;
+                            state.leave();
                             channels.request_gist_fetch(state);
                         }
                         Err(error) => {
@@ -1679,11 +1674,8 @@ fn absorb_background_results_body(
                             "\"{label}\" already has a single revision — nothing to compact"
                         )),
                         Ok(count) => {
-                            // Park compact restore target so Confirm cancel/execute restore it.
-                            state.diff_return = state
-                                .detail()
-                                .map(|d| d.compact_return_screen.clone())
-                                .unwrap_or_else(|| state.park_gist_detail_screen());
+                            // `pending_return` was staged at the 'c' keypress (keys.rs); `enter`
+                            // (inside `enter_confirm`) consumes it as the Confirm cancel path.
                             state.enter_confirm(
                                 PendingAction::CompactGist {
                                     gist_id: gist_id.clone(),
@@ -1756,10 +1748,8 @@ fn absorb_background_results_body(
                                 state.ignore_trailing_newline,
                             );
                             let identical = old_content == new_content;
-                            // Park revision payload so Esc restores list cursor/entries.
-                            if let Screen::Revisions(rev) = &state.screen {
-                                state.diff_return = Screen::Revisions(rev.clone());
-                            }
+                            // `enter_diff` (via `enter`) parks the live Revisions screen so Esc
+                            // restores list cursor/entries.
                             state.enter_diff(diff, String::new(), PathBuf::new(), PathBuf::new());
                             if let Some(d) = state.diff_mut() {
                                 d.identical = identical;
@@ -1788,10 +1778,8 @@ fn absorb_background_results_body(
                                 &current_content,
                                 state.ignore_trailing_newline,
                             );
-                            // Park revisions list so cancel restores cursor/entries.
-                            if let Screen::Revisions(rev) = &state.screen {
-                                state.diff_return = Screen::Revisions(rev.clone());
-                            }
+                            // `enter_confirm` (via `enter`) parks the live Revisions screen so
+                            // cancel restores cursor/entries.
                             state.enter_confirm(
                                 PendingAction::RestoreRevision {
                                     gist_id,
@@ -1841,19 +1829,18 @@ fn absorb_background_results_body(
                             state.set_status(format!(
                                 "Restored {filename} from old revision (new revision created)"
                             ));
-                            // Return to revisions list (prefer payload on Confirm return).
-                            let mut rev = match state.confirm().map(|c| &c.return_screen) {
-                                Some(Screen::Revisions(r)) => r.as_ref().clone(),
-                                _ => match &state.diff_return {
-                                    Screen::Revisions(r) => r.as_ref().clone(),
-                                    _ => state.revision().cloned().unwrap_or_default(),
-                                },
-                            };
-                            let gist_id = rev.gist_id.clone();
-                            rev.index = 0;
-                            rev.entries = None;
-                            rev.fetch_error = None;
-                            state.screen = Screen::Revisions(Box::new(rev));
+                            // Return to the revisions list `enter_confirm` parked when the
+                            // restore confirm was entered.
+                            state.leave();
+                            if !state.screen.is_revisions() {
+                                state.screen = Screen::Revisions(Box::default());
+                            }
+                            let gist_id = state.revision_mut().and_then(|rev| {
+                                rev.index = 0;
+                                rev.entries = None;
+                                rev.fetch_error = None;
+                                rev.gist_id.clone()
+                            });
                             channels.request_gist_fetch(state);
                             if let Some(gist_id) = gist_id {
                                 channels.spawn_action(state, "Loading revisions…", move || {

--- a/src/tui/dispatch.rs
+++ b/src/tui/dispatch.rs
@@ -24,7 +24,7 @@ pub(super) fn dispatch_outcome(
             upload_orientation,
         } => {
             // List-originated diff returns to List on Esc.
-            state.diff_return = Screen::List;
+            state.pending_return = Some(Screen::List);
             let gist = GistFile::for_sync(gist_id.clone(), filename.clone(), raw_url.clone());
             let (local_label, gist_label) = diff_labels(local_path.as_deref(), &gist);
 
@@ -63,19 +63,13 @@ pub(super) fn dispatch_outcome(
             });
         }
         KeyOutcome::OpenGistDetail { gist_id } => {
-            let gists_return = match &state.screen {
-                Screen::Gists(g) => Screen::Gists(g.clone()),
-                _ => Screen::Gists(Box::default()),
-            };
-            state.screen = Screen::GistDetail(Box::new(DetailState {
+            state.enter(Screen::GistDetail(Box::new(DetailState {
                 gist_id: Some(gist_id),
-                return_screen: gists_return,
-                compact_return_screen: Screen::Gists(Box::default()),
                 focus: DetailFocus::Files,
                 file_cursor: 0,
                 scroll: 0,
                 ..DetailState::default()
-            }));
+            })));
             state.reset_comment_pagination();
         }
         KeyOutcome::FetchComments { gist_id } => {
@@ -154,7 +148,7 @@ pub(super) fn dispatch_outcome(
             filename,
         } => {
             if !state.is_pin_diff_context() {
-                state.diff_return = Screen::List;
+                state.pending_return = Some(Screen::List);
             }
             let action = PendingAction::Upload {
                 gist_id,
@@ -185,7 +179,7 @@ pub(super) fn dispatch_outcome(
             from_pin_diff,
         } => {
             if !from_pin_diff {
-                state.diff_return = Screen::List;
+                state.pending_return = Some(Screen::List);
             }
             let gist_file = state
                 .gists
@@ -250,12 +244,8 @@ pub(super) fn dispatch_outcome(
                 crate::actions::upload_add_command(&temp_file_path, &gist_id)
             };
 
-            let return_screen = state
-                .confirm()
-                .map(|c| c.return_screen.clone())
-                .unwrap_or_else(|| state.diff_return.clone());
-            state.back_to_list();
-            state.screen = return_screen;
+            state.staged_diff_gist = None;
+            state.leave();
             jobs.spawn_action(state, "Uploading…", move || {
                 let result = crate::actions::execute_command(&plan)
                     .map(|_| ())
@@ -314,8 +304,8 @@ pub(super) fn dispatch_outcome(
         }
         KeyOutcome::RefreshPreview { gist_id, filename } => {
             // Keep the current return path when reloading.
-            if let Some(p) = state.preview() {
-                state.preview_return = p.return_screen.clone();
+            if state.screen.is_preview() {
+                state.pending_return = state.nav_stack.last().cloned();
             }
             let key = (gist_id.clone(), filename.clone());
             state.gist_content_cache.remove(&key);
@@ -469,11 +459,7 @@ pub(super) fn dispatch_outcome(
         }
         KeyOutcome::PreviewPinDiff { index } => {
             if let Some(m) = state.pinned.get(index).cloned() {
-                if let Screen::Pins(p) = &state.screen {
-                    state.diff_return = Screen::Pins(p.clone());
-                } else {
-                    state.diff_return = Screen::Pins(Box::default());
-                }
+                park_pins_on_diff_return(state);
                 spawn_pin_diff(state, jobs, &m);
             }
         }

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -103,21 +103,19 @@ impl AppState {
 
     /// Open the Help screen on the topic for the current screen, remembering where to return.
     /// A no-op while already on Help — otherwise the top bar's `(?)Help` click (reachable from
-    /// any screen, including Help itself) would overwrite `return_screen` with `Screen::Help`,
+    /// any screen, including Help itself) would push `Screen::Help` onto its own nav_stack,
     /// trapping Esc/`?`/the close button in Help with no keyboard way out.
     pub(crate) fn open_help(&mut self) {
         if self.screen.is_help() {
             return;
         }
-        let return_screen = self.screen.clone();
-        let topic = HelpTopic::for_screen(&return_screen);
-        self.screen = Screen::Help(Box::new(HelpState {
-            return_screen,
+        let topic = HelpTopic::for_screen(&self.screen);
+        self.enter(Screen::Help(Box::new(HelpState {
             topic,
             index_open: false,
             scroll: 0,
             index_sel: 0,
-        }));
+        })));
     }
 
     /// Open the flat Settings screen (`C` or palette). Opening alone does not write config.
@@ -125,11 +123,7 @@ impl AppState {
         if self.screen.is_config() {
             return;
         }
-        let return_screen = self.screen.clone();
-        self.screen = Screen::Config(Box::new(ConfigState {
-            index: 0,
-            return_screen,
-        }));
+        self.enter(Screen::Config(Box::new(ConfigState { index: 0 })));
     }
 
     /// Value string shown for a Config field row.
@@ -231,11 +225,7 @@ impl AppState {
         let n = ConfigField::ALL.len();
         match code {
             KeyCode::Char('q') | KeyCode::Esc => {
-                let ret = match &self.screen {
-                    Screen::Config(c) => c.return_screen.clone(),
-                    _ => Screen::List,
-                };
-                self.screen = ret;
+                self.leave();
             }
             KeyCode::Up | KeyCode::Char('k') => {
                 if let Some(c) = self.config_mut() {
@@ -562,11 +552,7 @@ impl AppState {
             }
         }
         if leave {
-            let ret = match &self.screen {
-                Screen::Help(h) => h.return_screen.clone(),
-                _ => Screen::List,
-            };
-            self.screen = ret;
+            self.leave();
         }
         KeyOutcome::None
     }
@@ -767,11 +753,7 @@ impl AppState {
                 return KeyOutcome::CopyGistUrl { gist_id };
             }
             KeyCode::Char('H') if index < groups_len => {
-                let ret = match &self.screen {
-                    Screen::Gists(g) => Screen::Gists(g.clone()),
-                    _ => Screen::Gists(Box::default()),
-                };
-                if self.open_revisions(ret) {
+                if self.open_revisions() {
                     if let Some(gist_id) = self.revision().and_then(|r| r.gist_id.clone()) {
                         return KeyOutcome::FetchRevisions { gist_id };
                     }
@@ -813,11 +795,7 @@ impl AppState {
         }
         match code {
             KeyCode::Char('q') | KeyCode::Esc => {
-                let ret = self
-                    .detail()
-                    .map(|d| d.return_screen.clone())
-                    .unwrap_or_else(|| Screen::Gists(Box::default()));
-                self.screen = ret;
+                self.leave();
             }
             KeyCode::Char('o') => {
                 let Some(gist_id) = self.context_gist_id() else {
@@ -832,8 +810,7 @@ impl AppState {
                 return KeyOutcome::CopyGistUrl { gist_id };
             }
             KeyCode::Char('H') => {
-                let ret = self.park_gist_detail_screen();
-                if self.open_revisions(ret) {
+                if self.open_revisions() {
                     if let Some(gist_id) = self.revision().and_then(|r| r.gist_id.clone()) {
                         return KeyOutcome::FetchRevisions { gist_id };
                     }
@@ -858,10 +835,7 @@ impl AppState {
                 if !self.gist_is_owned(&id) {
                     return KeyOutcome::None;
                 }
-                let parked = self.park_gist_detail_screen();
-                if let Some(d) = self.detail_mut() {
-                    d.compact_return_screen = parked;
-                }
+                self.pending_return = Some(self.park_gist_detail_screen());
                 let label = self
                     .group_by_id(&id)
                     .map(|g| {
@@ -910,8 +884,6 @@ impl AppState {
                     } else {
                         group.description.clone()
                     };
-                    // Park detail so cancel can restore; staged into Confirm.return_screen.
-                    self.diff_return = self.park_gist_detail_screen();
                     let text = format!(
                         "Delete gist {} ({} file(s)): {label}.\n\nThis permanently removes the entire gist and all its files.",
                         group.id, group.file_count
@@ -932,7 +904,7 @@ impl AppState {
                         if self.block_if_non_previewable_gist_file(&gist_id, &filename) {
                             return KeyOutcome::None;
                         }
-                        self.preview_return = self.park_gist_detail_screen();
+                        self.pending_return = Some(self.park_gist_detail_screen());
                         return KeyOutcome::PreviewContent { gist_id, filename };
                     }
                 }
@@ -968,11 +940,7 @@ impl AppState {
             .unwrap_or(0);
         match code {
             KeyCode::Char('q') | KeyCode::Esc => {
-                let ret = self
-                    .revision()
-                    .map(|r| r.return_screen.clone())
-                    .unwrap_or(Screen::List);
-                self.screen = ret;
+                self.leave();
             }
             KeyCode::Enter if entries_len > 0 => {
                 return self.revision_diff_incremental_intent();
@@ -1211,7 +1179,7 @@ impl AppState {
                 if self.block_if_non_previewable_gist_file(&gist_id, &filename) {
                     return KeyOutcome::None;
                 }
-                self.preview_return = self.park_gist_detail_screen();
+                self.pending_return = Some(self.park_gist_detail_screen());
                 return KeyOutcome::PreviewContent { gist_id, filename };
             }
         }
@@ -1499,12 +1467,7 @@ impl AppState {
             // In the preview, q and Esc return to wherever it was launched from (the list, or
             // the gist detail view) — never an accidental app exit.
             KeyCode::Char('q') | KeyCode::Esc => {
-                let ret = self
-                    .preview()
-                    .map(|p| p.return_screen.clone())
-                    .unwrap_or(Screen::List);
-                self.preview_return = Screen::List;
-                self.screen = ret;
+                self.leave();
             }
             KeyCode::Char('R') => {
                 let Some(p) = self.preview() else {
@@ -1687,7 +1650,7 @@ impl AppState {
                 let (_, ranked) = self.list_pane_snapshots();
                 if ranked.get(self.gist_index).is_none() {
                     self.status = Some("select a gist file to view revision history".into());
-                } else if self.open_revisions(Screen::List) {
+                } else if self.open_revisions() {
                     if let Some(gist_id) = self.revision().and_then(|r| r.gist_id.clone()) {
                         return KeyOutcome::FetchRevisions { gist_id };
                     }
@@ -1713,7 +1676,7 @@ impl AppState {
                 {
                     return KeyOutcome::None;
                 }
-                self.preview_return = Screen::List;
+                self.pending_return = Some(Screen::List);
                 return KeyOutcome::PreviewContent {
                     gist_id: gist.file.gist_id.clone(),
                     filename: gist.file.filename.clone(),
@@ -2001,7 +1964,7 @@ impl AppState {
         } else {
             gist.file.description.clone()
         };
-        self.diff_return = Screen::List;
+        self.pending_return = Some(Screen::List);
         let text = format!(
             "Remove file \"{filename}\" from gist {gist_id} ({label}).\n\nThe other files in this gist are kept. This cannot be undone."
         );
@@ -2025,7 +1988,7 @@ impl AppState {
         };
         self.editing_description = true;
         self.description_input.clear();
-        self.diff_return = Screen::List;
+        self.pending_return = Some(Screen::List);
         self.enter_confirm(
             PendingAction::Create {
                 local_path: local.path.clone(),
@@ -2039,14 +2002,12 @@ impl AppState {
 
     fn handle_key_diff(&mut self, code: KeyCode) -> KeyOutcome {
         match code {
-            // In the diff, q and Esc return to the payload return path (List, Pins, …).
+            // In the diff, q and Esc return to wherever `enter()` recorded (List, Pins, …).
             KeyCode::Char('q') | KeyCode::Esc => {
-                let ret = self
-                    .diff()
-                    .map(|d| d.return_screen.clone())
-                    .unwrap_or(Screen::List);
-                self.back_to_list();
-                self.screen = ret;
+                // Diff pairing identity lives on the payload; leaving drops it (not a full
+                // `back_to_list()` — that would also discard the rest of `nav_stack`).
+                self.staged_diff_gist = None;
+                self.leave();
             }
             // Identical files have nothing to sync, so download/upload are not offered.
             // Revision-history diffs are read-only (no local file pairing).

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -276,7 +276,6 @@ impl ConfigField {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ConfigState {
     pub index: usize,
-    pub return_screen: Screen,
 }
 
 /// A help topic — one per key-dense area, plus `About` (version/repo/update info, not tied
@@ -831,8 +830,6 @@ pub struct RevisionState {
     pub hscroll: u16,
     /// File within the gist that preview/diff/restore target.
     pub target_file: String,
-    /// Where `q`/`Esc` returns from `Screen::Revisions`.
-    pub return_screen: Screen,
     /// Error from the commits-list fetch, if any.
     pub fetch_error: Option<String>,
 }
@@ -841,8 +838,6 @@ pub struct RevisionState {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct HelpState {
     pub scroll: u16,
-    /// Screen to return to when leaving Help (mirrors `preview_return` / `diff_return`).
-    pub return_screen: Screen,
     /// The topic shown in the Help screen's topic view.
     pub topic: HelpTopic,
     /// When true the Help screen shows the topic index instead of a topic body.
@@ -871,8 +866,6 @@ pub struct PreviewState {
     pub hscroll: u16,
     /// `(gist_id, filename)` for refresh / copy-url context.
     pub gist_key: Option<(String, String)>,
-    /// Where `q`/`Esc` returns (List, GistDetail payload, etc.).
-    pub return_screen: Screen,
 }
 
 /// Unified-diff view — carried on [`Screen::Diff`] (issue #242).
@@ -883,8 +876,6 @@ pub struct DiffState {
     pub text: String,
     pub scroll: u16,
     pub hscroll: u16,
-    /// Where `q`/`Esc` returns (List, Pins, Revisions, …).
-    pub return_screen: Screen,
     /// Remote file body (download source content).
     pub remote_content: String,
     /// Local path paired in the diff (empty for revision-only comparisons).
@@ -907,8 +898,6 @@ pub struct ConfirmState {
     pub text: String,
     pub scroll: u16,
     pub hscroll: u16,
-    /// Where cancel lands (may be [`Screen::Diff`] after a download overwrite gate).
-    pub return_screen: Screen,
 }
 
 impl Default for ConfirmState {
@@ -918,7 +907,6 @@ impl Default for ConfirmState {
             text: String::new(),
             scroll: 0,
             hscroll: 0,
-            return_screen: Screen::List,
         }
     }
 }
@@ -939,7 +927,7 @@ pub struct GistsManagerState {
 /// Gist-detail screen state — carried on [`Screen::GistDetail`] (issue #242). Data only —
 /// the detail/comment methods stay on `AppState`. The `comments_*` count/paging fields keep
 /// their prefix so they don't collide with the `comments` Vec.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct DetailState {
     /// The gist currently shown; also guards stale comment responses.
     pub gist_id: Option<String>,
@@ -963,30 +951,6 @@ pub struct DetailState {
     pub focus: DetailFocus,
     /// Cursor index into the detail gist's files when `focus == Files`.
     pub file_cursor: usize,
-    /// Where `q`/`Esc` returns from detail (usually [`Screen::Gists`] with its payload).
-    pub return_screen: Screen,
-    /// Screen to return to after a compaction confirm is cancelled/finished (Gists or GistDetail).
-    pub compact_return_screen: Screen,
-}
-
-impl Default for DetailState {
-    fn default() -> Self {
-        Self {
-            gist_id: None,
-            comments: None,
-            comments_loading: false,
-            comments_error: None,
-            comments_total: None,
-            comments_loaded_oldest_page: 0,
-            comments_loading_more: false,
-            comments_scroll_to_bottom: false,
-            scroll: 0,
-            focus: DetailFocus::default(),
-            file_cursor: 0,
-            return_screen: Screen::Gists(Box::default()),
-            compact_return_screen: Screen::Gists(Box::default()),
-        }
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -1057,9 +1021,6 @@ pub struct AppState {
     /// How this binary was installed — resolved once at startup so the update hint can show
     /// the right upgrade command without per-frame IO.
     pub install_method: crate::upgrade::InstallMethod,
-    /// Staged return path for the next preview open (copied into [`PreviewState::return_screen`]
-    /// when Preview is entered). Live Esc path while Preview is open lives on the payload.
-    pub preview_return: Screen,
     pub gist_content_cache: crate::lru::LruCache<(String, String), String>,
     pub local_recursive: bool,
     pub skip_dirs: Vec<String>,
@@ -1083,10 +1044,15 @@ pub struct AppState {
     /// Staged pin/pull gist identity for the next [`Self::enter_diff`] (consumed into
     /// [`DiffState`]). Live identity while Diff/Confirm is open lives on the payload.
     pub staged_diff_gist: Option<(String, String)>,
-    /// Staged return path for the next Diff/Confirm open (copied into the payload by
-    /// [`Self::enter_diff`] / [`Self::enter_confirm`]). Live Esc path while Diff/Confirm is
-    /// open lives on the payload (issue #242).
-    pub diff_return: Screen,
+    /// Navigation history (issue #271): every [`Self::enter`] pushes the screen being left;
+    /// every [`Self::leave`] pops back to it. Flat — a screen's own return path never lives on
+    /// its payload.
+    pub nav_stack: Vec<Screen>,
+    /// Staged return target for a screen entered asynchronously (issue #271): set at the
+    /// triggering keypress (before the background fetch that will eventually call
+    /// [`Self::enter`] completes), since `self.screen` may have changed by the time that
+    /// happens. [`Self::enter`] consumes it in place of the live screen when present.
+    pub pending_return: Option<Screen>,
     /// Monotonic tick advanced once per event-loop iteration (~150ms); drives the in-progress
     /// spinner animation. Wraps freely — only its value modulo the frame count is observed.
     pub spinner_frame: usize,
@@ -1153,13 +1119,35 @@ fn unranked_locals(locals: &[LocalCandidate]) -> Vec<RankedLocal> {
 }
 
 impl AppState {
+    /// Finds the nearest screen (current, then Palette's origin if the overlay is open, then
+    /// `nav_stack` from most to least recent) matching `tag` (issue #271). Replaces the
+    /// hand-nested "walk return_screen" chains each payload accessor used to write for itself —
+    /// a payload's return path no longer lives on its own struct, so there's nothing left to
+    /// walk except the shared history.
+    fn find_screen(&self, tag: fn(&Screen) -> bool) -> Option<&Screen> {
+        let start = match &self.screen {
+            Screen::Palette(p) => &p.origin_screen,
+            s => s,
+        };
+        std::iter::once(start)
+            .chain(self.nav_stack.iter().rev())
+            .find(|s| tag(s))
+    }
+
+    fn find_screen_mut(&mut self, tag: fn(&Screen) -> bool) -> Option<&mut Screen> {
+        let start = match &mut self.screen {
+            Screen::Palette(p) => &mut p.origin_screen,
+            s => s,
+        };
+        std::iter::once(start)
+            .chain(self.nav_stack.iter_mut().rev())
+            .find(|s| tag(s))
+    }
+
     /// Help payload when Help is active, or when the palette is open over Help (issue #242).
     pub fn help(&self) -> Option<&HelpState> {
-        match &self.screen {
-            Screen::Help(h) => Some(h.as_ref()),
-            Screen::Palette(p) => p.origin_screen.help_state(),
-            _ => None,
-        }
+        self.find_screen(Screen::is_help)
+            .and_then(Screen::help_state)
     }
 
     /// Mutable help payload when Help is the active screen (not via palette origin).
@@ -1169,188 +1157,60 @@ impl AppState {
 
     /// Config payload when Settings is active, or when the palette is open over Config.
     pub fn config(&self) -> Option<&ConfigState> {
-        match &self.screen {
-            Screen::Config(c) => Some(c.as_ref()),
-            Screen::Palette(p) => p.origin_screen.config_state(),
-            _ => None,
-        }
+        self.find_screen(Screen::is_config)
+            .and_then(Screen::config_state)
     }
 
     pub fn config_mut(&mut self) -> Option<&mut ConfigState> {
         self.screen.config_state_mut()
     }
 
-    /// Revision payload when Revisions is active, parked on Diff/Confirm return, or under
-    /// palette origin (issue #242).
+    /// Revision payload when Revisions is active, parked on the Diff/Confirm/Preview return
+    /// path, or under palette origin (issue #242).
     pub fn revision(&self) -> Option<&RevisionState> {
-        match &self.screen {
-            Screen::Revisions(r) => Some(r.as_ref()),
-            Screen::Diff(d) => d.return_screen.revision_state(),
-            Screen::Confirm(c) => Self::nav_return_of_confirm(c).revision_state(),
-            Screen::Preview(p) => p.return_screen.revision_state(),
-            Screen::Palette(p) => p.origin_screen.revision_state(),
-            _ => None,
-        }
+        self.find_screen(Screen::is_revisions)
+            .and_then(Screen::revision_state)
     }
 
     pub fn revision_mut(&mut self) -> Option<&mut RevisionState> {
-        match &mut self.screen {
-            Screen::Revisions(r) => Some(r.as_mut()),
-            Screen::Diff(d) => d.return_screen.revision_state_mut(),
-            Screen::Confirm(c) => match &mut c.return_screen {
-                Screen::Diff(d) => d.return_screen.revision_state_mut(),
-                other => other.revision_state_mut(),
-            },
-            Screen::Preview(p) => p.return_screen.revision_state_mut(),
-            _ => None,
-        }
+        self.find_screen_mut(Screen::is_revisions)
+            .and_then(Screen::revision_state_mut)
     }
 
-    /// Pins payload when Pins is active, parked on Diff/Confirm return, or under palette
-    /// origin (issue #242).
+    /// Pins payload when Pins is active, parked on the Diff/Confirm/Preview return path, or
+    /// under palette origin (issue #242).
     pub fn pins(&self) -> Option<&PinsState> {
-        match &self.screen {
-            Screen::Pins(p) => Some(p.as_ref()),
-            Screen::Diff(d) => d.return_screen.pins_state(),
-            Screen::Confirm(c) => Self::nav_return_of_confirm(c).pins_state(),
-            Screen::Preview(p) => p.return_screen.pins_state(),
-            Screen::Palette(p) => p.origin_screen.pins_state(),
-            _ => None,
-        }
+        self.find_screen(Screen::is_pins)
+            .and_then(Screen::pins_state)
     }
 
     pub fn pins_mut(&mut self) -> Option<&mut PinsState> {
-        match &mut self.screen {
-            Screen::Pins(p) => Some(p.as_mut()),
-            Screen::Diff(d) => d.return_screen.pins_state_mut(),
-            Screen::Confirm(c) => match &mut c.return_screen {
-                Screen::Diff(d) => d.return_screen.pins_state_mut(),
-                other => other.pins_state_mut(),
-            },
-            Screen::Preview(p) => p.return_screen.pins_state_mut(),
-            _ => None,
-        }
+        self.find_screen_mut(Screen::is_pins)
+            .and_then(Screen::pins_state_mut)
     }
 
-    /// Nested Diff cancel path: Confirm may park `Screen::Diff` so download-n restores Diff.
-    fn nav_return_of_confirm(c: &ConfirmState) -> &Screen {
-        match &c.return_screen {
-            Screen::Diff(d) => &d.return_screen,
-            other => other,
-        }
-    }
-
-    /// Gist-manager payload when Gists is active, parked on detail/revision return paths, or
+    /// Gist-manager payload when Gists is active, parked on a detail/revision return path, or
     /// under palette origin (issue #242).
     pub fn gist_manager(&self) -> Option<&GistsManagerState> {
-        match &self.screen {
-            Screen::Gists(g) => Some(g.as_ref()),
-            Screen::GistDetail(d) => d.return_screen.gists_state(),
-            Screen::Revisions(r) => r.return_screen.gists_state(),
-            Screen::Palette(p) => match &p.origin_screen {
-                Screen::Gists(g) => Some(g.as_ref()),
-                Screen::GistDetail(d) => d.return_screen.gists_state(),
-                Screen::Revisions(r) => r.return_screen.gists_state(),
-                _ => None,
-            },
-            Screen::Help(h) => h.return_screen.gists_state().or_else(|| {
-                h.return_screen
-                    .detail_state()
-                    .and_then(|d| d.return_screen.gists_state())
-            }),
-            Screen::Config(c) => c.return_screen.gists_state().or_else(|| {
-                c.return_screen
-                    .detail_state()
-                    .and_then(|d| d.return_screen.gists_state())
-            }),
-            Screen::Preview(p) => p
-                .return_screen
-                .detail_state()
-                .and_then(|d| d.return_screen.gists_state())
-                .or_else(|| p.return_screen.gists_state()),
-            Screen::Diff(d) => match &d.return_screen {
-                Screen::Gists(g) => Some(g.as_ref()),
-                Screen::GistDetail(det) => det.return_screen.gists_state(),
-                Screen::Revisions(r) => r.return_screen.gists_state(),
-                _ => None,
-            },
-            Screen::Confirm(c) => match Self::nav_return_of_confirm(c) {
-                Screen::Gists(g) => Some(g.as_ref()),
-                Screen::GistDetail(d) => d.return_screen.gists_state(),
-                Screen::Revisions(r) => r.return_screen.gists_state(),
-                _ => None,
-            },
-            _ => None,
-        }
+        self.find_screen(Screen::is_gists)
+            .and_then(Screen::gists_state)
     }
 
     pub fn gist_manager_mut(&mut self) -> Option<&mut GistsManagerState> {
-        match &mut self.screen {
-            Screen::Gists(g) => Some(g.as_mut()),
-            Screen::GistDetail(d) => d.return_screen.gists_state_mut(),
-            Screen::Revisions(r) => r.return_screen.gists_state_mut(),
-            Screen::Palette(p) => match &mut p.origin_screen {
-                Screen::Gists(g) => Some(g.as_mut()),
-                Screen::GistDetail(d) => d.return_screen.gists_state_mut(),
-                Screen::Revisions(r) => r.return_screen.gists_state_mut(),
-                _ => None,
-            },
-            Screen::Preview(p) => match &mut p.return_screen {
-                Screen::Gists(g) => Some(g.as_mut()),
-                Screen::GistDetail(d) => d.return_screen.gists_state_mut(),
-                _ => None,
-            },
-            Screen::Diff(d) => match &mut d.return_screen {
-                Screen::Gists(g) => Some(g.as_mut()),
-                Screen::GistDetail(det) => det.return_screen.gists_state_mut(),
-                Screen::Revisions(r) => r.return_screen.gists_state_mut(),
-                _ => None,
-            },
-            Screen::Confirm(c) => match &mut c.return_screen {
-                Screen::Diff(d) => match &mut d.return_screen {
-                    Screen::Gists(g) => Some(g.as_mut()),
-                    Screen::GistDetail(det) => det.return_screen.gists_state_mut(),
-                    Screen::Revisions(r) => r.return_screen.gists_state_mut(),
-                    _ => None,
-                },
-                Screen::Gists(g) => Some(g.as_mut()),
-                Screen::GistDetail(d) => d.return_screen.gists_state_mut(),
-                Screen::Revisions(r) => r.return_screen.gists_state_mut(),
-                _ => None,
-            },
-            _ => None,
-        }
+        self.find_screen_mut(Screen::is_gists)
+            .and_then(Screen::gists_state_mut)
     }
 
-    /// Detail payload when GistDetail is active, parked on preview/revision/diff/confirm
-    /// return, palette origin, or help/config return (issue #242).
+    /// Detail payload when GistDetail is active, parked on a preview/revision/diff/confirm
+    /// return path, palette origin, or help/config return (issue #242).
     pub fn detail(&self) -> Option<&DetailState> {
-        match &self.screen {
-            Screen::GistDetail(d) => Some(d.as_ref()),
-            Screen::Preview(p) => p.return_screen.detail_state(),
-            Screen::Revisions(r) => r.return_screen.detail_state(),
-            Screen::Palette(p) => p.origin_screen.detail_state(),
-            Screen::Help(h) => h.return_screen.detail_state(),
-            Screen::Config(c) => c.return_screen.detail_state(),
-            Screen::Diff(d) => d.return_screen.detail_state(),
-            Screen::Confirm(c) => Self::nav_return_of_confirm(c).detail_state(),
-            _ => None,
-        }
+        self.find_screen(Screen::is_gist_detail)
+            .and_then(Screen::detail_state)
     }
 
     pub fn detail_mut(&mut self) -> Option<&mut DetailState> {
-        match &mut self.screen {
-            Screen::GistDetail(d) => Some(d.as_mut()),
-            Screen::Preview(p) => p.return_screen.detail_state_mut(),
-            Screen::Revisions(r) => r.return_screen.detail_state_mut(),
-            Screen::Palette(p) => p.origin_screen.detail_state_mut(),
-            Screen::Diff(d) => d.return_screen.detail_state_mut(),
-            Screen::Confirm(c) => match &mut c.return_screen {
-                Screen::Diff(d) => d.return_screen.detail_state_mut(),
-                other => other.detail_state_mut(),
-            },
-            _ => None,
-        }
+        self.find_screen_mut(Screen::is_gist_detail)
+            .and_then(Screen::detail_state_mut)
     }
 
     /// Palette payload when the overlay is open (issue #242).
@@ -1364,21 +1224,31 @@ impl AppState {
 
     /// Preview payload when Preview is active, or under palette origin (issue #242).
     pub fn preview(&self) -> Option<&PreviewState> {
-        match &self.screen {
-            Screen::Preview(p) => Some(p.as_ref()),
-            Screen::Palette(p) => p.origin_screen.preview_state(),
-            Screen::Help(h) => h.return_screen.preview_state(),
-            Screen::Config(c) => c.return_screen.preview_state(),
-            _ => None,
-        }
+        self.find_screen(Screen::is_preview)
+            .and_then(Screen::preview_state)
     }
 
     pub fn preview_mut(&mut self) -> Option<&mut PreviewState> {
-        match &mut self.screen {
-            Screen::Preview(p) => Some(p.as_mut()),
-            Screen::Palette(p) => p.origin_screen.preview_state_mut(),
-            _ => None,
-        }
+        self.find_screen_mut(Screen::is_preview)
+            .and_then(Screen::preview_state_mut)
+    }
+
+    /// Navigate to `new_screen`, remembering how to get back (issue #271). The screen being
+    /// left is pushed onto [`Self::nav_stack`] — or, if a [`Self::pending_return`] was staged
+    /// (an async entry: the triggering keypress ran before `self.screen` necessarily still
+    /// matched what the user meant), that staged screen is pushed instead and the live one is
+    /// discarded.
+    pub fn enter(&mut self, new_screen: Screen) {
+        let live = std::mem::replace(&mut self.screen, new_screen);
+        let prev = self.pending_return.take().unwrap_or(live);
+        self.nav_stack.push(prev);
+    }
+
+    /// Leave the current screen, restoring whatever [`Self::enter`] pushed for it. Falls back
+    /// to [`Screen::List`] if the stack is empty (defensive: every real transition goes through
+    /// [`Self::enter`], but a few call sites still assign `self.screen` directly).
+    pub fn leave(&mut self) {
+        self.screen = self.nav_stack.pop().unwrap_or_default();
     }
 
     /// Enter full-screen content preview with the given body and gist identity.
@@ -1388,57 +1258,37 @@ impl AppState {
         text: String,
         gist_key: Option<(String, String)>,
     ) {
-        let return_screen = std::mem::replace(&mut self.preview_return, Screen::List);
         self.status = None;
-        self.screen = Screen::Preview(Box::new(PreviewState {
+        self.enter(Screen::Preview(Box::new(PreviewState {
             title,
             text,
             scroll: 0,
             hscroll: 0,
             gist_key,
-            return_screen,
-        }));
+        })));
     }
 
-    /// Diff payload when Diff is active, under Confirm cancel path (`Screen::Diff`), or
-    /// palette origin (issue #242).
+    /// Diff payload when Diff is active, parked on the Confirm cancel path, or palette origin
+    /// (issue #242).
     pub fn diff(&self) -> Option<&DiffState> {
-        match &self.screen {
-            Screen::Diff(d) => Some(d.as_ref()),
-            Screen::Confirm(c) => c.return_screen.diff_state(),
-            Screen::Palette(p) => p.origin_screen.diff_state(),
-            Screen::Help(h) => h.return_screen.diff_state(),
-            Screen::Config(c) => c.return_screen.diff_state(),
-            _ => None,
-        }
+        self.find_screen(Screen::is_diff)
+            .and_then(Screen::diff_state)
     }
 
     pub fn diff_mut(&mut self) -> Option<&mut DiffState> {
-        match &mut self.screen {
-            Screen::Diff(d) => Some(d.as_mut()),
-            Screen::Confirm(c) => c.return_screen.diff_state_mut(),
-            Screen::Palette(p) => p.origin_screen.diff_state_mut(),
-            _ => None,
-        }
+        self.find_screen_mut(Screen::is_diff)
+            .and_then(Screen::diff_state_mut)
     }
 
-    /// Confirm payload when Confirm is active (issue #242).
+    /// Confirm payload when Confirm is active, or under palette origin (issue #242).
     pub fn confirm(&self) -> Option<&ConfirmState> {
-        match &self.screen {
-            Screen::Confirm(c) => Some(c.as_ref()),
-            Screen::Palette(p) => p.origin_screen.confirm_state(),
-            Screen::Help(h) => h.return_screen.confirm_state(),
-            Screen::Config(c) => c.return_screen.confirm_state(),
-            _ => None,
-        }
+        self.find_screen(Screen::is_confirm)
+            .and_then(Screen::confirm_state)
     }
 
     pub fn confirm_mut(&mut self) -> Option<&mut ConfirmState> {
-        match &mut self.screen {
-            Screen::Confirm(c) => Some(c.as_mut()),
-            Screen::Palette(p) => p.origin_screen.confirm_state_mut(),
-            _ => None,
-        }
+        self.find_screen_mut(Screen::is_confirm)
+            .and_then(Screen::confirm_state_mut)
     }
 
     /// Pending action while Confirm is open.
@@ -1479,17 +1329,16 @@ impl AppState {
         }
     }
 
-    /// Open Confirm with background `text` and the staged [`Self::diff_return`] as cancel path.
+    /// Open Confirm with background `text`. Cancel path is whatever [`Self::enter`] captures —
+    /// the staged [`Self::pending_return`] if this follows an async fetch, else the live screen.
     pub fn enter_confirm(&mut self, action: PendingAction, text: String) {
-        let return_screen = std::mem::replace(&mut self.diff_return, Screen::List);
         self.status = None;
-        self.screen = Screen::Confirm(Box::new(ConfirmState {
+        self.enter(Screen::Confirm(Box::new(ConfirmState {
             action,
             text,
             scroll: 0,
             hscroll: 0,
-            return_screen,
-        }));
+        })));
     }
 
     /// Open Confirm from the active Diff (download overwrite gate). Cancel restores Diff.
@@ -1498,13 +1347,16 @@ impl AppState {
             return;
         };
         self.status = None;
+        let (text, scroll, hscroll) = (d.text.clone(), d.scroll, d.hscroll);
+        // Park full Diff (pairing + identity) so cancel/download IO still have it; not a
+        // `pending_return` case (synchronous — `d` came straight off `self.screen`), so push it
+        // directly rather than going through `enter()`.
+        self.nav_stack.push(Screen::Diff(d));
         self.screen = Screen::Confirm(Box::new(ConfirmState {
             action,
-            text: d.text.clone(),
-            scroll: d.scroll,
-            hscroll: d.hscroll,
-            // Park full Diff (pairing + identity) so cancel/download IO still have it.
-            return_screen: Screen::Diff(d),
+            text,
+            scroll,
+            hscroll,
         }));
     }
 
@@ -1513,50 +1365,26 @@ impl AppState {
         let Screen::Confirm(c) = std::mem::replace(&mut self.screen, Screen::List) else {
             return;
         };
-        let ConfirmState {
-            text,
-            scroll,
-            hscroll,
-            return_screen,
-            ..
-        } = *c;
-        if let Screen::Diff(mut d) = return_screen {
-            d.text = text;
-            d.scroll = scroll;
-            d.hscroll = hscroll;
-            self.screen = Screen::Diff(d);
-        } else {
-            self.screen = return_screen;
+        self.leave();
+        if let Screen::Diff(ref mut d) = self.screen {
+            d.text = c.text;
+            d.scroll = c.scroll;
+            d.hscroll = c.hscroll;
         }
     }
 
-    /// Leave Confirm restoring `return_screen` from the payload (upload/compact/etc.).
+    /// Leave Confirm restoring whatever [`Self::enter`] parked for it (upload/compact/etc.).
     pub fn cancel_confirm(&mut self) {
-        let Screen::Confirm(c) = std::mem::replace(&mut self.screen, Screen::List) else {
-            self.screen = Screen::List;
-            return;
-        };
-        self.screen = c.return_screen;
+        self.leave();
     }
 
-    /// Snapshot the current detail payload as a restore `Screen` (for preview/compact/etc.).
+    /// Snapshot the live GistDetail payload as a `Screen`, to stage into
+    /// [`Self::pending_return`] before an async fetch (preview/revisions/compact) that will
+    /// eventually call [`Self::enter`] once its result lands. Every caller is itself part of
+    /// GistDetail's own key handling, so `self.screen` is always `Screen::GistDetail` here.
     fn park_gist_detail_screen(&self) -> Screen {
-        match &self.screen {
-            Screen::GistDetail(d) => {
-                let mut parked = d.as_ref().clone();
-                // Avoid deep nested compact-return clones when re-parking.
-                parked.compact_return_screen = Screen::Gists(Box::default());
-                Screen::GistDetail(Box::new(parked))
-            }
-            _ => self
-                .detail()
-                .map(|d| {
-                    let mut parked = d.clone();
-                    parked.compact_return_screen = Screen::Gists(Box::default());
-                    Screen::GistDetail(Box::new(parked))
-                })
-                .unwrap_or_else(|| Screen::GistDetail(Box::default())),
-        }
+        debug_assert!(self.screen.is_gist_detail());
+        self.screen.clone()
     }
 
     pub fn upload_local_path(&self) -> Option<std::path::PathBuf> {
@@ -2153,16 +1981,16 @@ impl AppState {
     }
 
     /// Look up a gist group by id (unaffected by filtering); used by detail + confirm background.
-    /// Open `Screen::Revisions` for the gist on `return_screen`. Returns false when no gist
-    /// is selected or the gist has no files.
-    pub fn open_revisions(&mut self, return_screen: Screen) -> bool {
+    /// Open `Screen::Revisions` for the gist on the current screen (List, GistDetail, or Gists).
+    /// Returns false when no gist is selected or the gist has no files.
+    pub fn open_revisions(&mut self) -> bool {
         // Snapshot the selected gist once for the List path; it feeds both `gist_id` and
         // `target_file` below, avoiding a second `ranked_gists` recompute (perf-1, #154).
-        let selected_list_gist = match return_screen {
+        let selected_list_gist = match self.screen {
             Screen::List => self.selected_gist(),
             _ => None,
         };
-        let gist_id = match &return_screen {
+        let gist_id = match &self.screen {
             Screen::List => selected_list_gist.as_ref().map(|g| g.file.gist_id.clone()),
             Screen::GistDetail(d) => d.gist_id.clone(),
             Screen::Gists(_) => self.selected_group().map(|g| g.id.clone()),
@@ -2172,7 +2000,7 @@ impl AppState {
             return false;
         };
         let filenames = self.gist_filenames(&gist_id);
-        let target_file = match &return_screen {
+        let target_file = match &self.screen {
             Screen::List => selected_list_gist
                 .as_ref()
                 .map(|g| g.file.filename.clone())
@@ -2187,15 +2015,14 @@ impl AppState {
         let Some(target_file) = target_file else {
             return false;
         };
-        self.screen = Screen::Revisions(Box::new(RevisionState {
+        self.enter(Screen::Revisions(Box::new(RevisionState {
             gist_id: Some(gist_id),
             target_file,
-            return_screen,
             index: 0,
             hscroll: 0,
             entries: None,
             fetch_error: None,
-        }));
+        })));
         true
     }
 
@@ -2227,9 +2054,12 @@ impl AppState {
     }
 
     /// True when the diff view supports local↔gist download/upload (`d`/`u`). Revision-history
-    /// diffs (returning to `Screen::Revisions`) are read-only comparisons.
+    /// diffs (returning to `Screen::Revisions`) are read-only comparisons. Checks the top of
+    /// `nav_stack` directly (not [`Self::diff`]'s deep search) — this only makes sense while
+    /// Diff is the live screen, so it's the immediate parent, not wherever else Diff might be
+    /// parked.
     pub fn diff_allows_sync(&self) -> bool {
-        !self.diff().is_some_and(|d| d.return_screen.is_revisions())
+        !self.nav_stack.last().is_some_and(Screen::is_revisions)
     }
 
     /// Footer label for the revision-history target file, including `(n/total)` when multi-file.
@@ -2426,53 +2256,22 @@ impl AppState {
         local: PathBuf,
         target: PathBuf,
     ) {
-        let return_screen = std::mem::replace(&mut self.diff_return, Screen::List);
         let (gist_id, gist_filename) = match self.staged_diff_gist.take() {
             Some((id, name)) => (Some(id), Some(name)),
             None => (None, None),
         };
         self.status = None;
-        self.screen = Screen::Diff(Box::new(DiffState {
+        self.enter(Screen::Diff(Box::new(DiffState {
             text: diff_text,
             scroll: 0,
             hscroll: 0,
-            return_screen,
             remote_content: remote,
             local_path: local,
             download_target: target,
             identical: false,
             gist_id,
             gist_filename,
-        }));
-    }
-
-    /// Enter Diff with explicit return path (does not consume staged `diff_return`).
-    pub fn enter_diff_returning(
-        &mut self,
-        diff_text: String,
-        remote: String,
-        local: PathBuf,
-        target: PathBuf,
-        return_screen: Screen,
-    ) {
-        self.diff_return = Screen::List;
-        let (gist_id, gist_filename) = match self.staged_diff_gist.take() {
-            Some((id, name)) => (Some(id), Some(name)),
-            None => (None, None),
-        };
-        self.status = None;
-        self.screen = Screen::Diff(Box::new(DiffState {
-            text: diff_text,
-            scroll: 0,
-            hscroll: 0,
-            return_screen,
-            remote_content: remote,
-            local_path: local,
-            download_target: target,
-            identical: false,
-            gist_id,
-            gist_filename,
-        }));
+        })));
     }
 
     /// True while a Diff payload is live (active Diff or parked under Confirm).
@@ -2513,7 +2312,10 @@ impl AppState {
         self.screen = Screen::List;
         // Diff pairing identity lives on the payload; leaving drops it.
         self.staged_diff_gist = None;
-        self.diff_return = Screen::List;
+        self.pending_return = None;
+        // A hard reset, not a `leave()` — nothing on the stack corresponds to List, so discard
+        // it rather than let stale entries resurface on some later, unrelated `leave()`.
+        self.nav_stack.clear();
     }
 
     pub fn set_status(&mut self, message: impl Into<String>) {
@@ -2664,7 +2466,6 @@ pub fn initial_state() -> AppState {
         no_update_check_cli: false,
         update_available: None,
         install_method: crate::upgrade::InstallMethod::Standalone,
-        preview_return: Screen::List,
         // Bound the in-memory preview cache so browsing many/large gists can't grow unbounded;
         // evicted entries are simply re-fetched on demand.
         gist_content_cache: crate::lru::LruCache::new(64),
@@ -2681,7 +2482,8 @@ pub fn initial_state() -> AppState {
         quit_armed: false,
         upload: UploadState::default(),
         staged_diff_gist: None,
-        diff_return: Screen::List,
+        nav_stack: Vec::new(),
+        pending_return: None,
         spinner_frame: 0,
         gist_comment_counts: std::collections::HashMap::new(),
         gist_fork_counts: std::collections::HashMap::new(),

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -19,9 +19,6 @@ fn config_mut(state: &mut AppState) -> &mut ConfigState {
     }
     state.config_mut().expect("expected Screen::Config")
 }
-fn config_ref(state: &AppState) -> &ConfigState {
-    state.config().expect("expected Screen::Config")
-}
 fn revision_mut(state: &mut AppState) -> &mut RevisionState {
     if !state.screen.is_revisions() {
         state.screen = Screen::Revisions(Box::default());
@@ -63,37 +60,20 @@ fn preview_ref(state: &AppState) -> &PreviewState {
 }
 
 /// Open Confirm with the given action (keeps existing body text when already on Diff/Confirm).
-/// Consumes staged `diff_return` as the cancel path when present (test convenience matching
-/// production `enter_confirm`).
+/// Mirrors production `enter_confirm`/`enter_confirm_from_diff`: a staged `pending_return`
+/// becomes the cancel path (via `AppState::enter`) when present, otherwise the live screen does.
 fn set_pending(state: &mut AppState, action: PendingAction) {
-    let staged = std::mem::replace(&mut state.diff_return, Screen::List);
     if state.screen.is_confirm() {
         if let Some(c) = state.confirm_mut() {
             c.action = action;
-            if matches!(c.return_screen, Screen::List) && !matches!(staged, Screen::List) {
-                c.return_screen = staged;
-            } else if !matches!(staged, Screen::List) {
-                // keep existing confirm return; re-stage unused
-                state.diff_return = staged;
-            }
         }
         return;
     }
-    let (text, scroll, hscroll, return_screen) = match &state.screen {
-        Screen::Diff(d) => {
-            // Keep staged for other uses; Diff cancel path embeds Diff.
-            state.diff_return = staged;
-            (d.text.clone(), d.scroll, d.hscroll, Screen::Diff(d.clone()))
-        }
-        _ => (String::new(), 0, 0, staged),
-    };
-    state.screen = Screen::Confirm(Box::new(ConfirmState {
-        action,
-        text,
-        scroll,
-        hscroll,
-        return_screen,
-    }));
+    if state.screen.is_diff() {
+        state.enter_confirm_from_diff(action);
+        return;
+    }
+    state.enter_confirm(action, String::new());
 }
 
 fn clear_pending(state: &mut AppState) {
@@ -475,7 +455,10 @@ fn detail_enter_previews_cursor_file_including_tenth() {
             ..
         } if gist_id == "g1" && filename == "f9.txt"
     ));
-    assert!(state.preview_return.is_gist_detail());
+    assert!(state
+        .pending_return
+        .as_ref()
+        .is_some_and(Screen::is_gist_detail));
 }
 
 #[test]
@@ -491,6 +474,8 @@ fn detail_enter_in_comments_focus_is_noop() {
 #[test]
 fn detail_q_returns_to_gists() {
     let mut state = state_with_gists();
+    // Mirrors what `enter()` does when GistDetail is opened from Gists (OpenGistDetail).
+    state.nav_stack.push(Screen::Gists(Box::default()));
     state.screen = Screen::GistDetail(Box::default());
     state.handle_key(KeyCode::Char('q'));
     assert!(state.screen.is_gists());
@@ -515,7 +500,10 @@ fn detail_c_triggers_compaction_and_records_origin() {
     detail_mut(&mut state).gist_id = Some("g1".into());
     let outcome = state.handle_key(KeyCode::Char('c'));
     assert!(matches!(outcome, KeyOutcome::CompactGist { .. }));
-    assert!(detail_ref(&state).compact_return_screen.is_gist_detail());
+    assert!(state
+        .pending_return
+        .as_ref()
+        .is_some_and(Screen::is_gist_detail));
 }
 
 #[test]
@@ -532,7 +520,10 @@ fn detail_number_key_requests_file_preview() {
             ..
         } if gist_id == "g1" && filename == "a.txt"
     ));
-    assert!(state.preview_return.is_gist_detail());
+    assert!(state
+        .pending_return
+        .as_ref()
+        .is_some_and(Screen::is_gist_detail));
 }
 
 #[test]
@@ -599,14 +590,12 @@ fn detail_x_requests_gist_delete_confirm() {
 #[test]
 fn preview_q_returns_to_launch_screen() {
     let mut state = state_with_gists();
-    state.screen = Screen::Preview(Box::new(PreviewState {
-        return_screen: Screen::GistDetail(Box::default()),
-        ..PreviewState::default()
-    }));
+    state.nav_stack.push(Screen::GistDetail(Box::default()));
+    state.screen = Screen::Preview(Box::default());
     state.handle_key(KeyCode::Char('q'));
     assert!(state.screen.is_gist_detail());
-    // Staging field reset so a later list-launched preview returns to the list.
-    assert_eq!(state.preview_return, Screen::List);
+    // nav_stack is now drained, so a later list-launched preview isn't left pointing here.
+    assert!(state.nav_stack.is_empty());
 }
 
 #[test]
@@ -1296,7 +1285,7 @@ fn question_opens_contextual_help_from_list() {
     state.handle_key(KeyCode::Char('?'));
     assert!(state.screen.is_help());
     assert_eq!(help_ref(&state).topic, HelpTopic::List);
-    assert_eq!(help_ref(&state).return_screen, Screen::List);
+    assert_eq!(state.nav_stack.last(), Some(&Screen::List));
     assert!(!help_ref(&state).index_open);
     // Arrow keys scroll help
     state.handle_key(KeyCode::Down);
@@ -2637,8 +2626,8 @@ fn c_in_detail_requests_compaction_not_gist_manager() {
 #[test]
 fn compact_confirm_y_executes_and_n_returns_to_gist_manager() {
     let mut state = state_with_two_gists();
-    // CompactAnalyze parks the restore target before Confirm opens (staged diff_return).
-    state.diff_return = Screen::Gists(Box::default());
+    // CompactAnalyze parks the restore target before Confirm opens (staged pending_return).
+    state.pending_return = Some(Screen::Gists(Box::default()));
     set_pending(
         &mut state,
         PendingAction::CompactGist {
@@ -2653,7 +2642,7 @@ fn compact_confirm_y_executes_and_n_returns_to_gist_manager() {
     );
 
     // Re-open confirm for the cancel path (y does not leave Confirm until IO runs).
-    state.diff_return = Screen::Gists(Box::default());
+    state.pending_return = Some(Screen::Gists(Box::default()));
     set_pending(
         &mut state,
         PendingAction::CompactGist {
@@ -2811,7 +2800,7 @@ fn confirm_upload_n_cancels_and_resets_watching() {
 #[test]
 fn confirm_upload_n_cancels_to_diff_return_screen() {
     let mut state = initial_state();
-    state.diff_return = Screen::Pins(Box::default());
+    state.pending_return = Some(Screen::Pins(Box::default()));
     set_pending(
         &mut state,
         PendingAction::Upload {
@@ -3865,7 +3854,7 @@ fn top_bar_config_click_opens_settings_from_any_screen() {
     };
     let out = state.handle_mouse(MouseInput::Click { col: 30, row: 0 }, &layout);
     assert!(state.screen.is_config());
-    assert!(config_ref(&state).return_screen.is_preview());
+    assert!(state.nav_stack.last().is_some_and(Screen::is_preview));
     assert_eq!(out, KeyOutcome::None);
 }
 
@@ -3879,12 +3868,12 @@ fn top_bar_config_click_while_already_on_config_does_not_trap_keyboard_exit() {
     };
     state.handle_mouse(MouseInput::Click { col: 30, row: 0 }, &layout);
     assert!(state.screen.is_config());
-    assert!(config_ref(&state).return_screen.is_preview());
+    assert!(state.nav_stack.last().is_some_and(Screen::is_preview));
 
     // Second click on Config while already there must not overwrite return_screen.
     let out = state.handle_mouse(MouseInput::Click { col: 30, row: 0 }, &layout);
     assert!(state.screen.is_config());
-    assert!(config_ref(&state).return_screen.is_preview());
+    assert!(state.nav_stack.last().is_some_and(Screen::is_preview));
     assert_eq!(out, KeyOutcome::None);
 
     state.handle_key(KeyCode::Esc);
@@ -3901,7 +3890,7 @@ fn top_bar_help_click_opens_help_and_remembers_return_screen_from_any_screen() {
     };
     let out = state.handle_mouse(MouseInput::Click { col: 32, row: 0 }, &layout);
     assert!(state.screen.is_help());
-    assert!(help_ref(&state).return_screen.is_preview());
+    assert!(state.nav_stack.last().is_some_and(Screen::is_preview));
     assert_eq!(out, KeyOutcome::None);
 }
 
@@ -3916,14 +3905,14 @@ fn top_bar_help_click_while_already_on_help_does_not_trap_keyboard_exit() {
     // First click opens Help from Preview, remembering Preview as the return screen.
     state.handle_mouse(MouseInput::Click { col: 32, row: 0 }, &layout);
     assert!(state.screen.is_help());
-    assert!(help_ref(&state).return_screen.is_preview());
+    assert!(state.nav_stack.last().is_some_and(Screen::is_preview));
 
     // A second click on the same top-bar Help hotspot, now that Help is already open, must
     // be a no-op — it must not overwrite return_screen with Screen::Help, which would trap
     // Esc/`?`/the close button in Help with no keyboard way out.
     let out = state.handle_mouse(MouseInput::Click { col: 32, row: 0 }, &layout);
     assert!(state.screen.is_help());
-    assert!(help_ref(&state).return_screen.is_preview());
+    assert!(state.nav_stack.last().is_some_and(Screen::is_preview));
     assert_eq!(out, KeyOutcome::None);
 
     // Esc must still return to the real origin screen, not stay stuck on Help.
@@ -4452,7 +4441,7 @@ fn capital_h_from_list_opens_revisions_for_selected_gist_file() {
     assert!(state.screen.is_revisions());
     assert_eq!(revision_ref(&state).gist_id.as_deref(), Some("a"));
     assert_eq!(revision_ref(&state).target_file, "settings.json");
-    assert_eq!(revision_ref(&state).return_screen, Screen::List);
+    assert_eq!(state.nav_stack.last(), Some(&Screen::List));
 }
 
 #[test]
@@ -4466,7 +4455,7 @@ fn capital_h_from_gist_detail_opens_revisions_and_fetches() {
     assert!(state.screen.is_revisions());
     assert_eq!(revision_ref(&state).gist_id.as_deref(), Some("g1"));
     assert_eq!(revision_ref(&state).target_file, "b.txt");
-    assert!(revision_ref(&state).return_screen.is_gist_detail());
+    assert!(state.nav_stack.last().is_some_and(Screen::is_gist_detail));
     assert!(revision_ref(&state).entries.is_none());
 }
 
@@ -4572,7 +4561,7 @@ fn revisions_enter_triggers_incremental_diff() {
 #[test]
 fn revision_diff_omits_download_upload() {
     let mut state = initial_state();
-    state.diff_return = Screen::Revisions(Box::default());
+    state.pending_return = Some(Screen::Revisions(Box::default()));
     state.enter_diff("diff".into(), String::new(), PathBuf::new(), PathBuf::new());
     let footer = diff_footer(&state);
     assert!(!footer.contains("download"));
@@ -4777,7 +4766,7 @@ fn question_mark_opens_contextual_help_from_pins() {
     state.handle_key(KeyCode::Char('?'));
     assert!(state.screen.is_help());
     assert_eq!(help_ref(&state).topic, HelpTopic::Pins);
-    assert!(help_ref(&state).return_screen.is_pins());
+    assert!(state.nav_stack.last().is_some_and(Screen::is_pins));
     assert!(!help_ref(&state).index_open);
 }
 
@@ -4840,7 +4829,7 @@ fn repo_link_click_opens_repo_url_regardless_of_which_screen_set_the_rect() {
 fn help_topic_view_esc_returns_to_origin() {
     let mut state = initial_state();
     state.screen = Screen::Help(Box::default());
-    help_mut(&mut state).return_screen = Screen::Gists(Box::default());
+    state.nav_stack.push(Screen::Gists(Box::default()));
     state.handle_key(KeyCode::Esc);
     assert!(state.screen.is_gists());
 }
@@ -4864,7 +4853,7 @@ fn help_index_esc_returns_to_origin() {
     let mut state = initial_state();
     state.screen = Screen::Help(Box::default());
     help_mut(&mut state).index_open = true;
-    help_mut(&mut state).return_screen = Screen::List;
+    state.nav_stack.push(Screen::List);
     state.handle_key(KeyCode::Esc);
     assert_eq!(state.screen, Screen::List);
     assert!(state.help().is_none());
@@ -4875,7 +4864,7 @@ fn help_index_question_mark_exits_help() {
     let mut state = initial_state();
     state.screen = Screen::Help(Box::default());
     help_mut(&mut state).index_open = true;
-    help_mut(&mut state).return_screen = Screen::Pins(Box::default());
+    state.nav_stack.push(Screen::Pins(Box::default()));
     state.handle_key(KeyCode::Char('?'));
     assert!(state.screen.is_pins());
     assert!(state.help().is_none());
@@ -5418,7 +5407,6 @@ fn scroll_up_moves_content_three_lines() {
 fn close_button_click_returns_from_help() {
     let mut state = state_with_gists();
     // Simulate entering Help (mirrors what open_help() does).
-    help_mut(&mut state).return_screen = Screen::List;
     state.screen = Screen::Help(Box::default());
     let layout = MouseLayout {
         close_button: Some(Rect::new(36, 0, 5, 1)),
@@ -5432,7 +5420,6 @@ fn close_button_click_returns_from_help() {
 #[test]
 fn close_button_click_outside_is_noop() {
     let mut state = state_with_gists();
-    help_mut(&mut state).return_screen = Screen::List;
     state.screen = Screen::Help(Box::default());
     let layout = MouseLayout {
         close_button: Some(Rect::new(36, 0, 5, 1)),
@@ -5533,7 +5520,6 @@ fn click_in_pane_blank_focuses_without_selecting() {
 #[test]
 fn click_off_list_screen_is_noop() {
     let mut state = state_with_gists();
-    help_mut(&mut state).return_screen = Screen::List;
     state.screen = Screen::Help(Box::default());
     let hit = PaneHit {
         rect: Rect::new(20, 0, 20, 10),

--- a/src/tui/view_model.rs
+++ b/src/tui/view_model.rs
@@ -1611,10 +1611,7 @@ mod tests {
     #[test]
     fn config_vm_rows_and_status() {
         let mut state = initial_state();
-        state.screen = Screen::Config(Box::new(ConfigState {
-            index: 1,
-            ..ConfigState::default()
-        }));
+        state.screen = Screen::Config(Box::new(ConfigState { index: 1 }));
         state.status = Some("Theme saved".into());
         match build_view_model(&state).screen {
             ScreenVm::Config(c) => {


### PR DESCRIPTION
## Summary

`AppState.nav_stack: Vec<Screen>` now owns "where do I go back to" as push/pop, replacing the `return_screen`/`compact_return_screen` fields that used to live on 7 payload structs (`DiffState`, `ConfirmState`, `PreviewState`, `HelpState`, `RevisionState`, `ConfigState`, `DetailState`) plus the parallel staged copies (`diff_return`, `preview_return`) that had to be kept in sync by convention across `enter_diff`, `enter_diff_returning`, `enter_confirm_from_diff`, `cancel_confirm_to_diff`, `cancel_confirm`, `open_help`, `open_config`, `close_palette`.

- `enter(new_screen)` pushes the screen being left (or a staged `pending_return`, for async entries where the triggering keypress ran before a background fetch landed) and switches to `new_screen`.
- `leave()` pops `nav_stack`, falling back to `Screen::List` if empty.
- `pending_return: Option<Screen>` is the one remaining staging field — its only job is bridging the async gap above; `enter()` consumes it.
- The "reach through the return chain to find a payload" accessors (`pins`, `revision`, `detail`, `gist_manager`, `preview`, `diff`, `confirm`) are rewritten on top of two generic `find_screen`/`find_screen_mut` helpers that walk palette origin + `nav_stack`, replacing hand-nested per-accessor chains (and `nav_return_of_confirm`, no longer needed).
- `enter_diff_returning` (dead code, zero callers) deleted. `open_revisions` drops its `return_screen` parameter — every call site passed `self.screen.clone()` in some form; it now reads `self.screen` internally.
- `back_to_list()` now also clears `nav_stack` — a real correctness fix: since the return chain is a field separate from `self.screen` now, a hard "give up, go to List" reset has to explicitly clear it or stale entries could resurface on a later unrelated `leave()`.

No behaviour change. Design was worked through via `/grilling` on #271 before implementation — see that issue's comments for the decision trail.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo test` (531 passed)
- [x] `cargo check`
- [x] `cargo clippy --all-targets -- -D warnings`

Closes #271