### PR TITLE
refactor(tui): share ListCursor across Pins and Gists navigation

### DIFF
--- a/src/tui/bg.rs
+++ b/src/tui/bg.rs
@@ -1087,9 +1087,9 @@ pub(super) fn unpin_at_pin_index(state: &mut AppState, idx: usize) {
             state.skip_dirs = config.skip_dirs;
             state.scan_depth = config.scan_depth;
             state.mark_pin_sync_cache_dirty();
-            let max = state.visible_pin_indices().len().saturating_sub(1);
+            let len = state.visible_pin_indices().len();
             if let Some(pins) = state.pins_mut() {
-                pins.index = pins.index.min(max);
+                pins.cursor.clamp_len(len);
             }
             refresh_locals(state);
             state.set_status(format!("Unpinned {label}"));
@@ -1270,12 +1270,8 @@ fn absorb_background_results_body(
                 state.gist_index = 0;
             }
             let count = state.visible_gist_groups().len();
-            if count > 0 {
-                if let Some(gm) = state.gist_manager_mut() {
-                    if gm.index >= count {
-                        gm.index = count - 1;
-                    }
-                }
+            if let Some(gm) = state.gist_manager_mut() {
+                gm.cursor.clamp_len(count);
             }
             let gist_ids: std::collections::HashSet<String> = state
                 .gists

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -37,6 +37,19 @@ fn nav_action(code: KeyCode, modifiers: KeyModifiers) -> Option<NavAction> {
 /// keeps paging predictable without threading terminal size into the key logic.
 const PAGE_SCROLL: u16 = 10;
 
+/// Dispatch [`NavAction`] onto a Pins/Gists [`ListCursor`] (step from [`PAGE_SCROLL`]).
+fn apply_list_cursor_nav(cursor: &mut ListCursor, action: NavAction, len: usize, hmax: u16) {
+    let step = PAGE_SCROLL as usize;
+    match action {
+        NavAction::Down => cursor.down(len),
+        NavAction::Up => cursor.up(),
+        NavAction::Right => cursor.right(hmax),
+        NavAction::Left => cursor.left(),
+        NavAction::PageDown => cursor.page_down(len, step),
+        NavAction::PageUp => cursor.page_up(step),
+    }
+}
+
 /// `T` theme toggle accepts a plain capital key (Caps Lock) or Shift+T; reject Ctrl/Alt combos.
 fn theme_toggle_modifiers_ok(modifiers: KeyModifiers) -> bool {
     modifiers.is_empty() || modifiers == KeyModifiers::SHIFT
@@ -271,85 +284,24 @@ impl AppState {
         {
             return false;
         }
-        // Pins: precompute len/hmax (immutable helpers) then mut the payload — cannot hold
-        // `&mut PinsState` from `match &mut self.screen` while calling those helpers.
+        // Pins/Gists: precompute len/hmax with &self, then mut ListCursor (issue #274).
+        // Cannot hold `&mut PinsState` from `match &mut self.screen` while calling helpers.
         if matches!(self.screen, Screen::Pins(_)) {
             let len = self.visible_pin_indices().len();
             let hmax = self.pins_hscroll_max();
             let Some(pins) = self.pins_mut() else {
                 return false;
             };
-            match action {
-                NavAction::Down => {
-                    if pins.index + 1 < len {
-                        pins.index += 1;
-                        pins.hscroll = 0;
-                    }
-                }
-                NavAction::Up => {
-                    if pins.index > 0 {
-                        pins.index -= 1;
-                        pins.hscroll = 0;
-                    }
-                }
-                NavAction::Right => {
-                    pins.hscroll = (pins.hscroll + 1).min(hmax);
-                }
-                NavAction::Left => {
-                    pins.hscroll = pins.hscroll.saturating_sub(1);
-                }
-                NavAction::PageDown => {
-                    if len > 0 {
-                        let max = len - 1;
-                        pins.index = (pins.index + PAGE_SCROLL as usize).min(max);
-                        pins.hscroll = 0;
-                    }
-                }
-                NavAction::PageUp => {
-                    pins.index = pins.index.saturating_sub(PAGE_SCROLL as usize);
-                    pins.hscroll = 0;
-                }
-            }
+            apply_list_cursor_nav(&mut pins.cursor, action, len, hmax);
             return true;
         }
-        // Gists: same borrow pattern as Pins (visible groups / hscroll max need &self).
         if matches!(self.screen, Screen::Gists(_)) {
             let len = self.visible_gist_groups().len();
             let hmax = self.gists_hscroll_max();
             let Some(gm) = self.gist_manager_mut() else {
                 return false;
             };
-            match action {
-                NavAction::Down => {
-                    if gm.index + 1 < len {
-                        gm.index += 1;
-                        gm.hscroll = 0;
-                    }
-                }
-                NavAction::Up => {
-                    if gm.index > 0 {
-                        gm.index -= 1;
-                        gm.hscroll = 0;
-                    }
-                }
-                NavAction::Right => {
-                    gm.hscroll = (gm.hscroll + 1).min(hmax);
-                }
-                NavAction::Left => {
-                    gm.hscroll = gm.hscroll.saturating_sub(1);
-                }
-                NavAction::PageDown => {
-                    if len > 0 {
-                        let max = len - 1;
-                        gm.index = (gm.index + PAGE_SCROLL as usize).min(max);
-                        gm.hscroll = 0;
-                    }
-                }
-                NavAction::PageUp => {
-                    gm.index = gm.index.saturating_sub(PAGE_SCROLL as usize);
-                    gm.hscroll = 0;
-                }
-            }
+            apply_list_cursor_nav(&mut gm.cursor, action, len, hmax);
             return true;
         }
         match &mut self.screen {
@@ -567,23 +519,15 @@ impl AppState {
                 return KeyOutcome::None;
             };
             match code {
-                KeyCode::Up if pins.index > 0 => {
-                    pins.index -= 1;
-                    pins.hscroll = 0;
-                }
-                KeyCode::Up => {}
+                KeyCode::Up => pins.cursor.up(),
                 KeyCode::Down => {
                     // visible length needs self; re-fetch after borrow ends
                 }
                 _ => match apply_filter_edit(code, &mut pins.filter_query) {
-                    FilterKey::Edited => {
-                        pins.index = 0;
-                        pins.hscroll = 0;
-                    }
+                    FilterKey::Edited => pins.cursor.reset(),
                     FilterKey::Cleared => {
                         pins.filtering = false;
-                        pins.index = 0;
-                        pins.hscroll = 0;
+                        pins.cursor.reset();
                     }
                     FilterKey::Exited => pins.filtering = false,
                     FilterKey::Moved | FilterKey::Pass => {}
@@ -592,10 +536,7 @@ impl AppState {
             if code == KeyCode::Down {
                 let len = self.visible_pin_indices().len();
                 if let Some(pins) = self.pins_mut() {
-                    if pins.index + 1 < len {
-                        pins.index += 1;
-                        pins.hscroll = 0;
-                    }
+                    pins.cursor.down(len);
                 }
             }
             return KeyOutcome::None;
@@ -657,8 +598,7 @@ impl AppState {
             KeyCode::Char('o') => {
                 if let Some(pins) = self.pins_mut() {
                     pins.sort = pins.sort.next();
-                    pins.index = 0;
-                    pins.hscroll = 0;
+                    pins.cursor.reset();
                 }
             }
             KeyCode::Char('?') => self.open_help(),
@@ -675,23 +615,15 @@ impl AppState {
                 return KeyOutcome::None;
             };
             match code {
-                KeyCode::Up if gm.index > 0 => {
-                    gm.index -= 1;
-                    gm.hscroll = 0;
-                }
-                KeyCode::Up => {}
+                KeyCode::Up => gm.cursor.up(),
                 KeyCode::Down => {
                     // visible length needs self; re-fetch after borrow ends
                 }
                 _ => match apply_filter_edit(code, &mut gm.filter_query) {
-                    FilterKey::Edited => {
-                        gm.index = 0;
-                        gm.hscroll = 0;
-                    }
+                    FilterKey::Edited => gm.cursor.reset(),
                     FilterKey::Cleared => {
                         gm.filtering = false;
-                        gm.index = 0;
-                        gm.hscroll = 0;
+                        gm.cursor.reset();
                     }
                     FilterKey::Exited => gm.filtering = false,
                     FilterKey::Moved | FilterKey::Pass => {}
@@ -700,16 +632,13 @@ impl AppState {
             if code == KeyCode::Down {
                 let len = self.visible_gist_groups().len();
                 if let Some(gm) = self.gist_manager_mut() {
-                    if gm.index + 1 < len {
-                        gm.index += 1;
-                        gm.hscroll = 0;
-                    }
+                    gm.cursor.down(len);
                 }
             }
             return KeyOutcome::None;
         }
         let groups_len = self.visible_gist_groups().len();
-        let index = self.gist_manager().map(|g| g.index).unwrap_or(0);
+        let index = self.gist_manager().map(|g| g.cursor.index).unwrap_or(0);
         match code {
             KeyCode::Char('q') | KeyCode::Esc => self.screen = Screen::List,
             KeyCode::Char('/') => {
@@ -720,15 +649,13 @@ impl AppState {
             KeyCode::Char('s') => {
                 if let Some(gm) = self.gist_manager_mut() {
                     gm.sort = gm.sort.next();
-                    gm.index = 0;
-                    gm.hscroll = 0;
+                    gm.cursor.reset();
                 }
             }
             KeyCode::Char('v') => {
                 if let Some(gm) = self.gist_manager_mut() {
                     gm.type_filter = gm.type_filter.next();
-                    gm.index = 0;
-                    gm.hscroll = 0;
+                    gm.cursor.reset();
                 }
             }
             KeyCode::Char('*') => return self.star_toggle_intent(),
@@ -1071,8 +998,7 @@ impl AppState {
                         let count = self.visible_gist_groups().len();
                         if let Some(idx) = hit.index_at(row, count) {
                             if let Some(gm) = self.gist_manager_mut() {
-                                gm.index = idx;
-                                gm.hscroll = 0;
+                                gm.cursor.select(idx);
                                 return true;
                             }
                         }
@@ -1086,8 +1012,7 @@ impl AppState {
                         let count = self.visible_pin_indices().len();
                         if let Some(idx) = hit.index_at(row, count) {
                             if let Some(pins) = self.pins_mut() {
-                                pins.index = idx;
-                                pins.hscroll = 0;
+                                pins.cursor.select(idx);
                                 return true;
                             }
                         }
@@ -1867,9 +1792,10 @@ impl AppState {
         self.screen = Screen::Gists(Box::default());
         let groups = self.visible_gist_groups();
         if let Some(gm) = self.gist_manager_mut() {
-            gm.index = target
+            let idx = target
                 .and_then(|id| groups.iter().position(|g| g.id == id))
                 .unwrap_or(0);
+            gm.cursor.select(idx);
         }
     }
 
@@ -1877,8 +1803,7 @@ impl AppState {
     /// filtered-in position from a previous visit never lingers.
     pub(crate) fn open_pins(&mut self) {
         self.screen = Screen::Pins(Box::new(PinsState {
-            index: 0,
-            hscroll: 0,
+            cursor: ListCursor::default(),
             ..PinsState::default()
         }));
     }

--- a/src/tui/list_cursor.rs
+++ b/src/tui/list_cursor.rs
@@ -1,0 +1,252 @@
+//! Shared list selection + horizontal scroll for Pins and Gists manager screens.
+//!
+//! Bounds (`len`, `hmax`, page `step`) are computed by the caller with `&AppState`
+//! *before* taking `&mut` on the payload, so navigation never fights the borrow
+//! checker (issue #274).
+
+/// Index + horizontal scroll for a single-column list that resets hscroll when the
+/// selection moves vertically (Pins / Gists policy).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ListCursor {
+    pub index: usize,
+    pub hscroll: u16,
+}
+
+impl ListCursor {
+    /// Move selection down one row; no-op at the bottom. Resets hscroll on move.
+    pub fn down(&mut self, len: usize) {
+        if self.index + 1 < len {
+            self.index += 1;
+            self.hscroll = 0;
+        }
+    }
+
+    /// Move selection up one row; no-op at the top. Resets hscroll on move.
+    pub fn up(&mut self) {
+        if self.index > 0 {
+            self.index -= 1;
+            self.hscroll = 0;
+        }
+    }
+
+    /// Page selection down by `step` rows (clamped). Resets hscroll when `len > 0`.
+    pub fn page_down(&mut self, len: usize, step: usize) {
+        if len > 0 {
+            let max = len - 1;
+            self.index = (self.index + step).min(max);
+            self.hscroll = 0;
+        }
+    }
+
+    /// Page selection up by `step` rows (clamped at 0). Always resets hscroll.
+    pub fn page_up(&mut self, step: usize) {
+        self.index = self.index.saturating_sub(step);
+        self.hscroll = 0;
+    }
+
+    /// Scroll the focused row right, clamped to `hmax`.
+    pub fn right(&mut self, hmax: u16) {
+        self.hscroll = (self.hscroll + 1).min(hmax);
+    }
+
+    /// Scroll the focused row left (floor 0).
+    pub fn left(&mut self) {
+        self.hscroll = self.hscroll.saturating_sub(1);
+    }
+
+    /// Jump to the first row and clear hscroll (filter edit, sort change, …).
+    pub fn reset(&mut self) {
+        self.index = 0;
+        self.hscroll = 0;
+    }
+
+    /// Select a concrete row (e.g. mouse click) and clear hscroll.
+    pub fn select(&mut self, index: usize) {
+        self.index = index;
+        self.hscroll = 0;
+    }
+
+    /// Clamp index into `0..len` after the visible list shrinks.
+    /// Empty list → index 0. Does not touch hscroll.
+    pub fn clamp_len(&mut self, len: usize) {
+        if len == 0 {
+            self.index = 0;
+        } else {
+            self.index = self.index.min(len - 1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn down_up_move_and_reset_hscroll() {
+        let mut c = ListCursor {
+            index: 0,
+            hscroll: 3,
+        };
+        c.down(3);
+        assert_eq!(
+            c,
+            ListCursor {
+                index: 1,
+                hscroll: 0
+            }
+        );
+        c.hscroll = 2;
+        c.down(3);
+        assert_eq!(
+            c,
+            ListCursor {
+                index: 2,
+                hscroll: 0
+            }
+        );
+        c.down(3); // already at bottom
+        assert_eq!(
+            c,
+            ListCursor {
+                index: 2,
+                hscroll: 0
+            }
+        );
+        c.hscroll = 5;
+        c.up();
+        assert_eq!(
+            c,
+            ListCursor {
+                index: 1,
+                hscroll: 0
+            }
+        );
+        c.up();
+        c.up(); // floor
+        assert_eq!(
+            c,
+            ListCursor {
+                index: 0,
+                hscroll: 0
+            }
+        );
+    }
+
+    #[test]
+    fn page_down_up_use_step_and_reset_hscroll() {
+        let mut c = ListCursor {
+            index: 0,
+            hscroll: 4,
+        };
+        c.page_down(20, 10);
+        assert_eq!(
+            c,
+            ListCursor {
+                index: 10,
+                hscroll: 0
+            }
+        );
+        c.hscroll = 1;
+        c.page_down(20, 10);
+        assert_eq!(
+            c,
+            ListCursor {
+                index: 19,
+                hscroll: 0
+            }
+        ); // clamped
+        c.hscroll = 2;
+        c.page_up(10);
+        assert_eq!(
+            c,
+            ListCursor {
+                index: 9,
+                hscroll: 0
+            }
+        );
+        c.page_up(100);
+        assert_eq!(
+            c,
+            ListCursor {
+                index: 0,
+                hscroll: 0
+            }
+        );
+    }
+
+    #[test]
+    fn page_down_on_empty_list_is_noop() {
+        let mut c = ListCursor {
+            index: 5,
+            hscroll: 2,
+        };
+        c.page_down(0, 10);
+        assert_eq!(
+            c,
+            ListCursor {
+                index: 5,
+                hscroll: 2
+            }
+        );
+    }
+
+    #[test]
+    fn left_right_clamp_hscroll() {
+        let mut c = ListCursor::default();
+        c.right(2);
+        c.right(2);
+        c.right(2); // clamp
+        assert_eq!(c.hscroll, 2);
+        c.left();
+        assert_eq!(c.hscroll, 1);
+        c.left();
+        c.left();
+        assert_eq!(c.hscroll, 0);
+    }
+
+    #[test]
+    fn reset_and_select_clear_hscroll() {
+        let mut c = ListCursor {
+            index: 4,
+            hscroll: 7,
+        };
+        c.reset();
+        assert_eq!(c, ListCursor::default());
+        c.select(3);
+        assert_eq!(
+            c,
+            ListCursor {
+                index: 3,
+                hscroll: 0
+            }
+        );
+    }
+
+    #[test]
+    fn clamp_len_empty_and_shrink() {
+        let mut c = ListCursor {
+            index: 9,
+            hscroll: 3,
+        };
+        c.clamp_len(5);
+        assert_eq!(
+            c,
+            ListCursor {
+                index: 4,
+                hscroll: 3
+            },
+            "hscroll preserved on clamp"
+        );
+        c.clamp_len(0);
+        assert_eq!(
+            c,
+            ListCursor {
+                index: 0,
+                hscroll: 3
+            }
+        );
+        c.index = 0;
+        c.clamp_len(10);
+        assert_eq!(c.index, 0);
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -826,6 +826,8 @@ pub struct RevisionState {
     /// Fetched revision rows (`None` while the initial list fetch is in flight).
     pub entries: Option<Vec<GistRevision>>,
     /// Cursor into `entries` (0 = current head).
+    /// Not a [`ListCursor`]: Revisions does not reset hscroll on vertical move and does
+    /// not clamp Right to an hmax (issue #274 — out of scope).
     pub index: usize,
     pub hscroll: u16,
     /// File within the gist that preview/diff/restore target.
@@ -849,8 +851,8 @@ pub struct HelpState {
 /// Pins-screen state — carried on [`Screen::Pins`] (issue #242).
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct PinsState {
-    pub index: usize,
-    pub hscroll: u16,
+    /// Selection + row hscroll (shared Pins/Gists policy; issue #274).
+    pub cursor: ListCursor,
     pub filtering: bool,
     pub filter_query: TextInput,
     pub sort: PinSort,
@@ -916,8 +918,8 @@ impl Default for ConfirmState {
 /// `Vec`. Data only — methods stay on `AppState`.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct GistsManagerState {
-    pub index: usize,
-    pub hscroll: u16,
+    /// Selection + row hscroll (shared Pins/Gists policy; issue #274).
+    pub cursor: ListCursor,
     pub sort: GistGroupSort,
     pub type_filter: GistTypeFilter,
     pub filtering: bool,
@@ -1820,7 +1822,7 @@ impl AppState {
 
     /// The gist highlighted in the gist-level view.
     pub fn selected_group(&self) -> Option<GistGroup> {
-        let idx = self.gist_manager().map(|g| g.index).unwrap_or(0);
+        let idx = self.gist_manager().map(|g| g.cursor.index).unwrap_or(0);
         self.visible_gist_groups().into_iter().nth(idx)
     }
 
@@ -1899,7 +1901,7 @@ impl AppState {
     /// The true `self.pinned` index of the currently selected Pins row (selection is a
     /// position within the filtered view).
     pub fn selected_pin_index(&self) -> Option<usize> {
-        let idx = self.pins().map(|p| p.index).unwrap_or(0);
+        let idx = self.pins().map(|p| p.cursor.index).unwrap_or(0);
         self.visible_pin_indices().get(idx).copied()
     }
 
@@ -2803,6 +2805,8 @@ use text::{comment_lines_count, hscroll_max_among, local_row_label};
 mod bg;
 mod dispatch;
 mod keys;
+mod list_cursor;
+pub(crate) use list_cursor::ListCursor;
 mod run_loop;
 use run_loop::run_loop;
 mod text_input;

--- a/src/tui/palette.rs
+++ b/src/tui/palette.rs
@@ -459,7 +459,7 @@ fn pins_palette_items(state: &AppState) -> Vec<PaletteItem> {
 
 fn gists_palette_items(state: &AppState) -> Vec<PaletteItem> {
     let groups = state.visible_gist_groups();
-    let index = state.gist_manager().map(|g| g.index).unwrap_or(0);
+    let index = state.gist_manager().map(|g| g.cursor.index).unwrap_or(0);
     let has_sel = index < groups.len();
     vec![
         key_item("Enter", "Open gist detail", KeyCode::Enter, has_sel),

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -162,7 +162,7 @@ fn state_with_gists() -> AppState {
             node_id: None,
         },
     ];
-    gists_mut(&mut state).index = 0;
+    gists_mut(&mut state).cursor.index = 0;
     state
 }
 
@@ -691,7 +691,7 @@ fn context_gist_id_uses_detail_id_on_detail_screen() {
 fn context_gist_id_uses_group_cursor_on_gists_screen() {
     let mut state = state_with_gists();
     state.screen = Screen::Gists(Box::default());
-    gists_mut(&mut state).index = 0;
+    gists_mut(&mut state).cursor.index = 0;
     assert_eq!(
         state.context_gist_id(),
         state.selected_group().map(|g| g.id)
@@ -3272,7 +3272,7 @@ fn g_opens_gist_view_landing_on_the_selected_files_gist() {
     state.gist_index = 1;
     assert_eq!(state.handle_key(KeyCode::Char('g')), KeyOutcome::None);
     assert!(state.screen.is_gists());
-    assert_eq!(gists_ref(&state).index, 1);
+    assert_eq!(gists_ref(&state).cursor.index, 1);
     assert_eq!(state.selected_group().unwrap().id, "b");
 }
 
@@ -3507,14 +3507,14 @@ fn gist_view_s_cycles_sort_updated_then_created() {
 fn gist_view_left_right_scrolls_horizontally() {
     let mut state = state_with_two_gists();
     state.screen = Screen::Gists(Box::default());
-    assert_eq!(gists_ref(&state).hscroll, 0);
+    assert_eq!(gists_ref(&state).cursor.hscroll, 0);
     state.handle_key(KeyCode::Right);
-    assert_eq!(gists_ref(&state).hscroll, 1);
+    assert_eq!(gists_ref(&state).cursor.hscroll, 1);
     state.handle_key(KeyCode::Left);
-    assert_eq!(gists_ref(&state).hscroll, 0);
+    assert_eq!(gists_ref(&state).cursor.hscroll, 0);
     // Left at the origin saturates at 0.
     state.handle_key(KeyCode::Left);
-    assert_eq!(gists_ref(&state).hscroll, 0);
+    assert_eq!(gists_ref(&state).cursor.hscroll, 0);
 }
 
 #[test]
@@ -3667,7 +3667,7 @@ fn pins_state_with_long_home_path() -> AppState {
         direction: None,
         last_seen_hash: None,
     }];
-    pins_mut(&mut state).index = 0;
+    pins_mut(&mut state).cursor.index = 0;
     state
 }
 
@@ -3675,7 +3675,7 @@ fn pins_state_with_long_home_path() -> AppState {
 fn pins_hscroll_starts_at_zero() {
     let mut state = initial_state();
     state.screen = Screen::Pins(Box::default());
-    assert_eq!(pins_ref(&state).hscroll, 0);
+    assert_eq!(pins_ref(&state).cursor.hscroll, 0);
 }
 
 #[test]
@@ -3757,7 +3757,7 @@ fn pins_right_scrolls_then_clamps_at_a_bound() {
     let mut state = pins_state_with_long_home_path();
     state.handle_key(KeyCode::Right);
     assert_eq!(
-        pins_ref(&state).hscroll,
+        pins_ref(&state).cursor.hscroll,
         1,
         "Right should advance the scroll"
     );
@@ -3765,10 +3765,10 @@ fn pins_right_scrolls_then_clamps_at_a_bound() {
     for _ in 0..500 {
         state.handle_key(KeyCode::Right);
     }
-    let clamped = pins_ref(&state).hscroll;
+    let clamped = pins_ref(&state).cursor.hscroll;
     state.handle_key(KeyCode::Right);
     assert_eq!(
-        pins_ref(&state).hscroll,
+        pins_ref(&state).cursor.hscroll,
         clamped,
         "scroll must clamp at its max"
     );
@@ -3781,7 +3781,7 @@ fn pins_left_clamps_at_zero() {
     state.handle_key(KeyCode::Right);
     state.handle_key(KeyCode::Left);
     state.handle_key(KeyCode::Left);
-    assert_eq!(pins_ref(&state).hscroll, 0);
+    assert_eq!(pins_ref(&state).cursor.hscroll, 0);
 }
 
 #[test]
@@ -3795,10 +3795,10 @@ fn pins_hscroll_resets_when_selection_moves() {
         last_seen_hash: None,
     });
     state.handle_key(KeyCode::Right);
-    assert!(pins_ref(&state).hscroll > 0);
+    assert!(pins_ref(&state).cursor.hscroll > 0);
     state.handle_key(KeyCode::Down);
     assert_eq!(
-        pins_ref(&state).hscroll,
+        pins_ref(&state).cursor.hscroll,
         0,
         "moving selection resets hscroll"
     );
@@ -3808,11 +3808,11 @@ fn pins_hscroll_resets_when_selection_moves() {
 fn entering_pins_screen_resets_hscroll() {
     let mut state = pins_state_with_long_home_path();
     state.handle_key(KeyCode::Right);
-    assert!(pins_ref(&state).hscroll > 0);
+    assert!(pins_ref(&state).cursor.hscroll > 0);
     state.screen = Screen::List;
     state.handle_key(KeyCode::Char('P'));
     assert!(state.screen.is_pins());
-    assert_eq!(pins_ref(&state).hscroll, 0);
+    assert_eq!(pins_ref(&state).cursor.hscroll, 0);
 }
 
 #[test]
@@ -3832,7 +3832,7 @@ fn top_bar_gists_click_opens_gist_manager_from_any_screen() {
 fn top_bar_pins_click_opens_pins_from_any_screen() {
     let mut state = pins_state_with_long_home_path();
     state.handle_key(KeyCode::Right); // dirty the hscroll so the reset is observable
-    assert!(pins_ref(&state).hscroll > 0);
+    assert!(pins_ref(&state).cursor.hscroll > 0);
     state.screen = Screen::Preview(Box::default());
     let layout = MouseLayout {
         top_bar_pins: Some(Rect::new(20, 0, 6, 1)),
@@ -3840,7 +3840,7 @@ fn top_bar_pins_click_opens_pins_from_any_screen() {
     };
     let out = state.handle_mouse(MouseInput::Click { col: 22, row: 0 }, &layout);
     assert!(state.screen.is_pins());
-    assert_eq!(pins_ref(&state).hscroll, 0);
+    assert_eq!(pins_ref(&state).cursor.hscroll, 0);
     assert_eq!(out, KeyOutcome::None);
 }
 
@@ -4270,10 +4270,10 @@ fn gists_filter_navigates_while_typing() {
     gists_mut(&mut state).filtering = true;
 
     state.handle_key(KeyCode::Down);
-    assert_eq!(gists_ref(&state).index, 1);
+    assert_eq!(gists_ref(&state).cursor.index, 1);
     assert!(gists_ref(&state).filtering);
     state.handle_key(KeyCode::Up);
-    assert_eq!(gists_ref(&state).index, 0);
+    assert_eq!(gists_ref(&state).cursor.index, 0);
 }
 
 #[test]
@@ -4342,7 +4342,7 @@ fn selected_pin_index_maps_through_filter() {
         ("/cwd/gamma", "g3", "gamma"),
     ]);
     pins_mut(&mut state).filter_query = "gamma".into(); // only row 2 visible
-    pins_mut(&mut state).index = 0; // first (and only) visible row
+    pins_mut(&mut state).cursor.index = 0; // first (and only) visible row
     assert_eq!(state.selected_pin_index(), Some(2)); // TRUE index, not 0
 }
 
@@ -4355,7 +4355,7 @@ fn pins_down_clamps_to_filtered_count() {
     ]);
     pins_mut(&mut state).filter_query = "lua".into(); // 1 visible
     state.handle_key(KeyCode::Down);
-    assert_eq!(pins_ref(&state).index, 0); // clamped to the single filtered row
+    assert_eq!(pins_ref(&state).cursor.index, 0); // clamped to the single filtered row
 }
 
 #[test]
@@ -4365,7 +4365,7 @@ fn pins_filter_input_behaviors() {
 
     // live nav while typing
     state.handle_key(KeyCode::Down);
-    assert_eq!(pins_ref(&state).index, 1);
+    assert_eq!(pins_ref(&state).cursor.index, 1);
     assert!(pins_ref(&state).filtering);
 
     // Tab is a no-op (single pane)
@@ -4681,9 +4681,9 @@ fn pins_page_keys_jump_selection() {
         })
         .collect();
     state.handle_key_with(KeyCode::Char('f'), KeyModifiers::CONTROL);
-    assert_eq!(pins_ref(&state).index, 10);
+    assert_eq!(pins_ref(&state).cursor.index, 10);
     state.handle_key(KeyCode::PageUp);
-    assert_eq!(pins_ref(&state).index, 0);
+    assert_eq!(pins_ref(&state).cursor.index, 0);
 }
 
 #[test]
@@ -4706,9 +4706,9 @@ fn gists_page_keys_jump_selection() {
         })
         .collect();
     state.handle_key(KeyCode::PageDown);
-    assert_eq!(gists_ref(&state).index, 10);
+    assert_eq!(gists_ref(&state).cursor.index, 10);
     state.handle_key(KeyCode::PageDown);
-    assert_eq!(gists_ref(&state).index, 11);
+    assert_eq!(gists_ref(&state).cursor.index, 11);
 }
 
 #[test]
@@ -5274,7 +5274,7 @@ fn fork_key_ignored_on_list_and_gist_manager() {
 
     state.screen = Screen::Gists(Box::default());
     gists_mut(&mut state).type_filter = GistTypeFilter::Starred;
-    gists_mut(&mut state).index = 0;
+    gists_mut(&mut state).cursor.index = 0;
     assert_eq!(state.handle_key(KeyCode::Char('F')), KeyOutcome::None);
 }
 
@@ -5636,7 +5636,7 @@ fn wheel_step_help_index_moves_one() {
 #[test]
 fn gists_click_selects_and_double_click_matches_enter() {
     let mut state = gists_screen_state(); // 2 groups, Screen::Gists
-    gists_mut(&mut state).index = 0;
+    gists_mut(&mut state).cursor.index = 0;
     let hit = PaneHit {
         rect: Rect::new(0, 0, 40, 10),
         offset: 0,
@@ -5648,7 +5648,7 @@ fn gists_click_selects_and_double_click_matches_enter() {
     // Row 2 is the 2nd content row (border at row 0) -> idx 1.
     let out = state.handle_mouse(MouseInput::Click { col: 5, row: 2 }, &layout);
     assert_eq!(out, KeyOutcome::None);
-    assert_eq!(gists_ref(&state).index, 1);
+    assert_eq!(gists_ref(&state).cursor.index, 1);
     // Double-click activates the same row, exactly as Enter would.
     let mut by_key = state.clone();
     let key_out = by_key.handle_key(KeyCode::Enter);
@@ -5670,7 +5670,7 @@ fn pins_click_selects_and_double_click_matches_enter() {
     };
     let out = state.handle_mouse(MouseInput::Click { col: 5, row: 2 }, &layout);
     assert_eq!(out, KeyOutcome::None);
-    assert_eq!(pins_ref(&state).index, 1);
+    assert_eq!(pins_ref(&state).cursor.index, 1);
     let mut by_key = state.clone();
     let key_out = by_key.handle_key(KeyCode::Enter);
     let by_mouse = state.handle_mouse(MouseInput::DoubleClick { col: 5, row: 2 }, &layout);

--- a/src/tui/view_model.rs
+++ b/src/tui/view_model.rs
@@ -801,12 +801,12 @@ pub(crate) fn build_gists_vm(state: &AppState) -> GistsVm {
         empty,
         empty_message,
         rows,
-        selected: (!groups.is_empty()).then_some(gm.index),
+        selected: (!groups.is_empty()).then_some(gm.cursor.index),
         filtering: gm.filtering,
         footer_title,
         footer,
         footer_colored,
-        hscroll: gm.hscroll,
+        hscroll: gm.cursor.hscroll,
     }
 }
 
@@ -1021,13 +1021,13 @@ pub(crate) fn build_pins_vm(state: &AppState) -> PinsVm {
         title,
         empty,
         rows,
-        selected: (!visible.is_empty()).then_some(pins.index),
+        selected: (!visible.is_empty()).then_some(pins.cursor.index),
         filtering: pins.filtering,
         filter_query: pins.filter_query.to_string(),
         footer_title,
         footer,
         footer_colored,
-        hscroll: pins.hscroll,
+        hscroll: pins.cursor.hscroll,
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `src/tui/list_cursor.rs` with `ListCursor { index, hscroll }` and methods: `down` / `up` / `page_down` / `page_up` / `left` / `right` / `reset` / `select` / `clamp_len`.
- `PinsState` and `GistsManagerState` each hold `pub cursor: ListCursor`; all mutations go through those methods (including filter-mode arrows, sort/type-filter reset, mouse select, bg clamp).
- `apply_navigation` precomputes `len`/`hmax` then calls a thin `apply_list_cursor_nav` (page step from existing `PAGE_SCROLL`).
- **Out of scope:** Revisions (no hscroll reset on vertical move; Right unclamped), Config/Palette/List.
- **Micro-diff:** empty Gists list after fetch now clamps index to 0 (was left untouched).

Grilling decisions are on #274.

Closes #274

## Test plan

- [x] `mise run check` (fmt + clippy `-D warnings` + 545 unit tests + 12 integration)
- [x] New `ListCursor` unit tests for all methods
- [x] Existing Pins/Gists key/screen tests (field path → `cursor.*`)