### PR TITLE
refactor(tui): share GistFileRef for gist-file identity on outcomes

### DIFF
--- a/src/domain.rs
+++ b/src/domain.rs
@@ -301,6 +301,51 @@ impl GistFile {
     }
 }
 
+/// Identity of one file inside a gist — the three fields a fetch/sync path needs,
+/// without list-row metadata on [`GistFile`] (issue #276).
+///
+/// Used on TUI `KeyOutcome` / `BgTaskOutcome` variants so dispatch does not re-split
+/// ad hoc `gist_id`/`filename`/`raw_url` bags. Labels and local paths stay outside.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GistFileRef {
+    pub gist_id: String,
+    pub filename: String,
+    pub raw_url: Option<String>,
+}
+
+impl GistFileRef {
+    pub fn new(
+        gist_id: impl Into<String>,
+        filename: impl Into<String>,
+        raw_url: Option<String>,
+    ) -> Self {
+        Self {
+            gist_id: gist_id.into(),
+            filename: filename.into(),
+            raw_url,
+        }
+    }
+
+    /// Identity without a raw URL (cache invalidation, upload replace, …).
+    pub fn id_name(gist_id: impl Into<String>, filename: impl Into<String>) -> Self {
+        Self::new(gist_id, filename, None)
+    }
+
+    /// Throwaway [`GistFile`] for plans / labels that still take a full row.
+    pub fn to_gist_file(&self) -> GistFile {
+        GistFile::for_sync(
+            self.gist_id.clone(),
+            self.filename.clone(),
+            self.raw_url.clone(),
+        )
+    }
+
+    /// Key for the gist content LRU: `(gist_id, filename)` only.
+    pub fn cache_key(&self) -> (String, String) {
+        (self.gist_id.clone(), self.filename.clone())
+    }
+}
+
 /// One entry from `gh api /gists/{id}/commits` — a gist revision (newest-first in the API).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GistRevision {
@@ -437,6 +482,23 @@ pub fn group_gists(files: &[GistFile]) -> Vec<GistGroup> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn gist_file_ref_to_gist_file_matches_for_sync() {
+        let r = GistFileRef::new("abc", "a.txt", Some("https://raw/x".into()));
+        let g = r.to_gist_file();
+        assert_eq!(g.gist_id, "abc");
+        assert_eq!(g.filename, "a.txt");
+        assert_eq!(g.raw_url.as_deref(), Some("https://raw/x"));
+        assert!(g.description.is_empty());
+    }
+
+    #[test]
+    fn gist_file_ref_cache_key_is_id_and_filename() {
+        let r = GistFileRef::new("g1", "f.toml", Some("https://raw".into()));
+        assert_eq!(r.cache_key(), ("g1".into(), "f.toml".into()));
+        assert_eq!(GistFileRef::id_name("g1", "f.toml").raw_url, None);
+    }
 
     #[test]
     fn sync_status_from_mtime() {

--- a/src/tui/bg.rs
+++ b/src/tui/bg.rs
@@ -49,21 +49,18 @@ pub(super) enum BgTaskOutcome {
         target: PathBuf,
         local_label: String,
         gist_label: String,
-        gist_id: String,
-        filename: String,
+        file: crate::domain::GistFileRef,
     },
     UploadPreview {
         result: std::result::Result<String, String>,
-        gist_id: String,
-        filename: String,
+        file: crate::domain::GistFileRef,
         local_path: PathBuf,
         local_label: String,
         gist_label: String,
     },
     UploadReplace {
         result: std::result::Result<(), String>,
-        gist_id: String,
-        filename: String,
+        file: crate::domain::GistFileRef,
     },
     CreateGist {
         result: std::result::Result<(), String>,
@@ -72,7 +69,7 @@ pub(super) enum BgTaskOutcome {
     },
     PreviewContent {
         result: std::result::Result<String, String>,
-        key: (String, String),
+        file: crate::domain::GistFileRef,
         preview_title: String,
     },
     DeleteGist {
@@ -455,14 +452,13 @@ pub(super) fn spawn_pin_push(
     let filename = m.gist_filename.clone();
     // Upload Confirm is opened when UploadPreview completes (staged return is Pins).
     let raw_url = state.gist_file_raw_url(&gist_id, &filename);
-    let gist_file = GistFile::for_sync(gist_id.clone(), filename.clone(), raw_url.clone());
-    let (local_label, gist_label) = diff_labels(Some(&local_path), &gist_file);
+    let file = crate::domain::GistFileRef::new(gist_id, filename, raw_url);
+    let (local_label, gist_label) = diff_labels(Some(&local_path), &file.to_gist_file());
     jobs.spawn_action(state, "Loading diff…", move || {
-        let result = fetch_gist_content(&gist_id, &filename, raw_url.as_deref());
+        let result = fetch_gist_content(&file.gist_id, &file.filename, file.raw_url.as_deref());
         BgTaskOutcome::UploadPreview {
             result,
-            gist_id,
-            filename,
+            file,
             local_path,
             local_label,
             gist_label,
@@ -482,17 +478,16 @@ pub(super) fn spawn_pin_pull(
     let gist_id = m.gist_id.clone();
     let filename = m.gist_filename.clone();
     let raw_url = state.gist_file_raw_url(&gist_id, &filename);
-    let gist_file = GistFile::for_sync(gist_id.clone(), filename.clone(), raw_url.clone());
-    let (local_label, gist_label) = diff_labels(Some(&target), &gist_file);
+    let file = crate::domain::GistFileRef::new(gist_id, filename, raw_url);
+    let (local_label, gist_label) = diff_labels(Some(&target), &file.to_gist_file());
     jobs.spawn_action(state, "Downloading…", move || {
-        let result = fetch_gist_content(&gist_id, &filename, raw_url.as_deref());
+        let result = fetch_gist_content(&file.gist_id, &file.filename, file.raw_url.as_deref());
         BgTaskOutcome::DownloadSelected {
             result,
             target,
             local_label,
             gist_label,
-            gist_id,
-            filename,
+            file,
         }
     });
 }
@@ -1463,8 +1458,7 @@ fn absorb_background_results_body(
                         target,
                         local_label,
                         gist_label,
-                        gist_id,
-                        filename,
+                        file,
                     } => match result {
                         Ok(remote) => {
                             if target.exists() {
@@ -1483,7 +1477,7 @@ fn absorb_background_results_body(
                                             state.ignore_trailing_newline,
                                         );
                                         state.staged_diff_gist =
-                                            Some((gist_id.clone(), filename.clone()));
+                                            Some((file.gist_id.clone(), file.filename.clone()));
                                         state.enter_diff(diff, remote, target.clone(), target);
                                         if let Some(d) = state.diff_mut() {
                                             d.identical = identical;
@@ -1508,8 +1502,8 @@ fn absorb_background_results_body(
                                         record_pin_sync(
                                             state,
                                             &target,
-                                            &gist_id,
-                                            &filename,
+                                            &file.gist_id,
+                                            &file.filename,
                                             &remote,
                                             Some(crate::domain::SyncDirection::Download),
                                         );
@@ -1525,8 +1519,7 @@ fn absorb_background_results_body(
                     },
                     BgTaskOutcome::UploadPreview {
                         result,
-                        gist_id,
-                        filename,
+                        file,
                         local_path,
                         local_label,
                         gist_label,
@@ -1534,8 +1527,8 @@ fn absorb_background_results_body(
                         Ok(remote) => {
                             // Keep staged pin/list return; enter_confirm consumes it.
                             let action = PendingAction::Upload {
-                                gist_id,
-                                filename,
+                                gist_id: file.gist_id,
+                                filename: file.filename,
                                 local_path: local_path.clone(),
                             };
                             match state.init_upload_state(
@@ -1561,23 +1554,20 @@ fn absorb_background_results_body(
                         }
                         Err(error) => state.set_status(format!("fetch failed: {error}")),
                     },
-                    BgTaskOutcome::UploadReplace {
-                        result,
-                        gist_id,
-                        filename,
-                    } => match result {
+                    BgTaskOutcome::UploadReplace { result, file } => match result {
                         Ok(_) => {
-                            state
-                                .gist_content_cache
-                                .remove(&(gist_id.clone(), filename.clone()));
-                            state.set_status(format!("Uploaded {} to gist {}", filename, gist_id));
+                            state.gist_content_cache.remove(&file.cache_key());
+                            state.set_status(format!(
+                                "Uploaded {} to gist {}",
+                                file.filename, file.gist_id
+                            ));
                             if let Some(local_path) = state.upload_local_path() {
                                 let content = state.content_to_upload();
                                 record_pin_sync(
                                     state,
                                     &local_path,
-                                    &gist_id,
-                                    &filename,
+                                    &file.gist_id,
+                                    &file.filename,
                                     &content,
                                     Some(crate::domain::SyncDirection::Upload),
                                 );
@@ -1617,10 +1607,11 @@ fn absorb_background_results_body(
                     },
                     BgTaskOutcome::PreviewContent {
                         result,
-                        key,
+                        file,
                         preview_title,
                     } => match result {
                         Ok(content) => {
+                            let key = file.cache_key();
                             state
                                 .gist_content_cache
                                 .insert(key.clone(), content.clone());

--- a/src/tui/dispatch.rs
+++ b/src/tui/dispatch.rs
@@ -17,19 +17,18 @@ pub(super) fn dispatch_outcome(
         KeyOutcome::Quit => return Ok(LoopFlow::Quit),
         KeyOutcome::PreviewDiff {
             local_path,
-            gist_id,
-            filename,
-            raw_url,
+            file,
             target,
             upload_orientation,
         } => {
             // List-originated diff returns to List on Esc.
             state.pending_return = Some(Screen::List);
-            let gist = GistFile::for_sync(gist_id.clone(), filename.clone(), raw_url.clone());
+            let gist = file.to_gist_file();
             let (local_label, gist_label) = diff_labels(local_path.as_deref(), &gist);
 
             jobs.spawn_action(state, "Loading diff…", move || {
-                let result = fetch_gist_content(&gist_id, &filename, raw_url.as_deref());
+                let result =
+                    fetch_gist_content(&file.gist_id, &file.filename, file.raw_url.as_deref());
                 BgTaskOutcome::PreviewDiff {
                     result,
                     local_path,
@@ -41,24 +40,19 @@ pub(super) fn dispatch_outcome(
             });
         }
         KeyOutcome::Download { mode } => download(state, mode),
-        KeyOutcome::DownloadGist {
-            gist_id,
-            filename,
-            raw_url,
-            target,
-        } => {
-            let gist = GistFile::for_sync(gist_id.clone(), filename.clone(), raw_url.clone());
+        KeyOutcome::DownloadGist { file, target } => {
+            let gist = file.to_gist_file();
             let (local_label, gist_label) = diff_labels(Some(&target), &gist);
 
             jobs.spawn_action(state, "Downloading…", move || {
-                let result = fetch_gist_content(&gist_id, &filename, raw_url.as_deref());
+                let result =
+                    fetch_gist_content(&file.gist_id, &file.filename, file.raw_url.as_deref());
                 BgTaskOutcome::DownloadSelected {
                     result,
                     target,
                     local_label,
                     gist_label,
-                    gist_id,
-                    filename,
+                    file,
                 }
             });
         }
@@ -173,9 +167,7 @@ pub(super) fn dispatch_outcome(
         }
         KeyOutcome::UploadPreview {
             local_path,
-            gist_id,
-            filename,
-            raw_url,
+            file,
             from_pin_diff,
         } => {
             if !from_pin_diff {
@@ -184,18 +176,22 @@ pub(super) fn dispatch_outcome(
             let gist_file = state
                 .gists
                 .iter()
-                .find(|g| g.gist_id == gist_id && g.filename == filename)
+                .find(|g| g.gist_id == file.gist_id && g.filename == file.filename)
                 .cloned()
-                .unwrap_or_else(|| GistFile::for_sync(gist_id.clone(), filename.clone(), raw_url));
+                .unwrap_or_else(|| file.to_gist_file());
             let (local_label, gist_label) = diff_labels(Some(&local_path), &gist_file);
-            let raw_url = gist_file.raw_url.clone();
+            // Prefer list-row raw_url when present (may be richer than the outcome's ref).
+            let mut file = file;
+            if file.raw_url.is_none() {
+                file.raw_url = gist_file.raw_url.clone();
+            }
 
             jobs.spawn_action(state, "Loading diff…", move || {
-                let result = fetch_gist_content(&gist_id, &filename, raw_url.as_deref());
+                let result =
+                    fetch_gist_content(&file.gist_id, &file.filename, file.raw_url.as_deref());
                 BgTaskOutcome::UploadPreview {
                     result,
-                    gist_id,
-                    filename,
+                    file,
                     local_path,
                     local_label,
                     gist_label,
@@ -235,11 +231,11 @@ pub(super) fn dispatch_outcome(
                 .iter()
                 .any(|g| g.gist_id == gist_id && g.filename == filename);
 
+            let file = crate::domain::GistFileRef::id_name(gist_id, filename);
             let plan = if has_same_name {
-                let target = GistFile::for_sync(gist_id.clone(), filename.clone(), None);
-                crate::actions::upload_command(&temp_file_path, &target)
+                crate::actions::upload_command(&temp_file_path, &file.to_gist_file())
             } else {
-                crate::actions::upload_add_command(&temp_file_path, &gist_id)
+                crate::actions::upload_add_command(&temp_file_path, &file.gist_id)
             };
 
             state.staged_diff_gist = None;
@@ -251,11 +247,7 @@ pub(super) fn dispatch_outcome(
 
                 drop(scratch);
 
-                BgTaskOutcome::UploadReplace {
-                    result,
-                    gist_id,
-                    filename,
-                }
+                BgTaskOutcome::UploadReplace { result, file }
             });
         }
         KeyOutcome::EditUpload => {
@@ -279,41 +271,46 @@ pub(super) fn dispatch_outcome(
                 }
             });
         }
-        KeyOutcome::PreviewContent { gist_id, filename } => {
-            let key = (gist_id.clone(), filename.clone());
+        KeyOutcome::PreviewContent { mut file } => {
+            let key = file.cache_key();
             if let Some(content) = state.gist_content_cache.get(&key).cloned() {
                 state.enter_preview(
-                    format!("Preview: {gist_id} / {filename}"),
+                    format!("Preview: {} / {}", file.gist_id, file.filename),
                     content,
                     Some(key),
                 );
             } else {
-                let raw_url = state.gist_file_raw_url(&gist_id, &filename);
-                let preview_title = format!("Preview: {gist_id} / {filename}");
+                if file.raw_url.is_none() {
+                    file.raw_url = state.gist_file_raw_url(&file.gist_id, &file.filename);
+                }
+                let preview_title = format!("Preview: {} / {}", file.gist_id, file.filename);
                 jobs.spawn_action(state, "Loading preview…", move || {
-                    let result = fetch_gist_content(&gist_id, &filename, raw_url.as_deref());
+                    let result =
+                        fetch_gist_content(&file.gist_id, &file.filename, file.raw_url.as_deref());
                     BgTaskOutcome::PreviewContent {
                         result,
-                        key,
+                        file,
                         preview_title,
                     }
                 });
             }
         }
-        KeyOutcome::RefreshPreview { gist_id, filename } => {
+        KeyOutcome::RefreshPreview { mut file } => {
             // Keep the current return path when reloading.
             if state.screen.is_preview() {
                 state.pending_return = state.nav_stack.last().cloned();
             }
-            let key = (gist_id.clone(), filename.clone());
-            state.gist_content_cache.remove(&key);
-            let raw_url = state.gist_file_raw_url(&gist_id, &filename);
-            let preview_title = format!("Preview: {gist_id} / {filename}");
+            state.gist_content_cache.remove(&file.cache_key());
+            if file.raw_url.is_none() {
+                file.raw_url = state.gist_file_raw_url(&file.gist_id, &file.filename);
+            }
+            let preview_title = format!("Preview: {} / {}", file.gist_id, file.filename);
             jobs.spawn_action(state, "Loading preview…", move || {
-                let result = fetch_gist_content(&gist_id, &filename, raw_url.as_deref());
+                let result =
+                    fetch_gist_content(&file.gist_id, &file.filename, file.raw_url.as_deref());
                 BgTaskOutcome::PreviewContent {
                     result,
-                    key,
+                    file,
                     preview_title,
                 }
             });

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -832,7 +832,9 @@ impl AppState {
                             return KeyOutcome::None;
                         }
                         self.pending_return = Some(self.park_gist_detail_screen());
-                        return KeyOutcome::PreviewContent { gist_id, filename };
+                        return KeyOutcome::PreviewContent {
+                            file: crate::domain::GistFileRef::id_name(gist_id, filename),
+                        };
                     }
                 }
             }
@@ -1105,7 +1107,9 @@ impl AppState {
                     return KeyOutcome::None;
                 }
                 self.pending_return = Some(self.park_gist_detail_screen());
-                return KeyOutcome::PreviewContent { gist_id, filename };
+                return KeyOutcome::PreviewContent {
+                    file: crate::domain::GistFileRef::id_name(gist_id, filename),
+                };
             }
         }
         KeyOutcome::None
@@ -1401,7 +1405,9 @@ impl AppState {
                 let Some((gist_id, filename)) = p.gist_key.clone() else {
                     return KeyOutcome::None;
                 };
-                return KeyOutcome::RefreshPreview { gist_id, filename };
+                return KeyOutcome::RefreshPreview {
+                    file: crate::domain::GistFileRef::id_name(gist_id, filename),
+                };
             }
             KeyCode::Char('w') => self.preview_wrap = !self.preview_wrap,
             KeyCode::Char('y') => {
@@ -1603,8 +1609,11 @@ impl AppState {
                 }
                 self.pending_return = Some(Screen::List);
                 return KeyOutcome::PreviewContent {
-                    gist_id: gist.file.gist_id.clone(),
-                    filename: gist.file.filename.clone(),
+                    file: crate::domain::GistFileRef::new(
+                        gist.file.gist_id.clone(),
+                        gist.file.filename.clone(),
+                        gist.file.raw_url.clone(),
+                    ),
                 };
             }
             KeyCode::Char('d') if self.focus == FocusPane::Gist => {
@@ -1612,9 +1621,11 @@ impl AppState {
                 if let Some(gist) = ranked.get(self.gist_index) {
                     let filename = gist.file.filename.clone();
                     return KeyOutcome::DownloadGist {
-                        gist_id: gist.file.gist_id.clone(),
-                        filename: filename.clone(),
-                        raw_url: gist.file.raw_url.clone(),
+                        file: crate::domain::GistFileRef::new(
+                            gist.file.gist_id.clone(),
+                            filename.clone(),
+                            gist.file.raw_url.clone(),
+                        ),
                         target: self.cwd.join(&filename),
                     };
                 }
@@ -1640,9 +1651,11 @@ impl AppState {
                 let filename = gist.file.filename.clone();
                 return KeyOutcome::PreviewDiff {
                     local_path,
-                    gist_id: gist.file.gist_id.clone(),
-                    filename: filename.clone(),
-                    raw_url: gist.file.raw_url.clone(),
+                    file: crate::domain::GistFileRef::new(
+                        gist.file.gist_id.clone(),
+                        filename.clone(),
+                        gist.file.raw_url.clone(),
+                    ),
                     target: self.cwd.join(&filename),
                     upload_orientation: self.focus == FocusPane::Local,
                 };

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,5 +1,6 @@
 use crate::domain::{
-    group_gists, GistComment, GistFile, GistGroup, GistRevision, LocalCandidate, PinnedMapping,
+    group_gists, GistComment, GistFile, GistFileRef, GistGroup, GistRevision, LocalCandidate,
+    PinnedMapping,
 };
 use crate::ranking::{rank_gist_files, rank_local_files, MatchReason, RankedGistFile, RankedLocal};
 use anyhow::Result;
@@ -566,9 +567,7 @@ pub enum KeyOutcome {
     /// List-originated local↔gist diff.
     PreviewDiff {
         local_path: Option<PathBuf>,
-        gist_id: String,
-        filename: String,
-        raw_url: Option<String>,
+        file: GistFileRef,
         target: PathBuf,
         /// When true, unified diff is oriented local→gist (local focus).
         upload_orientation: bool,
@@ -581,9 +580,7 @@ pub enum KeyOutcome {
     },
     /// Download/fetch a selected gist file (may land on Diff/Confirm).
     DownloadGist {
-        gist_id: String,
-        filename: String,
-        raw_url: Option<String>,
+        file: GistFileRef,
         target: PathBuf,
     },
     Pin {
@@ -603,9 +600,7 @@ pub enum KeyOutcome {
     },
     UploadPreview {
         local_path: PathBuf,
-        gist_id: String,
-        filename: String,
-        raw_url: Option<String>,
+        file: GistFileRef,
         /// When true, keep pin-originated `diff_return`; when false, reset to List.
         from_pin_diff: bool,
     },
@@ -613,8 +608,7 @@ pub enum KeyOutcome {
     Upload,
     Create(bool),
     PreviewContent {
-        gist_id: String,
-        filename: String,
+        file: GistFileRef,
     },
     OpenBrowser {
         gist_id: String,
@@ -649,8 +643,7 @@ pub enum KeyOutcome {
         url: String,
     },
     RefreshPreview {
-        gist_id: String,
-        filename: String,
+        file: GistFileRef,
     },
     UnpinAtPin {
         index: usize,
@@ -2143,9 +2136,7 @@ impl AppState {
             return if has_same_name {
                 KeyOutcome::UploadPreview {
                     local_path,
-                    gist_id,
-                    filename: local_filename,
-                    raw_url,
+                    file: GistFileRef::new(gist_id, local_filename, raw_url),
                     from_pin_diff: true,
                 }
             } else {
@@ -2179,9 +2170,7 @@ impl AppState {
         if has_same_name {
             KeyOutcome::UploadPreview {
                 local_path,
-                gist_id,
-                filename: local_filename,
-                raw_url,
+                file: GistFileRef::new(gist_id, local_filename, raw_url),
                 from_pin_diff: false,
             }
         } else {

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -450,10 +450,9 @@ fn detail_enter_previews_cursor_file_including_tenth() {
     assert!(matches!(
         outcome,
         KeyOutcome::PreviewContent {
-            ref gist_id,
-            ref filename,
+            file: ref f,
             ..
-        } if gist_id == "g1" && filename == "f9.txt"
+        } if f.gist_id == "g1" && f.filename == "f9.txt"
     ));
     assert!(state
         .pending_return
@@ -515,10 +514,9 @@ fn detail_number_key_requests_file_preview() {
     assert!(matches!(
         outcome,
         KeyOutcome::PreviewContent {
-            ref gist_id,
-            ref filename,
+            file: ref f,
             ..
-        } if gist_id == "g1" && filename == "a.txt"
+        } if f.gist_id == "g1" && f.filename == "a.txt"
     ));
     assert!(state
         .pending_return
@@ -5776,10 +5774,9 @@ fn gist_detail_file_click_selects_and_double_previews() {
     assert!(matches!(
         out,
         KeyOutcome::PreviewContent {
-            ref gist_id,
-            ref filename,
+            file: ref f,
             ..
-        } if gist_id == "g1" && filename == "b.txt"
+        } if f.gist_id == "g1" && f.filename == "b.txt"
     ));
 }
 


### PR DESCRIPTION
## Summary

- Add `domain::GistFileRef` (`gist_id` + `filename` + `Option<raw_url>`) with `to_gist_file()` / `cache_key()`.
- Thread it through first-slice **KeyOutcome** / **BgTaskOutcome** variants: PreviewDiff, DownloadGist, UploadPreview, PreviewContent, RefreshPreview (+ DownloadSelected / UploadReplace on the Bg side).
- Dispatch no longer re-splits three loose strings into `for_sync` / `fetch_gist_content` for those paths.
- **Out of scope:** Pin/Unpin/Sync pair, revision family, gist_id-only outcomes, `PendingAction`, changing the content LRU key type.

Grilling decisions are on #276.

Closes #276

## Test plan

- [x] `mise run check` (fmt + clippy + 547 unit + 12 integration)
- [x] New `GistFileRef` unit tests (`to_gist_file`, `cache_key`, `id_name`)
- [x] Existing key/outcome match tests updated for `file:` field