### PR TITLE
refactor(tui): colocate remaining screens' mouse dispatch

### DIFF
--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -34,10 +34,15 @@ fn nav_action(code: KeyCode, modifiers: KeyModifiers) -> Option<NavAction> {
 /// Lines moved per PageUp/PageDown in the scrollable views. Matches the gist-detail paging step
 /// (`detail_nav(10)`); `handle_key` is pure and cannot read the viewport height, so a fixed step
 /// keeps paging predictable without threading terminal size into the key logic.
-const PAGE_SCROLL: u16 = 10;
+pub(crate) const PAGE_SCROLL: u16 = 10;
 
 /// Dispatch [`NavAction`] onto a Pins/Gists [`ListCursor`] (step from [`PAGE_SCROLL`]).
-fn apply_list_cursor_nav(cursor: &mut ListCursor, action: NavAction, len: usize, hmax: u16) {
+pub(crate) fn apply_list_cursor_nav(
+    cursor: &mut ListCursor,
+    action: NavAction,
+    len: usize,
+    hmax: u16,
+) {
     let step = PAGE_SCROLL as usize;
     match action {
         NavAction::Down => cursor.down(len),
@@ -188,25 +193,14 @@ impl AppState {
         {
             return false;
         }
-        // Pins/Gists: precompute len/hmax with &self, then mut ListCursor (issue #274).
-        // Cannot hold `&mut PinsState` from `match &mut self.screen` while calling helpers.
+        // Pins/Gists dispatch before the match below (issue #274: cannot hold `&mut PinsState`
+        // from `match &mut self.screen` while calling helpers) -- each screen's own
+        // apply_navigation_<screen> reproduces that precompute-then-mutate shape.
         if matches!(self.screen, Screen::Pins(_)) {
-            let len = self.visible_pin_indices().len();
-            let hmax = self.pins_hscroll_max();
-            let Some(pins) = self.pins_mut() else {
-                return false;
-            };
-            apply_list_cursor_nav(&mut pins.cursor, action, len, hmax);
-            return true;
+            return self.apply_navigation_pins(action);
         }
         if matches!(self.screen, Screen::Gists(_)) {
-            let len = self.visible_gist_groups().len();
-            let hmax = self.gists_hscroll_max();
-            let Some(gm) = self.gist_manager_mut() else {
-                return false;
-            };
-            apply_list_cursor_nav(&mut gm.cursor, action, len, hmax);
-            return true;
+            return self.apply_navigation_gists(action);
         }
         match &mut self.screen {
             Screen::Palette(_) => {
@@ -226,95 +220,11 @@ impl AppState {
                 }
                 true
             }
-            Screen::Help(help) => {
-                let topics = HelpTopic::all();
-                if help.index_open {
-                    match action {
-                        NavAction::Up => help.index_sel = help.index_sel.saturating_sub(1),
-                        NavAction::Down => {
-                            if help.index_sel + 1 < topics.len() {
-                                help.index_sel += 1;
-                            }
-                        }
-                        _ => return false,
-                    }
-                } else {
-                    match action {
-                        NavAction::Up => {
-                            help.scroll = help.scroll.saturating_sub(1);
-                        }
-                        NavAction::Down => {
-                            help.scroll = help.scroll.saturating_add(1);
-                        }
-                        NavAction::PageUp => {
-                            help.scroll = help.scroll.saturating_sub(PAGE_SCROLL);
-                        }
-                        NavAction::PageDown => {
-                            help.scroll = help.scroll.saturating_add(PAGE_SCROLL);
-                        }
-                        _ => return false,
-                    }
-                }
-                true
-            }
+            Screen::Help(_) => self.apply_navigation_help(action),
             Screen::GistDetail(_) => self.apply_navigation_detail(action),
-            Screen::Revisions(rev) => {
-                let entries_len = rev.entries.as_ref().map(|e| e.len()).unwrap_or(0);
-                if entries_len == 0 {
-                    return false;
-                }
-                match action {
-                    NavAction::Down => {
-                        rev.index = (rev.index + 1).min(entries_len - 1);
-                    }
-                    NavAction::Up => {
-                        rev.index = rev.index.saturating_sub(1);
-                    }
-                    NavAction::PageDown => {
-                        rev.index = (rev.index + PAGE_SCROLL as usize).min(entries_len - 1);
-                    }
-                    NavAction::PageUp => {
-                        rev.index = rev.index.saturating_sub(PAGE_SCROLL as usize);
-                    }
-                    NavAction::Left => {
-                        rev.hscroll = rev.hscroll.saturating_sub(1);
-                    }
-                    NavAction::Right => {
-                        rev.hscroll = rev.hscroll.saturating_add(1);
-                    }
-                }
-                true
-            }
-            Screen::List => {
-                match action {
-                    NavAction::Down => self.list_move_focused(true),
-                    NavAction::Up => self.list_move_focused(false),
-                    NavAction::PageDown => self.list_page_focused(true),
-                    NavAction::PageUp => self.list_page_focused(false),
-                    NavAction::Left => self.scroll_focused_left(),
-                    NavAction::Right => self.scroll_focused_right(),
-                }
-                true
-            }
-            Screen::Config(cfg) => {
-                let n = ConfigField::ALL.len();
-                match action {
-                    NavAction::Up => {
-                        cfg.index = cfg.index.saturating_sub(1);
-                    }
-                    NavAction::Down => {
-                        if cfg.index + 1 < n {
-                            cfg.index += 1;
-                        }
-                    }
-                    NavAction::Left | NavAction::Right => {
-                        // Adjust is handled in handle_key_config (needs PersistSettings).
-                        return false;
-                    }
-                    _ => return false,
-                }
-                true
-            }
+            Screen::Revisions(_) => self.apply_navigation_revisions(action),
+            Screen::List => self.apply_navigation_list(action),
+            Screen::Config(_) => self.apply_navigation_config(action),
             // Diff, Preview and Confirm all scroll the same diff/preview buffer identically.
             Screen::Diff(_) | Screen::Preview(_) | Screen::Confirm(_) => {
                 match action {
@@ -375,105 +285,13 @@ impl AppState {
     /// blank area or border focuses it but selects nothing (returns `false`); a click off
     /// every list returns `false`.
     fn click_select(&mut self, col: u16, row: u16, layout: &MouseLayout) -> bool {
-        match &mut self.screen {
-            Screen::List => {
-                if let Some(hit) = layout.local {
-                    if point_in(hit.rect, col, row) {
-                        // A click anywhere in the pane (incl. blank/border) focuses it; a
-                        // click on a row also selects it.
-                        self.focus = FocusPane::Local;
-                        if let Some(idx) = hit.index_at(row, self.visible_locals().len()) {
-                            self.local_index = idx;
-                            self.local_hscroll = 0;
-                            if self.anchor == FocusPane::Local {
-                                self.reset_ranked_pane();
-                            }
-                            return true;
-                        }
-                        return false;
-                    }
-                }
-                if let Some(hit) = layout.gist {
-                    if point_in(hit.rect, col, row) {
-                        self.focus = FocusPane::Gist;
-                        if let Some(idx) = hit.index_at(row, self.ranked_gists().len()) {
-                            self.gist_index = idx;
-                            self.gist_hscroll = 0;
-                            if self.anchor == FocusPane::Gist {
-                                self.reset_ranked_pane();
-                            }
-                            return true;
-                        }
-                        return false;
-                    }
-                }
-                false
-            }
-            Screen::Gists(_) => {
-                if let Some(hit) = layout.list {
-                    if point_in(hit.rect, col, row) {
-                        let count = self.visible_gist_groups().len();
-                        if let Some(idx) = hit.index_at(row, count) {
-                            if let Some(gm) = self.gist_manager_mut() {
-                                gm.cursor.select(idx);
-                                return true;
-                            }
-                        }
-                    }
-                }
-                false
-            }
-            Screen::Pins(_) => {
-                if let Some(hit) = layout.list {
-                    if point_in(hit.rect, col, row) {
-                        let count = self.visible_pin_indices().len();
-                        if let Some(idx) = hit.index_at(row, count) {
-                            if let Some(pins) = self.pins_mut() {
-                                pins.cursor.select(idx);
-                                return true;
-                            }
-                        }
-                    }
-                }
-                false
-            }
-            Screen::Revisions(rev) => {
-                if let Some(hit) = layout.list {
-                    if point_in(hit.rect, col, row) {
-                        let count = rev.entries.as_ref().map_or(0, |e| e.len());
-                        if let Some(idx) = hit.index_at(row, count) {
-                            rev.index = idx;
-                            rev.hscroll = 0;
-                            return true;
-                        }
-                    }
-                }
-                false
-            }
-            // Only set when the topic index is open (render_help), so this is a no-op while
-            // viewing a topic's body.
-            Screen::Help(help) => {
-                if let Some(hit) = layout.list {
-                    if point_in(hit.rect, col, row) {
-                        if let Some(idx) = hit.index_at(row, HelpTopic::all().len()) {
-                            help.index_sel = idx;
-                            return true;
-                        }
-                    }
-                }
-                false
-            }
-            Screen::Config(cfg) => {
-                if let Some(hit) = layout.list {
-                    if point_in(hit.rect, col, row) {
-                        if let Some(idx) = hit.index_at(row, ConfigField::ALL.len()) {
-                            cfg.index = idx;
-                            return true;
-                        }
-                    }
-                }
-                false
-            }
+        match &self.screen {
+            Screen::List => self.click_select_list(col, row, layout),
+            Screen::Gists(_) => self.click_select_gists(col, row, layout),
+            Screen::Pins(_) => self.click_select_pins(col, row, layout),
+            Screen::Revisions(_) => self.click_select_revisions(col, row, layout),
+            Screen::Help(_) => self.click_select_help(col, row, layout),
+            Screen::Config(_) => self.click_select_config(col, row, layout),
             Screen::GistDetail(_) => self.click_select_detail(col, row, layout),
             _ => false,
         }
@@ -696,7 +514,7 @@ pub(crate) fn diff_pair_previewable(
 
 impl AppState {
     /// Page the focused list-pane selection by [`PAGE_SCROLL`] rows (clamped at bounds).
-    fn list_page_focused(&mut self, forward: bool) {
+    pub(crate) fn list_page_focused(&mut self, forward: bool) {
         let step = PAGE_SCROLL as usize;
         // One snapshot for the focused pane length (issue #224) — selection-index
         // changes do not alter list length, so this is safe.

--- a/src/tui/screens/config.rs
+++ b/src/tui/screens/config.rs
@@ -1,8 +1,11 @@
 //! `Screen::Config` (Settings) — key handling, view-model, paint, and palette items
 //! colocated in one file (issue #287, Phase 2).
 
+use crate::tui::keys::{point_in, NavAction};
 use crate::tui::view_model::{ChromeVm, ConfigVm};
-use crate::tui::{AppState, ConfigField, HelpTopic, KeyOutcome, MouseLayout, PaneHit, Theme};
+use crate::tui::{
+    AppState, ConfigField, HelpTopic, KeyOutcome, MouseLayout, PaneHit, Screen, Theme,
+};
 use crossterm::event::KeyCode;
 use ratatui::{
     layout::{Constraint, Direction, Layout},
@@ -117,6 +120,47 @@ impl AppState {
                 true
             }
         }
+    }
+
+    /// Arrow key navigation for `Screen::Config`: moves the field-index selection. Left/Right
+    /// are handled in `handle_key_config` (adjusting a field needs `PersistSettings`).
+    pub(crate) fn apply_navigation_config(&mut self, action: NavAction) -> bool {
+        let Screen::Config(cfg) = &mut self.screen else {
+            return false;
+        };
+        let n = ConfigField::ALL.len();
+        match action {
+            NavAction::Up => {
+                cfg.index = cfg.index.saturating_sub(1);
+            }
+            NavAction::Down => {
+                if cfg.index + 1 < n {
+                    cfg.index += 1;
+                }
+            }
+            NavAction::Left | NavAction::Right => {
+                // Adjust is handled in handle_key_config (needs PersistSettings).
+                return false;
+            }
+            _ => return false,
+        }
+        true
+    }
+
+    /// Select the clicked field row on `Screen::Config`. Returns `true` when a row was hit.
+    pub(crate) fn click_select_config(&mut self, col: u16, row: u16, layout: &MouseLayout) -> bool {
+        let Screen::Config(cfg) = &mut self.screen else {
+            return false;
+        };
+        if let Some(hit) = layout.list {
+            if point_in(hit.rect, col, row) {
+                if let Some(idx) = hit.index_at(row, ConfigField::ALL.len()) {
+                    cfg.index = idx;
+                    return true;
+                }
+            }
+        }
+        false
     }
 }
 

--- a/src/tui/screens/gists.rs
+++ b/src/tui/screens/gists.rs
@@ -1,6 +1,7 @@
 //! `Screen::Gists` — key handling, view-model, paint, and palette items colocated in one
 //! file (issue #287, Phase 2).
 
+use crate::tui::keys::{apply_list_cursor_nav, point_in, NavAction};
 use crate::tui::view_model::{ChromeVm, GistGroupRowVm, GistsEmptyKind, GistsVm};
 use crate::tui::{AppState, HelpTopic, KeyOutcome, MouseLayout, PaneHit, Screen};
 use crossterm::event::KeyCode;
@@ -103,6 +104,36 @@ impl AppState {
             _ => {}
         }
         KeyOutcome::None
+    }
+
+    /// Arrow / hjkl / page-key navigation for `Screen::Gists`'s list cursor. Precomputes
+    /// len/hmax with `&self`, then mutates the cursor (issue #274: cannot hold
+    /// `&mut GistsManagerState` from `match &mut self.screen` while calling helpers).
+    pub(crate) fn apply_navigation_gists(&mut self, action: NavAction) -> bool {
+        let len = self.visible_gist_groups().len();
+        let hmax = self.gists_hscroll_max();
+        let Some(gm) = self.gist_manager_mut() else {
+            return false;
+        };
+        apply_list_cursor_nav(&mut gm.cursor, action, len, hmax);
+        true
+    }
+
+    /// Select the clicked row on `Screen::Gists`, moving the list cursor. Returns `true` when
+    /// a row was hit.
+    pub(crate) fn click_select_gists(&mut self, col: u16, row: u16, layout: &MouseLayout) -> bool {
+        if let Some(hit) = layout.list {
+            if point_in(hit.rect, col, row) {
+                let count = self.visible_gist_groups().len();
+                if let Some(idx) = hit.index_at(row, count) {
+                    if let Some(gm) = self.gist_manager_mut() {
+                        gm.cursor.select(idx);
+                        return true;
+                    }
+                }
+            }
+        }
+        false
     }
 }
 

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -1,8 +1,9 @@
 //! `Screen::Help` — key handling, view-model, paint, and palette items colocated in one
 //! file (issue #287, Phase 2).
 
+use crate::tui::keys::{point_in, NavAction, PAGE_SCROLL};
 use crate::tui::view_model::{ChromeVm, HelpIndexItemVm, HelpModeVm, HelpVm};
-use crate::tui::{AppState, HelpState, HelpTopic, KeyOutcome, MouseLayout, PaneHit};
+use crate::tui::{AppState, HelpState, HelpTopic, KeyOutcome, MouseLayout, PaneHit, Screen};
 use crossterm::event::KeyCode;
 use ratatui::{
     layout::Rect,
@@ -84,6 +85,61 @@ impl AppState {
             self.leave();
         }
         KeyOutcome::None
+    }
+
+    /// Arrow / hjkl / page-key navigation for `Screen::Help`: moves the topic-index
+    /// selection, or scrolls the topic body.
+    pub(crate) fn apply_navigation_help(&mut self, action: NavAction) -> bool {
+        let Screen::Help(help) = &mut self.screen else {
+            return false;
+        };
+        let topics = HelpTopic::all();
+        if help.index_open {
+            match action {
+                NavAction::Up => help.index_sel = help.index_sel.saturating_sub(1),
+                NavAction::Down => {
+                    if help.index_sel + 1 < topics.len() {
+                        help.index_sel += 1;
+                    }
+                }
+                _ => return false,
+            }
+        } else {
+            match action {
+                NavAction::Up => {
+                    help.scroll = help.scroll.saturating_sub(1);
+                }
+                NavAction::Down => {
+                    help.scroll = help.scroll.saturating_add(1);
+                }
+                NavAction::PageUp => {
+                    help.scroll = help.scroll.saturating_sub(PAGE_SCROLL);
+                }
+                NavAction::PageDown => {
+                    help.scroll = help.scroll.saturating_add(PAGE_SCROLL);
+                }
+                _ => return false,
+            }
+        }
+        true
+    }
+
+    /// Select the clicked topic-index row on `Screen::Help`. Only set when the topic index is
+    /// open (render_help), so this is a no-op while viewing a topic's body. Returns `true`
+    /// when a row was hit.
+    pub(crate) fn click_select_help(&mut self, col: u16, row: u16, layout: &MouseLayout) -> bool {
+        let Screen::Help(help) = &mut self.screen else {
+            return false;
+        };
+        if let Some(hit) = layout.list {
+            if point_in(hit.rect, col, row) {
+                if let Some(idx) = hit.index_at(row, HelpTopic::all().len()) {
+                    help.index_sel = idx;
+                    return true;
+                }
+            }
+        }
+        false
     }
 }
 

--- a/src/tui/screens/list.rs
+++ b/src/tui/screens/list.rs
@@ -1,7 +1,7 @@
 //! `Screen::List` — key handling, view-model, paint, and palette items colocated in one
 //! file (issue #287, Phase 2).
 
-use crate::tui::keys::{apply_filter_edit, diff_pair_previewable, FilterKey};
+use crate::tui::keys::{apply_filter_edit, diff_pair_previewable, point_in, FilterKey, NavAction};
 use crate::tui::view_model::{
     ChromeVm, ListFooterVm, ListPaneEmpty, ListPaneVm, ListRowVm, ListVm,
 };
@@ -435,6 +435,57 @@ impl AppState {
                 local.path.display()
             ),
         );
+    }
+
+    /// Arrow / hjkl / page-key navigation for `Screen::List`: moves the focused pane's
+    /// selection, or scrolls it horizontally.
+    pub(crate) fn apply_navigation_list(&mut self, action: NavAction) -> bool {
+        match action {
+            NavAction::Down => self.list_move_focused(true),
+            NavAction::Up => self.list_move_focused(false),
+            NavAction::PageDown => self.list_page_focused(true),
+            NavAction::PageUp => self.list_page_focused(false),
+            NavAction::Left => self.scroll_focused_left(),
+            NavAction::Right => self.scroll_focused_right(),
+        }
+        true
+    }
+
+    /// Select the clicked row on `Screen::List`, focusing its pane. Returns `true` when a row
+    /// was hit (so a double-click should "open" it). A click in a pane's blank area or border
+    /// focuses it but selects nothing (returns `false`); a click off every list returns `false`.
+    pub(crate) fn click_select_list(&mut self, col: u16, row: u16, layout: &MouseLayout) -> bool {
+        if let Some(hit) = layout.local {
+            if point_in(hit.rect, col, row) {
+                // A click anywhere in the pane (incl. blank/border) focuses it; a
+                // click on a row also selects it.
+                self.focus = FocusPane::Local;
+                if let Some(idx) = hit.index_at(row, self.visible_locals().len()) {
+                    self.local_index = idx;
+                    self.local_hscroll = 0;
+                    if self.anchor == FocusPane::Local {
+                        self.reset_ranked_pane();
+                    }
+                    return true;
+                }
+                return false;
+            }
+        }
+        if let Some(hit) = layout.gist {
+            if point_in(hit.rect, col, row) {
+                self.focus = FocusPane::Gist;
+                if let Some(idx) = hit.index_at(row, self.ranked_gists().len()) {
+                    self.gist_index = idx;
+                    self.gist_hscroll = 0;
+                    if self.anchor == FocusPane::Gist {
+                        self.reset_ranked_pane();
+                    }
+                    return true;
+                }
+                return false;
+            }
+        }
+        false
     }
 }
 

--- a/src/tui/screens/pins.rs
+++ b/src/tui/screens/pins.rs
@@ -1,6 +1,7 @@
 //! `Screen::Pins` — key handling, view-model, paint, and palette items colocated in one
 //! file (issue #287, Phase 2).
 
+use crate::tui::keys::{apply_list_cursor_nav, point_in, NavAction};
 use crate::tui::view_model::{ChromeVm, PinRowVm, PinsEmptyKind, PinsVm};
 use crate::tui::{AppState, HelpTopic, KeyOutcome, MouseLayout, PaneHit, Screen};
 use crossterm::event::KeyCode;
@@ -110,6 +111,36 @@ impl AppState {
             _ => {}
         }
         KeyOutcome::None
+    }
+
+    /// Arrow / hjkl / page-key navigation for `Screen::Pins`'s list cursor. Precomputes
+    /// len/hmax with `&self`, then mutates the cursor (issue #274: cannot hold
+    /// `&mut PinsState` from `match &mut self.screen` while calling helpers).
+    pub(crate) fn apply_navigation_pins(&mut self, action: NavAction) -> bool {
+        let len = self.visible_pin_indices().len();
+        let hmax = self.pins_hscroll_max();
+        let Some(pins) = self.pins_mut() else {
+            return false;
+        };
+        apply_list_cursor_nav(&mut pins.cursor, action, len, hmax);
+        true
+    }
+
+    /// Select the clicked row on `Screen::Pins`, moving the list cursor. Returns `true` when
+    /// a row was hit.
+    pub(crate) fn click_select_pins(&mut self, col: u16, row: u16, layout: &MouseLayout) -> bool {
+        if let Some(hit) = layout.list {
+            if point_in(hit.rect, col, row) {
+                let count = self.visible_pin_indices().len();
+                if let Some(idx) = hit.index_at(row, count) {
+                    if let Some(pins) = self.pins_mut() {
+                        pins.cursor.select(idx);
+                        return true;
+                    }
+                }
+            }
+        }
+        false
     }
 }
 

--- a/src/tui/screens/revisions.rs
+++ b/src/tui/screens/revisions.rs
@@ -2,8 +2,9 @@
 //! one file (issue #287, Phase 2).
 
 use crate::tui::bg::revision_version_label;
+use crate::tui::keys::{point_in, NavAction, PAGE_SCROLL};
 use crate::tui::view_model::{ChromeVm, RevisionsEmptyKind, RevisionsVm};
-use crate::tui::{AppState, HelpTopic, KeyOutcome, MouseLayout, PaneHit};
+use crate::tui::{AppState, HelpTopic, KeyOutcome, MouseLayout, PaneHit, Screen};
 use crossterm::event::KeyCode;
 use ratatui::{
     layout::{Constraint, Direction, Layout},
@@ -248,6 +249,63 @@ impl AppState {
             .map(|i| i + 1)
             .unwrap_or(1);
         format!("{} ({index}/{})", rev.target_file, files.len())
+    }
+
+    /// Arrow / hjkl / page-key navigation for `Screen::Revisions`: moves the entry cursor, or
+    /// scrolls it horizontally.
+    pub(crate) fn apply_navigation_revisions(&mut self, action: NavAction) -> bool {
+        let Screen::Revisions(rev) = &mut self.screen else {
+            return false;
+        };
+        let entries_len = rev.entries.as_ref().map(|e| e.len()).unwrap_or(0);
+        if entries_len == 0 {
+            return false;
+        }
+        match action {
+            NavAction::Down => {
+                rev.index = (rev.index + 1).min(entries_len - 1);
+            }
+            NavAction::Up => {
+                rev.index = rev.index.saturating_sub(1);
+            }
+            NavAction::PageDown => {
+                rev.index = (rev.index + PAGE_SCROLL as usize).min(entries_len - 1);
+            }
+            NavAction::PageUp => {
+                rev.index = rev.index.saturating_sub(PAGE_SCROLL as usize);
+            }
+            NavAction::Left => {
+                rev.hscroll = rev.hscroll.saturating_sub(1);
+            }
+            NavAction::Right => {
+                rev.hscroll = rev.hscroll.saturating_add(1);
+            }
+        }
+        true
+    }
+
+    /// Select the clicked row on `Screen::Revisions`, moving the entry cursor. Returns `true`
+    /// when a row was hit.
+    pub(crate) fn click_select_revisions(
+        &mut self,
+        col: u16,
+        row: u16,
+        layout: &MouseLayout,
+    ) -> bool {
+        let Screen::Revisions(rev) = &mut self.screen else {
+            return false;
+        };
+        if let Some(hit) = layout.list {
+            if point_in(hit.rect, col, row) {
+                let count = rev.entries.as_ref().map_or(0, |e| e.len());
+                if let Some(idx) = hit.index_at(row, count) {
+                    rev.index = idx;
+                    rev.hscroll = 0;
+                    return true;
+                }
+            }
+        }
+        false
     }
 }
 


### PR DESCRIPTION
## Summary
- Second and final PR colocating mouse dispatch into `screens/*.rs`, the way keyboard dispatch already is (issue #310) — PR 1 (merged) handled `GistDetail`; this one does `List`, `Gists`, `Pins`, `Revisions`, `Help`, `Config`
- Each screen gets `apply_navigation_<screen>`/`click_select_<screen>` as `impl AppState` methods in its `screens/x.rs`, matching PR 1's `detail.rs` precedent; `keys.rs`'s `apply_navigation`/`click_select` shrink to one line per arm
- Pins/Gists preserve their pre-match early-return special case (issue #274 borrow-avoidance shape) and their original `pins_mut()`/`gist_manager_mut()` accessor style; Revisions/Help/Config keep their original direct `&mut self.screen` matching (translated to `let Screen::X(payload) = &mut self.screen else { return false };`)
- `apply_list_cursor_nav`/`PAGE_SCROLL`/`list_page_focused` widen from private to `pub(crate)` in `keys.rs` (minimal necessary widening for the cross-module calls)
- Palette's `apply_navigation` arm and the `Diff`/`Preview`/`Confirm` shared scroll arm are untouched, per the issue's explicit exclusions
- No behavior change — moved bodies are byte-identical, only file/visibility changed

Closes #310

## Test plan
- [x] `mise run check` (fmt --check, clippy --all-targets -D warnings, cargo test, cargo check) all green
- [x] Two rounds of `/code-review` (Standards + Spec) — both rounds clean on both axes