### PR TITLE
refactor(tui): collapse the gist-fetch action-spawn template

### DIFF
--- a/src/tui/bg.rs
+++ b/src/tui/bg.rs
@@ -454,8 +454,7 @@ pub(super) fn spawn_pin_push(
     let raw_url = state.gist_file_raw_url(&gist_id, &filename);
     let file = crate::domain::GistFileRef::new(gist_id, filename, raw_url);
     let (local_label, gist_label) = diff_labels(Some(&local_path), &file.to_gist_file());
-    jobs.spawn_action(state, "Loading diff…", move || {
-        let result = fetch_gist_content(&file.gist_id, &file.filename, file.raw_url.as_deref());
+    jobs.spawn_gist_fetch_action(state, "Loading diff…", file, move |result, file| {
         BgTaskOutcome::UploadPreview {
             result,
             file,
@@ -480,8 +479,7 @@ pub(super) fn spawn_pin_pull(
     let raw_url = state.gist_file_raw_url(&gist_id, &filename);
     let file = crate::domain::GistFileRef::new(gist_id, filename, raw_url);
     let (local_label, gist_label) = diff_labels(Some(&target), &file.to_gist_file());
-    jobs.spawn_action(state, "Downloading…", move || {
-        let result = fetch_gist_content(&file.gist_id, &file.filename, file.raw_url.as_deref());
+    jobs.spawn_gist_fetch_action(state, "Downloading…", file, move |result, file| {
         BgTaskOutcome::DownloadSelected {
             result,
             target,
@@ -518,8 +516,8 @@ pub(super) fn spawn_pin_diff(
     };
     let (local_label, gist_label) = diff_labels(Some(&local_abs), &gist_file);
     let target = local_abs.clone();
-    jobs.spawn_action(state, "Loading diff…", move || {
-        let result = fetch_gist_content(&gist_id, &filename, raw_url.as_deref());
+    let file = crate::domain::GistFileRef::new(gist_id, filename, raw_url);
+    jobs.spawn_gist_fetch_action(state, "Loading diff…", file, move |result, _file| {
         BgTaskOutcome::PreviewDiff {
             result,
             local_path: Some(local_abs),
@@ -1157,6 +1155,27 @@ impl Jobs {
         self.action = Some(rx);
         std::thread::spawn(move || {
             let _ = tx.send((generation, work()));
+        });
+    }
+
+    /// Spawn a background job that fetches a gist file's content, then hands the result
+    /// (and the file identity back) to `wrap` to build the `BgTaskOutcome`. Collapses the
+    /// `fetch_gist_content` template shared by `PreviewDiff`/`DownloadSelected`/
+    /// `UploadPreview`/`PreviewContent` across `dispatch.rs` and the pin-spawn helpers
+    /// below (issue #299). `wrap` gets `file` back so variants that store it (all but
+    /// `PreviewDiff`) don't need a second clone.
+    pub(super) fn spawn_gist_fetch_action(
+        &mut self,
+        state: &mut AppState,
+        msg: impl Into<String>,
+        file: crate::domain::GistFileRef,
+        wrap: impl FnOnce(std::result::Result<String, String>, crate::domain::GistFileRef) -> BgTaskOutcome
+            + Send
+            + 'static,
+    ) {
+        self.spawn_action(state, msg, move || {
+            let result = fetch_gist_content(&file.gist_id, &file.filename, file.raw_url.as_deref());
+            wrap(result, file)
         });
     }
 

--- a/src/tui/dispatch.rs
+++ b/src/tui/dispatch.rs
@@ -26,9 +26,7 @@ pub(super) fn dispatch_outcome(
             let gist = file.to_gist_file();
             let (local_label, gist_label) = diff_labels(local_path.as_deref(), &gist);
 
-            jobs.spawn_action(state, "Loading diff…", move || {
-                let result =
-                    fetch_gist_content(&file.gist_id, &file.filename, file.raw_url.as_deref());
+            jobs.spawn_gist_fetch_action(state, "Loading diff…", file, move |result, _file| {
                 BgTaskOutcome::PreviewDiff {
                     result,
                     local_path,
@@ -51,9 +49,7 @@ pub(super) fn dispatch_outcome(
             let gist = file.to_gist_file();
             let (local_label, gist_label) = diff_labels(Some(&target), &gist);
 
-            jobs.spawn_action(state, "Downloading…", move || {
-                let result =
-                    fetch_gist_content(&file.gist_id, &file.filename, file.raw_url.as_deref());
+            jobs.spawn_gist_fetch_action(state, "Downloading…", file, move |result, file| {
                 BgTaskOutcome::DownloadSelected {
                     result,
                     target,
@@ -193,9 +189,7 @@ pub(super) fn dispatch_outcome(
                 file.raw_url = gist_file.raw_url.clone();
             }
 
-            jobs.spawn_action(state, "Loading diff…", move || {
-                let result =
-                    fetch_gist_content(&file.gist_id, &file.filename, file.raw_url.as_deref());
+            jobs.spawn_gist_fetch_action(state, "Loading diff…", file, move |result, file| {
                 BgTaskOutcome::UploadPreview {
                     result,
                     file,
@@ -291,15 +285,16 @@ pub(super) fn dispatch_outcome(
                     file.raw_url = state.gist_file_raw_url(&file.gist_id, &file.filename);
                 }
                 let preview_title = format!("Preview: {} / {}", file.gist_id, file.filename);
-                jobs.spawn_action(state, "Loading preview…", move || {
-                    let result =
-                        fetch_gist_content(&file.gist_id, &file.filename, file.raw_url.as_deref());
-                    BgTaskOutcome::PreviewContent {
+                jobs.spawn_gist_fetch_action(
+                    state,
+                    "Loading preview…",
+                    file,
+                    move |result, file| BgTaskOutcome::PreviewContent {
                         result,
                         file,
                         preview_title,
-                    }
-                });
+                    },
+                );
             }
         }
         KeyOutcome::RefreshPreview { mut file } => {
@@ -312,9 +307,7 @@ pub(super) fn dispatch_outcome(
                 file.raw_url = state.gist_file_raw_url(&file.gist_id, &file.filename);
             }
             let preview_title = format!("Preview: {} / {}", file.gist_id, file.filename);
-            jobs.spawn_action(state, "Loading preview…", move || {
-                let result =
-                    fetch_gist_content(&file.gist_id, &file.filename, file.raw_url.as_deref());
+            jobs.spawn_gist_fetch_action(state, "Loading preview…", file, move |result, file| {
                 BgTaskOutcome::PreviewContent {
                     result,
                     file,


### PR DESCRIPTION
## Summary
- 8 call sites (5 in `src/tui/dispatch.rs`, 3 pin-spawn helpers in `src/tui/bg.rs`) repeated the same `fetch_gist_content(...)` + `BgTaskOutcome::X{...}` closure template for 4 variants: `PreviewDiff`, `DownloadSelected`, `UploadPreview`, `PreviewContent`.
- Add `Jobs::spawn_gist_fetch_action(state, msg, file, wrap)`, which does the fetch and hands `(result, file)` back to `wrap` to build the outcome. Migrate all 8 sites; `PreviewDiff` (no `file` field on that variant) discards the returned `file`, the other 3 variants store it as-is.
- Deliberately scoped to just these 4 variants, not a fully generic `spawn_result_action` covering all ~24 `spawn_action` call sites — the other ~16 each call a genuinely different fetch/execute function (fails the issue's "deletion test").

No interface change to `KeyOutcome`/`BgTaskOutcome` or `spawn_action`; no user-facing behavior change (`skip-changelog`).

Closes #299

## Test plan
- [x] `mise run check` (fmt --check, clippy --all-targets -D warnings, full test suite, cargo check) — all green
- [x] Two rounds of `/code-review` (Standards + Spec axes) — no findings in either round