### PR TITLE
refactor: consolidate scratch-directory handling into temp_dir

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -2,7 +2,7 @@ use crate::config::{save_config, AppConfig};
 use crate::domain::{GistFile, PinnedMapping, SyncDirection};
 use anyhow::{anyhow, bail, Context, Result};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::process::Command;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -423,9 +423,11 @@ pub fn compact_git_plans(dir: &Path, branch: &str) -> Vec<CommandPlan> {
 /// and remove the temp dir. The temp dir is always cleaned up, even on error. This is a thin IO
 /// boundary (real `gh`/`git`); the command planning it drives is what carries the unit tests.
 pub fn execute_compact_gist(gist_id: &str) -> Result<()> {
-    let dir = compact_temp_dir(gist_id);
-    let result = compact_in_dir(gist_id, &dir);
-    let _ = fs::remove_dir_all(&dir);
+    // `with_temp_scratch_dir` owns create + cleanup, including on clone/compact failure (issue #275).
+    // The dir is created empty; `git clone` accepts an empty existing destination.
+    let safe: String = gist_id.chars().filter(|c| c.is_alphanumeric()).collect();
+    let kind = format!("compact-{safe}");
+    let result = crate::temp_dir::with_temp_scratch_dir(&kind, |dir| compact_in_dir(gist_id, dir));
     // A raw git HTTPS auth failure (no gist.github.com credential helper) is confusing; map it
     // to an actionable hint. Unrelated errors surface verbatim, and the happy path is untouched.
     result.map_err(|e| match compact_auth_hint(&e.to_string()) {
@@ -463,22 +465,6 @@ fn compact_in_dir(gist_id: &str, dir: &Path) -> Result<()> {
         run_command(&SystemRunner, &plan)?;
     }
     Ok(())
-}
-
-/// A unique, not-yet-existing temp path for a clone (let `git` create it, avoiding any
-/// "clone into a non-empty dir" surprise). Uniqueness: gist id + pid + a high-resolution stamp.
-fn compact_temp_dir(gist_id: &str) -> PathBuf {
-    let stamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    let safe: String = gist_id.chars().filter(|c| c.is_alphanumeric()).collect();
-    let mut dir = std::env::temp_dir();
-    dir.push(format!(
-        "gistui-compact-{safe}-{}-{stamp}",
-        std::process::id()
-    ));
-    dir
 }
 
 pub fn execute_command(plan: &CommandPlan) -> Result<String> {
@@ -639,6 +625,7 @@ pub fn unpin_mapping_exact(
 mod tests {
     use super::*;
     use crate::config::{load_config, AppConfig};
+    use std::path::PathBuf;
 
     fn gist_file() -> GistFile {
         GistFile {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod gh;
 pub mod local;
 pub mod lru;
 pub mod ranking;
+pub mod temp_dir;
 pub mod tui;
 pub mod update_check;
 pub mod upgrade;

--- a/src/temp_dir.rs
+++ b/src/temp_dir.rs
@@ -1,0 +1,145 @@
+//! Unique scratch directories under the system temp dir with guaranteed cleanup.
+//!
+//! Upload, restore-revision, and gist compaction each need a short-lived work
+//! directory. Hand-rolling create + `remove_dir_all` at every site made it easy
+//! to miss a failure path (issue #275). This module owns that pattern once:
+//!
+//! - [`with_temp_scratch_dir`] — sync create → run → always clean up (e.g. compact)
+//! - [`ScratchDir`] — same ownership as RAII when the path must outlive the
+//!   creating scope (upload/restore write on the UI thread, consume in a bg job)
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// RAII unique scratch directory under the system temp dir.
+///
+/// Best-effort removed on drop, so early returns and ownership moved into a
+/// background job both clean up without a second manual `remove_dir_all`.
+#[derive(Debug)]
+pub struct ScratchDir {
+    path: PathBuf,
+}
+
+impl ScratchDir {
+    /// Create a unique empty directory named `.gistui_{kind}_{pid}_{stamp}`.
+    pub fn create(kind: &str) -> std::io::Result<Self> {
+        let path = unique_path(kind);
+        fs::create_dir_all(&path)?;
+        Ok(Self { path })
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for ScratchDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+/// Create a unique scratch directory, run `f`, and always clean up afterward.
+///
+/// Cleanup runs even when `f` returns `Err` (Drop of the internal [`ScratchDir`]).
+/// Create failures surface as `E` via [`From<std::io::Error>`].
+///
+/// Prefer this for fully-synchronous work. When the scratch path must live past
+/// the creating scope (e.g. into a background job), use [`ScratchDir`] instead
+/// and move it into that scope — Drop still owns cleanup.
+pub fn with_temp_scratch_dir<T, E, F>(kind: &str, f: F) -> Result<T, E>
+where
+    F: FnOnce(&Path) -> Result<T, E>,
+    E: From<std::io::Error>,
+{
+    let dir = ScratchDir::create(kind)?;
+    f(dir.path())
+}
+
+fn unique_path(kind: &str) -> PathBuf {
+    let stamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let safe: String = kind
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+        .collect();
+    let kind = if safe.is_empty() {
+        "scratch"
+    } else {
+        safe.as_str()
+    };
+    std::env::temp_dir().join(format!(".gistui_{kind}_{}_{stamp}", std::process::id()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
+
+    #[test]
+    fn with_temp_scratch_dir_creates_dir_and_cleans_up_on_success() {
+        let mut seen = PathBuf::new();
+        let result: Result<(), io::Error> = with_temp_scratch_dir("test_ok", |dir| {
+            assert!(dir.is_dir(), "scratch dir should exist for the body");
+            assert!(
+                dir.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.contains("test_ok")),
+                "kind should appear in the directory name"
+            );
+            seen = dir.to_path_buf();
+            fs::write(dir.join("payload.txt"), b"hi")?;
+            Ok(())
+        });
+        assert!(result.is_ok());
+        assert!(
+            !seen.exists(),
+            "scratch dir must be removed after the body returns Ok"
+        );
+    }
+
+    #[test]
+    fn with_temp_scratch_dir_cleans_up_on_body_error() {
+        // Spec: cleanup-on-write-failure (and any early Err) is owned by the helper,
+        // so callers cannot forget remove_dir_all (issue #275).
+        let mut seen = PathBuf::new();
+        let result: Result<(), io::Error> = with_temp_scratch_dir("test_err", |dir| {
+            seen = dir.to_path_buf();
+            fs::write(dir.join("partial.txt"), b"partial")?;
+            Err(io::Error::other("simulated write/body failure"))
+        });
+        assert!(result.is_err());
+        assert!(
+            !seen.exists(),
+            "scratch dir must be removed even when the body returns Err"
+        );
+    }
+
+    #[test]
+    fn scratch_dir_drop_cleans_up_after_move() {
+        // Models the upload/restore pattern: create on the UI thread, move into a
+        // background job, drop after the job finishes.
+        let path = {
+            let scratch = ScratchDir::create("test_move").expect("create");
+            let path = scratch.path().to_path_buf();
+            assert!(path.is_dir());
+            fs::write(path.join("file.txt"), b"x").unwrap();
+            // Move ownership out of this block the way a `move ||` closure would.
+            let held = scratch;
+            assert!(path.is_dir(), "dir must survive while ScratchDir is alive");
+            drop(held);
+            path
+        };
+        assert!(!path.exists(), "drop after move must still clean up");
+    }
+
+    #[test]
+    fn unique_paths_differ_across_calls() {
+        let a = ScratchDir::create("uniq").expect("create a");
+        let b = ScratchDir::create("uniq").expect("create b");
+        assert_ne!(a.path(), b.path());
+    }
+}

--- a/src/tui/dispatch.rs
+++ b/src/tui/dispatch.rs
@@ -214,21 +214,19 @@ pub(super) fn dispatch_outcome(
 
             let upload_content = state.content_to_upload();
 
-            let timestamp = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or(0);
-            let temp_dir = std::env::temp_dir().join(format!(".gistui_upload_{timestamp}"));
+            // ScratchDir owns cleanup: early write failure drops here; on success
+            // ownership moves into the bg job and drops after execute (issue #275).
+            let scratch = match crate::temp_dir::ScratchDir::create("upload") {
+                Ok(dir) => dir,
+                Err(e) => {
+                    state.set_status(format!("failed to create temp dir: {e}"));
+                    return Ok(LoopFlow::Proceed);
+                }
+            };
 
-            if let Err(e) = std::fs::create_dir_all(&temp_dir) {
-                state.set_status(format!("failed to create temp dir: {e}"));
-                return Ok(LoopFlow::Proceed);
-            }
-
-            let temp_file_path = temp_dir.join(&filename);
+            let temp_file_path = scratch.path().join(&filename);
             if let Err(e) = std::fs::write(&temp_file_path, &upload_content) {
                 state.set_status(format!("failed to write temp file: {e}"));
-                let _ = std::fs::remove_dir_all(&temp_dir);
                 return Ok(LoopFlow::Proceed);
             }
 
@@ -251,7 +249,7 @@ pub(super) fn dispatch_outcome(
                     .map(|_| ())
                     .map_err(|e| e.to_string());
 
-                let _ = std::fs::remove_dir_all(&temp_dir);
+                drop(scratch);
 
                 BgTaskOutcome::UploadReplace {
                     result,
@@ -564,20 +562,19 @@ pub(super) fn dispatch_outcome(
             else {
                 return Ok(LoopFlow::Proceed);
             };
-            let timestamp = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or(0);
-            let temp_dir = std::env::temp_dir().join(format!(".gistui_restore_{timestamp}"));
-            if let Err(e) = std::fs::create_dir_all(&temp_dir) {
-                state.set_status(format!("failed to create temp dir: {e}"));
-                return Ok(LoopFlow::Proceed);
-            }
-            let json_path = temp_dir.join("restore.json");
+            // ScratchDir owns cleanup across write-failure early return and the
+            // bg job that consumes the JSON payload (issue #275).
+            let scratch = match crate::temp_dir::ScratchDir::create("restore") {
+                Ok(dir) => dir,
+                Err(e) => {
+                    state.set_status(format!("failed to create temp dir: {e}"));
+                    return Ok(LoopFlow::Proceed);
+                }
+            };
+            let json_path = scratch.path().join("restore.json");
             let body = crate::actions::restore_revision_json(&filename, &content);
             if let Err(e) = std::fs::write(&json_path, &body) {
                 state.set_status(format!("failed to write restore payload: {e}"));
-                let _ = std::fs::remove_dir_all(&temp_dir);
                 return Ok(LoopFlow::Proceed);
             }
             let plan = crate::actions::restore_revision_command(&gist_id, &json_path);
@@ -585,7 +582,7 @@ pub(super) fn dispatch_outcome(
                 let result = crate::actions::execute_command(&plan)
                     .map(|_| ())
                     .map_err(|e| e.to_string());
-                let _ = std::fs::remove_dir_all(&temp_dir);
+                drop(scratch);
                 BgTaskOutcome::RestoreRevisionDone {
                     result,
                     gist_id,


### PR DESCRIPTION
## Summary

- Add `src/temp_dir.rs` so unique system-temp scratch dirs always clean up on drop (or after a sync body), instead of three hand-rolled create/write/`remove_dir_all` sequences.
- **Compact** uses `with_temp_scratch_dir` (sync create → work → cleanup, including on error).
- **Upload** and **restore-revision** use `ScratchDir` RAII: write on the UI thread, move ownership into the background job so cleanup still runs after `execute` (or on early write failure without a manual `remove_dir_all`).
- No intentional behaviour change beyond making cleanup uniform on failure paths.

Closes #275

## Test plan

- [x] `mise run check` (fmt + clippy `-D warnings` + 539 unit tests + 12 integration tests + `cargo check`)
- [x] New `temp_dir` tests: cleanup on success, cleanup on body `Err`, drop after move, unique paths