### PR TITLE
refactor(gh): convert gh.rs to a directory module, extract gh/stars

### DIFF
--- a/src/gh/mod.rs
+++ b/src/gh/mod.rs
@@ -559,87 +559,12 @@ pub fn collect_gist_fork_counts_with(
     counts
 }
 
-const STARGAZER_GRAPHQL_CHUNK: usize = 40;
-
 /// Escape a value for safe interpolation inside a GraphQL double-quoted string literal:
 /// backslash first, then the quote (GraphQL string literals follow JSON escaping). Keeps a
-/// stray `"`/`\` in an API-supplied node id from breaking out of the query.
+/// stray `"`/`\` in an API-supplied node id from breaking out of the query. Shared by
+/// `forks`' fork-flags query and `stars`' stargazer query (issue #301).
 fn escape_graphql_string(s: &str) -> String {
     s.replace('\\', "\\\\").replace('"', "\\\"")
-}
-
-/// Build a batched GraphQL query (`n0`…`n{k}` aliases) for stargazer counts.
-pub fn build_stargazer_graphql_query(node_ids: &[String]) -> String {
-    let mut query = String::from("query { ");
-    for (i, id) in node_ids.iter().enumerate() {
-        let id = escape_graphql_string(id);
-        query.push_str(&format!(
-            "n{i}: node(id: \"{id}\") {{ ... on Gist {{ name stargazerCount }} }} "
-        ));
-    }
-    query.push('}');
-    query
-}
-
-pub fn gist_stargazer_graphql_plan(query: &str) -> CommandPlan {
-    CommandPlan {
-        program: "gh".into(),
-        args: vec![
-            "api".into(),
-            "graphql".into(),
-            "-f".into(),
-            format!("query={query}"),
-        ],
-    }
-}
-
-/// Parse alias-keyed GraphQL data (`n0`, `n1`, …) into `gist_id → stargazerCount`.
-pub fn parse_stargazer_counts_graphql(raw: &str) -> Result<HashMap<String, u32>> {
-    let v: serde_json::Value = serde_json::from_str(raw).context("parse stargazer GraphQL")?;
-    let data = v
-        .get("data")
-        .and_then(|d| d.as_object())
-        .context("GraphQL data object")?;
-    let mut out = HashMap::new();
-    for node in data.values() {
-        if node.is_null() {
-            continue;
-        }
-        let Some(name) = node.get("name").and_then(|n| n.as_str()) else {
-            continue;
-        };
-        let count = node
-            .get("stargazerCount")
-            .and_then(|n| n.as_u64())
-            .unwrap_or(0) as u32;
-        if count > 0 {
-            out.insert(name.to_string(), count);
-        }
-    }
-    Ok(out)
-}
-
-pub fn collect_gist_star_counts(node_ids: HashMap<String, String>) -> HashMap<String, u32> {
-    collect_gist_star_counts_with(&SystemRunner, node_ids)
-}
-
-pub fn collect_gist_star_counts_with(
-    runner: &dyn CommandRunner,
-    node_ids: HashMap<String, String>,
-) -> HashMap<String, u32> {
-    let ids: Vec<String> = node_ids.into_values().collect();
-    let mut out = HashMap::new();
-    for chunk in ids.chunks(STARGAZER_GRAPHQL_CHUNK) {
-        let query = build_stargazer_graphql_query(chunk);
-        let raw = match run_command(runner, &gist_stargazer_graphql_plan(&query)) {
-            Ok(raw) => raw,
-            Err(_) => continue,
-        };
-        if let Ok(batch) = parse_stargazer_counts_graphql(&raw) {
-            out.extend(batch);
-        }
-    }
-    out
 }
 
 #[derive(Debug, Deserialize)]
@@ -991,13 +916,21 @@ fn classify_revision_file(entry: &serde_json::Value) -> Result<RevisionFileConte
     }
 }
 
+// Per-resource submodules (issue #301). Each is a private `mod` re-exported flat below, so
+// existing `crate::gh::X` call sites don't need to know the submodule boundary exists.
+mod stars;
+pub use stars::{
+    build_stargazer_graphql_query, collect_gist_star_counts, collect_gist_star_counts_with,
+    gist_stargazer_graphql_plan, parse_stargazer_counts_graphql,
+};
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn parses_gist_list_into_file_rows() {
-        let raw = include_str!("../tests/fixtures/gh/gist-list.json");
+        let raw = include_str!("../../tests/fixtures/gh/gist-list.json");
         let files = parse_gist_list_json(raw).unwrap();
 
         assert_eq!(files.len(), 3);
@@ -1016,7 +949,7 @@ mod tests {
 
     #[test]
     fn parses_starred_gist_ids() {
-        let raw = include_str!("../tests/fixtures/gh/gist-starred.json");
+        let raw = include_str!("../../tests/fixtures/gh/gist-starred.json");
         let ids = parse_starred_gist_ids(raw).unwrap();
         assert_eq!(ids.len(), 1);
         assert!(ids.contains("star111"));
@@ -1026,7 +959,7 @@ mod tests {
 
     #[test]
     fn null_description_parses_as_empty_string() {
-        let raw = include_str!("../tests/fixtures/gh/gist-list.json");
+        let raw = include_str!("../../tests/fixtures/gh/gist-list.json");
         let files = parse_gist_list_json(raw).unwrap();
 
         let notes = files.iter().find(|f| f.filename == "notes.md").unwrap();
@@ -1036,7 +969,7 @@ mod tests {
 
     #[test]
     fn parses_gist_commits_into_revisions() {
-        let raw = include_str!("../tests/fixtures/gh/gist-commits.json");
+        let raw = include_str!("../../tests/fixtures/gh/gist-commits.json");
         let revisions = parse_gist_commits_json(raw).unwrap();
         assert_eq!(revisions.len(), 2);
         assert_eq!(revisions[0].version, "abc111def222333444");
@@ -1048,7 +981,7 @@ mod tests {
 
     #[test]
     fn revision_file_content_reads_present_and_truncated() {
-        let raw = include_str!("../tests/fixtures/gh/gist-revision.json");
+        let raw = include_str!("../../tests/fixtures/gh/gist-revision.json");
         match revision_file_content(raw, "settings.json").unwrap() {
             RevisionFileContent::Present(content) => {
                 assert!(content.contains("\"old\": true"));
@@ -1064,41 +997,6 @@ mod tests {
             revision_file_content(truncated, "missing.txt").unwrap(),
             RevisionFileContent::Absent
         );
-    }
-
-    #[test]
-    fn parses_stargazer_counts_graphql_aliases() {
-        let raw = r#"{
-            "data": {
-                "n0": {"name": "abc123", "stargazerCount": 3},
-                "n1": null,
-                "n2": {"name": "def456", "stargazerCount": 0}
-            }
-        }"#;
-        let counts = parse_stargazer_counts_graphql(raw).unwrap();
-        assert_eq!(counts.get("abc123").copied(), Some(3));
-        assert!(!counts.contains_key("def456"));
-    }
-
-    #[test]
-    fn build_stargazer_graphql_query_aliases_nodes() {
-        let q = build_stargazer_graphql_query(&["G_a".into(), "G_b".into()]);
-        assert!(q.contains(r#"n0: node(id: "G_a")"#));
-        assert!(q.contains(r#"n1: node(id: "G_b")"#));
-        assert!(q.contains("stargazerCount"));
-    }
-
-    #[test]
-    fn build_stargazer_graphql_query_escapes_quotes_and_backslashes() {
-        // A node_id carrying a double-quote or backslash must stay inside its string
-        // literal rather than break out of the query (defensive against malformed ids).
-        let q = build_stargazer_graphql_query(&["a\"b".into(), "c\\d".into()]);
-        assert!(q.contains(r#"n0: node(id: "a\"b")"#));
-        assert!(q.contains(r#"n1: node(id: "c\\d")"#));
-        // The injected quote does not prematurely close the literal: a break-out attempt
-        // like `") {} #` stays escaped, so no bare `) {` from the payload appears.
-        let inj = build_stargazer_graphql_query(&["x\") { __typename } #".into()]);
-        assert!(inj.contains(r#"node(id: "x\") { __typename } #")"#));
     }
 
     #[test]
@@ -1354,7 +1252,7 @@ mod tests {
 
     #[test]
     fn parses_comment_counts_defaulting_to_zero() {
-        let raw = include_str!("../tests/fixtures/gh/gist-list.json");
+        let raw = include_str!("../../tests/fixtures/gh/gist-list.json");
         let counts = parse_gist_comment_counts(raw).unwrap();
 
         assert_eq!(counts.get("abc123").copied(), Some(2));

--- a/src/gh/stars.rs
+++ b/src/gh/stars.rs
@@ -1,0 +1,122 @@
+//! Stargazer counts via a batched GraphQL query (issue #301).
+
+use super::escape_graphql_string;
+use crate::actions::{run_command, CommandPlan, CommandRunner, SystemRunner};
+use anyhow::{Context, Result};
+use std::collections::HashMap;
+
+const STARGAZER_GRAPHQL_CHUNK: usize = 40;
+
+/// Build a batched GraphQL query (`n0`…`n{k}` aliases) for stargazer counts.
+pub fn build_stargazer_graphql_query(node_ids: &[String]) -> String {
+    let mut query = String::from("query { ");
+    for (i, id) in node_ids.iter().enumerate() {
+        let id = escape_graphql_string(id);
+        query.push_str(&format!(
+            "n{i}: node(id: \"{id}\") {{ ... on Gist {{ name stargazerCount }} }} "
+        ));
+    }
+    query.push('}');
+    query
+}
+
+pub fn gist_stargazer_graphql_plan(query: &str) -> CommandPlan {
+    CommandPlan {
+        program: "gh".into(),
+        args: vec![
+            "api".into(),
+            "graphql".into(),
+            "-f".into(),
+            format!("query={query}"),
+        ],
+    }
+}
+
+/// Parse alias-keyed GraphQL data (`n0`, `n1`, …) into `gist_id → stargazerCount`.
+pub fn parse_stargazer_counts_graphql(raw: &str) -> Result<HashMap<String, u32>> {
+    let v: serde_json::Value = serde_json::from_str(raw).context("parse stargazer GraphQL")?;
+    let data = v
+        .get("data")
+        .and_then(|d| d.as_object())
+        .context("GraphQL data object")?;
+    let mut out = HashMap::new();
+    for node in data.values() {
+        if node.is_null() {
+            continue;
+        }
+        let Some(name) = node.get("name").and_then(|n| n.as_str()) else {
+            continue;
+        };
+        let count = node
+            .get("stargazerCount")
+            .and_then(|n| n.as_u64())
+            .unwrap_or(0) as u32;
+        if count > 0 {
+            out.insert(name.to_string(), count);
+        }
+    }
+    Ok(out)
+}
+
+pub fn collect_gist_star_counts(node_ids: HashMap<String, String>) -> HashMap<String, u32> {
+    collect_gist_star_counts_with(&SystemRunner, node_ids)
+}
+
+pub fn collect_gist_star_counts_with(
+    runner: &dyn CommandRunner,
+    node_ids: HashMap<String, String>,
+) -> HashMap<String, u32> {
+    let ids: Vec<String> = node_ids.into_values().collect();
+    let mut out = HashMap::new();
+    for chunk in ids.chunks(STARGAZER_GRAPHQL_CHUNK) {
+        let query = build_stargazer_graphql_query(chunk);
+        let raw = match run_command(runner, &gist_stargazer_graphql_plan(&query)) {
+            Ok(raw) => raw,
+            Err(_) => continue,
+        };
+        if let Ok(batch) = parse_stargazer_counts_graphql(&raw) {
+            out.extend(batch);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_stargazer_counts_graphql_aliases() {
+        let raw = r#"{
+            "data": {
+                "n0": {"name": "abc123", "stargazerCount": 3},
+                "n1": null,
+                "n2": {"name": "def456", "stargazerCount": 0}
+            }
+        }"#;
+        let counts = parse_stargazer_counts_graphql(raw).unwrap();
+        assert_eq!(counts.get("abc123").copied(), Some(3));
+        assert!(!counts.contains_key("def456"));
+    }
+
+    #[test]
+    fn build_stargazer_graphql_query_aliases_nodes() {
+        let q = build_stargazer_graphql_query(&["G_a".into(), "G_b".into()]);
+        assert!(q.contains(r#"n0: node(id: "G_a")"#));
+        assert!(q.contains(r#"n1: node(id: "G_b")"#));
+        assert!(q.contains("stargazerCount"));
+    }
+
+    #[test]
+    fn build_stargazer_graphql_query_escapes_quotes_and_backslashes() {
+        // A node_id carrying a double-quote or backslash must stay inside its string
+        // literal rather than break out of the query (defensive against malformed ids).
+        let q = build_stargazer_graphql_query(&["a\"b".into(), "c\\d".into()]);
+        assert!(q.contains(r#"n0: node(id: "a\"b")"#));
+        assert!(q.contains(r#"n1: node(id: "c\\d")"#));
+        // The injected quote does not prematurely close the literal: a break-out attempt
+        // like `") {} #` stays escaped, so no bare `) {` from the payload appears.
+        let inj = build_stargazer_graphql_query(&["x\") { __typename } #".into()]);
+        assert!(inj.contains(r#"node(id: "x\") { __typename } #")"#));
+    }
+}


### PR DESCRIPTION
## Summary
PR 1 of 5 in the `gh.rs` per-resource submodule split (issue #301, plan confirmed in the [grilling session comment](https://github.com/akunzai/gistui/issues/301#issuecomment-5119055665)).

- One-time `src/gh.rs` → `src/gh/mod.rs` directory conversion.
- Extract the smallest resource, `gh/stars.rs` (stargazer-count batched GraphQL functions + 3 unit tests).
- `escape_graphql_string` stays in `gh/mod.rs` as shared kernel (also used by a not-yet-extracted fork-flags query).
- `gh/mod.rs` re-exports `stars`' public items by explicit name (matching `tui/mod.rs`'s existing `pub use` convention, not a glob), declared near the bottom of the file — so none of the ~30 existing `crate::gh::X` call sites need to change.
- `include_str!` fixture paths in the not-yet-extracted tests bumped one directory level.

The remaining 4 submodules (`gists`, `comments`, `forks`, `revisions`) stay inline in `gh/mod.rs` for now; later PRs in this series extract them one at a time, same pattern used for the `tui/` screen colocation series.

No signature or behavior change (`skip-changelog`).

Part of #301

## Test plan
- [x] `mise run check` (fmt --check, clippy --all-targets -D warnings, full test suite — 621 unit + 12 integration, same counts as before the split, cargo check) — all green
- [x] Two rounds of `/code-review` (Standards + Spec axes) — round 1 found a glob `pub use stars::*;` where the codebase convention is explicit named re-exports (fixed); round 2 found the `mod`/`pub use` declaration was placed at the top of the file where `tui/mod.rs`'s convention places it near the bottom (fixed). Both confirmed clean after fixes.