### PR TITLE
ci(dependabot): ignore actions minor/patch updates globally

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,12 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    # Floating major tags already track latest minor/patch at runtime.
+    # Only surface major action upgrades.
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-minor
+          - version-update:semver-patch
     commit-message:
       prefix: ci


### PR DESCRIPTION
## Summary

Optimize Dependabot configuration for `github-actions` by ignoring minor and patch updates globally.

## Changes

- Ignore `version-update:semver-minor` and `version-update:semver-patch` for `github-actions` in `.github/dependabot.yml` because floating major tags already track latest minor/patch at runtime.

## Testing

- [x] `mise run check` (runs fmt, clippy, test, and check)
- [ ] Manually verified in the TUI (if applicable)

## Related Issues