### PR TITLE
refactor(tui): extract AppState::is_any_filtering() (#319)

### DIFF
--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -85,9 +85,7 @@ impl AppState {
         // be typed into filters and description editors.
         if code == KeyCode::Char('T')
             && theme_toggle_modifiers_ok(modifiers)
-            && !self.filtering
-            && !self.pins().is_some_and(|p| p.filtering)
-            && !self.gist_manager().is_some_and(|g| g.filtering)
+            && !self.is_any_filtering()
             && !self.editing_description
         {
             self.theme_choice = match self.theme_choice {
@@ -186,11 +184,7 @@ impl AppState {
         }
         // While filtering, arrows/hjkl are typed or handled in the filter branches; page keys
         // still jump the live selection by PAGE_SCROLL.
-        if (self.filtering
-            || self.pins().is_some_and(|p| p.filtering)
-            || self.gist_manager().is_some_and(|g| g.filtering))
-            && !matches!(action, NavAction::PageUp | NavAction::PageDown)
-        {
+        if self.is_any_filtering() && !matches!(action, NavAction::PageUp | NavAction::PageDown) {
             return false;
         }
         // Pins/Gists dispatch before the match below (issue #274: cannot hold `&mut PinsState`

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1144,6 +1144,14 @@ impl AppState {
             .find(|s| tag(s))
     }
 
+    /// True when List, Pins, or the Gists manager has an active filter query (issue #319).
+    /// Centralizes the 3-way guard that was duplicated across `keys.rs` and `palette.rs`.
+    pub fn is_any_filtering(&self) -> bool {
+        self.filtering
+            || self.pins().is_some_and(|p| p.filtering)
+            || self.gist_manager().is_some_and(|g| g.filtering)
+    }
+
     screen_payload_accessor! {
         /// Help payload when Help is active, or when the palette is open over Help (issue #242).
         help, help_mut, is_help, HelpState, help_state, help_state_mut,

--- a/src/tui/palette.rs
+++ b/src/tui/palette.rs
@@ -50,11 +50,7 @@ pub struct PaletteState {
 impl AppState {
     /// Whether a global palette opener (`;` / `Ctrl+p`) should be ignored right now.
     pub(crate) fn palette_blocked(&self) -> bool {
-        self.screen.is_confirm()
-            || self.filtering
-            || self.pins().is_some_and(|p| p.filtering)
-            || self.gist_manager().is_some_and(|g| g.filtering)
-            || self.editing_description
+        self.screen.is_confirm() || self.is_any_filtering() || self.editing_description
     }
 
     pub(crate) fn open_palette_menu(&mut self, anchor: Option<(u16, u16)>) {


### PR DESCRIPTION
## Summary

- Add `AppState::is_any_filtering(&self) -> bool` in `src/tui/mod.rs`, centralizing the 3-way "is List / Pins / Gists manager filtering" guard.
- Replace the 3 duplicated call sites: theme-toggle guard and `apply_navigation` in `src/tui/keys.rs`, palette-open guard in `src/tui/palette.rs`.
- No behavior change.

Closes #319

## Test plan

- [x] `mise run check` (fmt + clippy -D warnings + full test suite + `cargo check`) passes
- [x] `/code-review` (Standards + Spec axes) — both clean, no findings