### PR TITLE
refactor(tui): extract write_scratch_file to dedup KeyOutcome::Upload/ExecuteRestoreRevision

### DIFF
--- a/src/tui/bg.rs
+++ b/src/tui/bg.rs
@@ -866,6 +866,33 @@ pub(super) fn edit_upload_buffer(
     Ok(())
 }
 
+/// Create a scratch dir and write `body` to `filename` inside it, setting a status message
+/// and returning `None` on either failure — the caller owns the early return (`ScratchDir`
+/// cleanup on early failure, or ownership moving into a bg job on success, per issue #275).
+/// `context` names the file for the write-failure message (e.g. "temp file"); the
+/// create-dir failure message is the same regardless of caller.
+pub(super) fn write_scratch_file(
+    state: &mut AppState,
+    label: &str,
+    filename: &str,
+    context: &str,
+    body: &[u8],
+) -> Option<(crate::temp_dir::ScratchDir, PathBuf)> {
+    let scratch = match crate::temp_dir::ScratchDir::create(label) {
+        Ok(dir) => dir,
+        Err(e) => {
+            state.set_status(format!("failed to create temp dir: {e}"));
+            return None;
+        }
+    };
+    let path = scratch.path().join(filename);
+    if let Err(e) = std::fs::write(&path, body) {
+        state.set_status(format!("failed to write {context}: {e}"));
+        return None;
+    }
+    Some((scratch, path))
+}
+
 pub(super) fn download(state: &mut AppState, mode: crate::actions::DownloadMode) {
     let target = state.download_target();
     let content = state.preview_remote().to_string();

--- a/src/tui/dispatch.rs
+++ b/src/tui/dispatch.rs
@@ -211,21 +211,17 @@ pub(super) fn dispatch_outcome(
 
             let upload_content = state.content_to_upload();
 
-            // ScratchDir owns cleanup: early write failure drops here; on success
-            // ownership moves into the bg job and drops after execute (issue #275).
-            let scratch = match crate::temp_dir::ScratchDir::create("upload") {
-                Ok(dir) => dir,
-                Err(e) => {
-                    state.set_status(format!("failed to create temp dir: {e}"));
-                    return Ok(LoopFlow::Proceed);
-                }
-            };
-
-            let temp_file_path = scratch.path().join(&filename);
-            if let Err(e) = std::fs::write(&temp_file_path, &upload_content) {
-                state.set_status(format!("failed to write temp file: {e}"));
+            // ScratchDir owns cleanup: `write_scratch_file` drops it on early failure; on
+            // success ownership moves into the bg job and drops after execute (issue #275).
+            let Some((scratch, temp_file_path)) = write_scratch_file(
+                state,
+                "upload",
+                &filename,
+                "temp file",
+                upload_content.as_bytes(),
+            ) else {
                 return Ok(LoopFlow::Proceed);
-            }
+            };
 
             let has_same_name = state
                 .gists
@@ -559,21 +555,19 @@ pub(super) fn dispatch_outcome(
             else {
                 return Ok(LoopFlow::Proceed);
             };
-            // ScratchDir owns cleanup across write-failure early return and the
-            // bg job that consumes the JSON payload (issue #275).
-            let scratch = match crate::temp_dir::ScratchDir::create("restore") {
-                Ok(dir) => dir,
-                Err(e) => {
-                    state.set_status(format!("failed to create temp dir: {e}"));
-                    return Ok(LoopFlow::Proceed);
-                }
-            };
-            let json_path = scratch.path().join("restore.json");
+            // ScratchDir owns cleanup: `write_scratch_file` drops it on early failure; on
+            // success ownership moves into the bg job that consumes the JSON payload
+            // (issue #275).
             let body = crate::actions::restore_revision_json(&filename, &content);
-            if let Err(e) = std::fs::write(&json_path, &body) {
-                state.set_status(format!("failed to write restore payload: {e}"));
+            let Some((scratch, json_path)) = write_scratch_file(
+                state,
+                "restore",
+                "restore.json",
+                "restore payload",
+                body.as_bytes(),
+            ) else {
                 return Ok(LoopFlow::Proceed);
-            }
+            };
             let plan = crate::actions::restore_revision_command(&gist_id, &json_path);
             jobs.spawn_action(state, "Restoring revision…", move || {
                 let result = crate::actions::execute_command(&plan)


### PR DESCRIPTION
## Summary
- `KeyOutcome::Upload` and `KeyOutcome::ExecuteRestoreRevision` each inlined an identical `ScratchDir::create` → write-one-file → on-error `set_status` + early return sequence (issue #314)
- Extracts `write_scratch_file(state, label, filename, context, body) -> Option<(ScratchDir, PathBuf)>` in `bg.rs`; both call sites now use it instead of inlining
- `download`/`pin_paths` don't apply as a template as-is (they're `()`-returning and never abort the caller), so the new helper hands failure back via `Option` instead — each call site does its own `let Some(...) = ... else { return Ok(LoopFlow::Proceed); }`
- Create-dir failure message is identical at both sites and stays hardcoded; write-failure message differs and is preserved exactly via a `context: &str` param (status-bar text is user-visible)
- No new unit test — thin IO, matching the documented exclusion for `download`/`pin_paths`-style helpers

Closes #314

## Test plan
- [x] `mise run check` (fmt --check, clippy --all-targets -D warnings, cargo test, cargo check) all green
- [x] Two rounds of `/code-review` (Standards + Spec) — round 1 found two stale comments (fixed), round 2 clean