### PR TITLE
refactor: ponytail cleanup from audit

### DIFF
--- a/src/actions.rs
+++ b/src/actions.rs
@@ -467,6 +467,8 @@ fn compact_in_dir(gist_id: &str, dir: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Runs a planned command with the real process boundary ([`SystemRunner`]).
+/// Prefer this over spelling `run_command(&SystemRunner, …)` at every write path.
 pub fn execute_command(plan: &CommandPlan) -> Result<String> {
     run_command(&SystemRunner, plan)
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -62,22 +62,6 @@ pub fn save_gist_cache(path: &Path, cache: &GistListCache) {
     }
 }
 
-/// Legacy helper — loads only the owned gist rows from cache.
-pub fn load_cached_gists(path: &Path) -> Vec<GistFile> {
-    load_gist_cache(path).map(|c| c.owned).unwrap_or_default()
-}
-
-/// Legacy helper — saves only owned gist rows (prefer [`save_gist_cache`]).
-pub fn save_cached_gists(path: &Path, gists: &[GistFile]) {
-    save_gist_cache(
-        path,
-        &GistListCache {
-            owned: gists.to_vec(),
-            ..GistListCache::default()
-        },
-    );
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/config.rs
+++ b/src/config.rs
@@ -196,18 +196,6 @@ pub fn save_config(path: &Path, config: &AppConfig) -> Result<()> {
     fs::write(path, raw).with_context(|| format!("write {}", path.display()))
 }
 
-/// Effective mouse-enabled state: the config value, with the `--no-mouse` CLI flag able
-/// to force it off. There is intentionally no `--mouse` flag — edit the config to force on.
-pub fn resolve_mouse_enabled(config_mouse: bool, no_mouse: bool) -> bool {
-    config_mouse && !no_mouse
-}
-
-/// Effective update-check state: the config value, with the `--no-update-check` CLI flag
-/// able to force it off (no `--update-check` flag — edit the config to force on).
-pub fn resolve_update_check(config_check: bool, no_update_check: bool) -> bool {
-    config_check && !no_update_check
-}
-
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
@@ -461,14 +449,6 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn resolve_mouse_enabled_truth_table() {
-        assert!(resolve_mouse_enabled(true, false)); // default on, no flag
-        assert!(!resolve_mouse_enabled(true, true)); // flag forces off
-        assert!(!resolve_mouse_enabled(false, false)); // config off
-        assert!(!resolve_mouse_enabled(false, true)); // both off
-    }
-
-    #[test]
     fn check_updates_defaults_to_true_when_absent() {
         // A config file with no `check_updates` key must load as enabled.
         let toml = "scan_depth = 4\n";
@@ -493,13 +473,5 @@ pub(crate) mod tests {
         let text = toml::to_string(&config).unwrap();
         let parsed: AppConfig = toml::from_str(&text).unwrap();
         assert!(!parsed.ignore_trailing_newline);
-    }
-
-    #[test]
-    fn resolve_update_check_truth_table() {
-        assert!(resolve_update_check(true, false)); // default on, no flag
-        assert!(!resolve_update_check(true, true)); // flag forces off
-        assert!(!resolve_update_check(false, false)); // config off
-        assert!(!resolve_update_check(false, true)); // both off
     }
 }

--- a/src/gh/forks.rs
+++ b/src/gh/forks.rs
@@ -29,10 +29,6 @@ pub fn gist_forks_plan(gist_id: &str) -> CommandPlan {
     }
 }
 
-pub fn fetch_gist_fork_count(gist_id: &str) -> Result<u32> {
-    fetch_gist_fork_count_with(&SystemRunner, gist_id)
-}
-
 pub fn fetch_gist_fork_count_with(runner: &dyn CommandRunner, gist_id: &str) -> Result<u32> {
     let raw = run_command(runner, &gist_forks_plan(gist_id))?;
     let forks: Vec<serde_json::Value> = serde_json::from_str(&raw).context("parse gist forks")?;
@@ -76,10 +72,6 @@ pub fn gist_detail_plan(gist_id: &str) -> CommandPlan {
         program: "gh".into(),
         args: vec!["api".into(), format!("/gists/{gist_id}")],
     }
-}
-
-pub fn fetch_forked_gist_ids_graphql() -> Result<HashSet<String>> {
-    fetch_forked_gist_ids_graphql_with(&SystemRunner)
 }
 
 pub fn fetch_forked_gist_ids_graphql_with(runner: &dyn CommandRunner) -> Result<HashSet<String>> {
@@ -160,10 +152,6 @@ fn parse_fork_flags_page(raw: &str) -> Result<(HashSet<String>, Option<String>)>
 /// Pagination is handled by [`fetch_forked_gist_ids_graphql_with`].
 pub fn parse_forked_gist_ids_graphql(raw: &str) -> Result<HashSet<String>> {
     parse_fork_flags_page(raw).map(|(ids, _)| ids)
-}
-
-pub fn fetch_gist_fork_of_id(gist_id: &str) -> Result<Option<String>> {
-    fetch_gist_fork_of_id_with(&SystemRunner, gist_id)
 }
 
 pub fn fetch_gist_fork_of_id_with(

--- a/src/gh/mod.rs
+++ b/src/gh/mod.rs
@@ -119,9 +119,8 @@ pub use comments::{
 mod forks;
 pub use forks::{
     apply_fork_of_ids, collect_gist_fork_counts, collect_gist_fork_counts_with,
-    collect_owned_fork_of_ids, collect_owned_fork_of_ids_with, fetch_forked_gist_ids_graphql,
-    fetch_forked_gist_ids_graphql_with, fetch_gist_fork_count, fetch_gist_fork_count_with,
-    fetch_gist_fork_of_id, fetch_gist_fork_of_id_with, gist_detail_plan,
+    collect_owned_fork_of_ids, collect_owned_fork_of_ids_with, fetch_forked_gist_ids_graphql_with,
+    fetch_gist_fork_count_with, fetch_gist_fork_of_id_with, gist_detail_plan,
     gist_fork_flags_graphql_plan, gist_forks_plan, parse_forked_gist_ids_graphql,
     parse_gist_fork_counts,
 };
@@ -138,10 +137,10 @@ pub use gists::{
 mod revisions;
 pub use revisions::{
     build_gist_revision_raw_url, fetch_gist_commits_json, fetch_gist_commits_json_with,
-    fetch_gist_revision_json, fetch_gist_revision_json_with, fetch_revision_file_text,
-    fetch_revision_file_text_optional, fetch_revision_file_text_optional_with,
-    fetch_revision_file_text_with, fetch_revision_file_with, gist_commits_plan, gist_revision_plan,
-    parse_gist_commits_json, revision_file_content, RevisionFileContent,
+    fetch_gist_revision_json_with, fetch_revision_file_text, fetch_revision_file_text_optional,
+    fetch_revision_file_text_optional_with, fetch_revision_file_text_with,
+    fetch_revision_file_with, gist_commits_plan, gist_revision_plan, parse_gist_commits_json,
+    revision_file_content, RevisionFileContent,
 };
 
 mod stars;

--- a/src/gh/revisions.rs
+++ b/src/gh/revisions.rs
@@ -34,10 +34,6 @@ pub fn fetch_gist_commits_json_with(runner: &dyn CommandRunner, gist_id: &str) -
     run_command(runner, &gist_commits_plan(gist_id))
 }
 
-pub fn fetch_gist_revision_json(gist_id: &str, version: &str) -> Result<String> {
-    fetch_gist_revision_json_with(&SystemRunner, gist_id, version)
-}
-
 pub fn fetch_gist_revision_json_with(
     runner: &dyn CommandRunner,
     gist_id: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub mod diff;
 pub mod domain;
 pub mod gh;
 pub mod local;
-pub mod lru;
+pub(crate) mod lru;
 pub mod ranking;
 pub mod temp_dir;
 pub mod tui;

--- a/src/local.rs
+++ b/src/local.rs
@@ -86,10 +86,6 @@ fn walk_recursive(
     }
 }
 
-pub fn is_empty_candidate_mode(candidates: &[LocalCandidate]) -> bool {
-    candidates.is_empty()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -144,11 +140,11 @@ mod tests {
     }
 
     #[test]
-    fn empty_candidate_mode_when_nothing_found() {
+    fn empty_dir_yields_no_candidates() {
         let dir = tempfile::tempdir().unwrap();
         let candidates =
             discover_local_candidates(dir.path(), &[], false, &default_skip(), 10).unwrap();
-        assert!(is_empty_candidate_mode(&candidates));
+        assert!(candidates.is_empty());
     }
 
     #[test]

--- a/src/lru.rs
+++ b/src/lru.rs
@@ -10,7 +10,7 @@ use std::hash::Hash;
 /// cache past its capacity, the least-recently-used entry is evicted. Both `get` and `insert`
 /// count as a use (they mark the entry most-recently-used).
 #[derive(Debug, Clone)]
-pub struct LruCache<K, V> {
+pub(crate) struct LruCache<K, V> {
     map: HashMap<K, V>,
     /// Keys ordered least- to most-recently used (back = most recent).
     order: Vec<K>,
@@ -20,7 +20,7 @@ pub struct LruCache<K, V> {
 impl<K: Clone + Eq + Hash, V> LruCache<K, V> {
     /// Create a cache holding at most `capacity` entries. A `capacity` of 0 is clamped to 1 so
     /// the cache always retains at least the most recent entry.
-    pub fn new(capacity: usize) -> Self {
+    pub(crate) fn new(capacity: usize) -> Self {
         Self {
             map: HashMap::new(),
             order: Vec::new(),
@@ -29,17 +29,13 @@ impl<K: Clone + Eq + Hash, V> LruCache<K, V> {
     }
 
     /// Number of entries currently held.
-    pub fn len(&self) -> usize {
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
         self.map.len()
     }
 
-    /// Whether the cache holds no entries.
-    pub fn is_empty(&self) -> bool {
-        self.map.is_empty()
-    }
-
     /// Fetch a value, marking it most-recently-used.
-    pub fn get(&mut self, key: &K) -> Option<&V> {
+    pub(crate) fn get(&mut self, key: &K) -> Option<&V> {
         if self.map.contains_key(key) {
             self.touch(key);
             self.map.get(key)
@@ -50,7 +46,7 @@ impl<K: Clone + Eq + Hash, V> LruCache<K, V> {
 
     /// Insert or replace a value, marking it most-recently-used and evicting the
     /// least-recently-used entry if that pushes the cache past its capacity.
-    pub fn insert(&mut self, key: K, value: V) {
+    pub(crate) fn insert(&mut self, key: K, value: V) {
         if self.map.insert(key.clone(), value).is_some() {
             self.touch(&key);
         } else {
@@ -63,7 +59,7 @@ impl<K: Clone + Eq + Hash, V> LruCache<K, V> {
     }
 
     /// Remove a value, if present, returning it.
-    pub fn remove(&mut self, key: &K) -> Option<V> {
+    pub(crate) fn remove(&mut self, key: &K) -> Option<V> {
         if let Some(pos) = self.order.iter().position(|k| k == key) {
             self.order.remove(pos);
         }

--- a/src/ranking.rs
+++ b/src/ranking.rs
@@ -1,17 +1,61 @@
 use crate::domain::{GistFile, LocalCandidate, PinnedMapping};
+use std::cmp::Ordering;
 use std::path::Path;
+
+/// How a list row relates to the opposite pane's selection (sort key; UI maps this to style).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MatchMark {
+    /// No pin / filename match.
+    None,
+    /// Same basename as the opposite selection.
+    ExactFilename,
+    /// Explicit pin mapping (ranks above exact name).
+    Pinned,
+}
+
+impl MatchMark {
+    /// Sort weight: higher wins. Explicit — not derived from variant order.
+    pub const fn rank(self) -> u8 {
+        match self {
+            MatchMark::None => 0,
+            MatchMark::ExactFilename => 1,
+            MatchMark::Pinned => 2,
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RankedGistFile {
     pub file: GistFile,
-    pub score: u16,
-    pub reasons: Vec<MatchReason>,
+    pub mark: MatchMark,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum MatchReason {
-    Pinned,
-    ExactFilename,
+pub struct RankedLocal {
+    pub candidate: LocalCandidate,
+    pub mark: MatchMark,
+}
+
+fn match_mark(
+    local_path: &Path,
+    local_filename: &str,
+    gist_id: &str,
+    gist_filename: &str,
+    pinned: &[PinnedMapping],
+) -> MatchMark {
+    if pinned.iter().any(|m| {
+        m.local_path == local_path && m.gist_id == gist_id && m.gist_filename == gist_filename
+    }) {
+        MatchMark::Pinned
+    } else if local_filename == gist_filename {
+        MatchMark::ExactFilename
+    } else {
+        MatchMark::None
+    }
+}
+
+fn cmp_mark_then(a_mark: MatchMark, b_mark: MatchMark, tie: Ordering) -> Ordering {
+    b_mark.rank().cmp(&a_mark.rank()).then(tie)
 }
 
 pub fn rank_gist_files(
@@ -28,48 +72,22 @@ pub fn rank_gist_files(
         .iter()
         .cloned()
         .map(|file| {
-            let mut score = 0;
-            let mut reasons = Vec::new();
-
-            if pinned.iter().any(|m| {
-                m.local_path == local_path
-                    && m.gist_id == file.gist_id
-                    && m.gist_filename == file.filename
-            }) {
-                score += 10_000;
-                reasons.push(MatchReason::Pinned);
-            }
-
-            if file.filename == local_filename {
-                score += 1_000;
-                reasons.push(MatchReason::ExactFilename);
-            }
-
-            RankedGistFile {
-                file,
-                score,
-                reasons,
-            }
+            let mark = match_mark(
+                local_path,
+                local_filename,
+                &file.gist_id,
+                &file.filename,
+                pinned,
+            );
+            RankedGistFile { file, mark }
         })
         .collect();
 
-    ranked.sort_by(|a, b| {
-        b.score
-            .cmp(&a.score)
-            .then(a.file.filename.cmp(&b.file.filename))
-    });
+    ranked.sort_by(|a, b| cmp_mark_then(a.mark, b.mark, a.file.filename.cmp(&b.file.filename)));
     ranked
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct RankedLocal {
-    pub candidate: LocalCandidate,
-    pub score: u16,
-    pub reasons: Vec<MatchReason>,
-}
-
-/// The mirror of [`rank_gist_files`]: scores local files by how well they match a
-/// selected gist (used for the gist-pane-driven reverse ranking).
+/// Scores local files by how well they match a selected gist (gist-pane reverse ranking).
 pub fn rank_local_files(
     gist: &GistFile,
     locals: &[LocalCandidate],
@@ -84,37 +102,34 @@ pub fn rank_local_files(
                 .file_name()
                 .and_then(|s| s.to_str())
                 .unwrap_or_default();
-            let mut score = 0;
-            let mut reasons = Vec::new();
-
-            if pinned.iter().any(|m| {
-                m.local_path == candidate.path
-                    && m.gist_id == gist.gist_id
-                    && m.gist_filename == gist.filename
-            }) {
-                score += 10_000;
-                reasons.push(MatchReason::Pinned);
-            }
-
-            if local_filename == gist.filename {
-                score += 1_000;
-                reasons.push(MatchReason::ExactFilename);
-            }
-
-            RankedLocal {
-                candidate,
-                score,
-                reasons,
-            }
+            let mark = match_mark(
+                &candidate.path,
+                local_filename,
+                &gist.gist_id,
+                &gist.filename,
+                pinned,
+            );
+            RankedLocal { candidate, mark }
         })
         .collect();
 
-    ranked.sort_by(|a, b| {
-        b.score
-            .cmp(&a.score)
-            .then(a.candidate.path.cmp(&b.candidate.path))
-    });
+    ranked.sort_by(|a, b| cmp_mark_then(a.mark, b.mark, a.candidate.path.cmp(&b.candidate.path)));
     ranked
+}
+
+/// Unranked pane row (no opposite selection driving the score).
+pub fn unranked_gist(file: GistFile) -> RankedGistFile {
+    RankedGistFile {
+        file,
+        mark: MatchMark::None,
+    }
+}
+
+pub fn unranked_local(candidate: LocalCandidate) -> RankedLocal {
+    RankedLocal {
+        candidate,
+        mark: MatchMark::None,
+    }
 }
 
 #[cfg(test)]
@@ -132,11 +147,8 @@ mod tests {
             created_at: "2026-06-08T00:00:00Z".into(),
             owner_login: String::new(),
             fork_of_id: None,
-
             raw_url: None,
-
             content_type: None,
-
             node_id: None,
         }
     }
@@ -158,7 +170,7 @@ mod tests {
 
         let ranked = rank_gist_files(&local, &files, &pinned);
         assert_eq!(ranked[0].file.gist_id, "b");
-        assert!(ranked[0].reasons.contains(&MatchReason::Pinned));
+        assert_eq!(ranked[0].mark, MatchMark::Pinned);
     }
 
     #[test]
@@ -171,10 +183,11 @@ mod tests {
 
         let ranked = rank_gist_files(&local, &files, &[]);
         assert_eq!(ranked[0].file.gist_id, "b");
+        assert_eq!(ranked[0].mark, MatchMark::ExactFilename);
     }
 
     #[test]
-    fn filename_tie_break_ascending_when_scores_are_equal() {
+    fn filename_tie_break_ascending_when_marks_are_equal() {
         let local = PathBuf::from("/Users/me/project/config.json");
         let files = vec![
             gist("a", "unrelated", "zeta.txt"),
@@ -184,6 +197,12 @@ mod tests {
         let ranked = rank_gist_files(&local, &files, &[]);
         assert_eq!(ranked[0].file.filename, "alpha.txt");
         assert_eq!(ranked[1].file.filename, "zeta.txt");
+    }
+
+    #[test]
+    fn mark_rank_is_explicit_not_discriminant_order() {
+        assert!(MatchMark::Pinned.rank() > MatchMark::ExactFilename.rank());
+        assert!(MatchMark::ExactFilename.rank() > MatchMark::None.rank());
     }
 
     fn local(path: &str) -> LocalCandidate {
@@ -207,7 +226,7 @@ mod tests {
             ranked[0].candidate.path,
             PathBuf::from("/Users/me/.claude/settings.json")
         );
-        assert!(ranked[0].reasons.contains(&MatchReason::ExactFilename));
+        assert_eq!(ranked[0].mark, MatchMark::ExactFilename);
     }
 
     #[test]
@@ -225,6 +244,6 @@ mod tests {
 
         let ranked = rank_local_files(&target, &locals, &pinned);
         assert_eq!(ranked[0].candidate.path, pinned_local.path);
-        assert!(ranked[0].reasons.contains(&MatchReason::Pinned));
+        assert_eq!(ranked[0].mark, MatchMark::Pinned);
     }
 }

--- a/src/tui/list_ranking.rs
+++ b/src/tui/list_ranking.rs
@@ -6,37 +6,22 @@
 //!
 //! Named `list_ranking`, not `ranking`, to avoid colliding with the top-level pure module
 //! `crate::ranking` — the scoring algorithm these methods call into.
+//!
+//! Cost model:
+//! - [`AppState::ranked_gists`] / [`AppState::visible_locals`] build **only the side they
+//!   return** (plus a minimal driver peek for reverse-rank when the other pane is anchor).
+//! - [`AppState::list_pane_snapshots`] builds **both** once — prefer when a handler needs
+//!   both sides or both selections.
+//! - [`AppState::selected_local`] / [`AppState::selected_gist`] use the single-side paths.
 
 use crate::domain::{GistFile, LocalCandidate};
-use crate::ranking::{rank_gist_files, rank_local_files, RankedGistFile, RankedLocal};
+use crate::ranking::{
+    rank_gist_files, rank_local_files, unranked_gist, unranked_local, RankedGistFile, RankedLocal,
+};
 use crate::tui::{AppState, FocusPane};
 
-fn unranked_gists(gists: Vec<GistFile>) -> Vec<RankedGistFile> {
-    gists
-        .into_iter()
-        .map(|file| RankedGistFile {
-            file,
-            score: 0,
-            reasons: Vec::new(),
-        })
-        .collect()
-}
-
-fn unranked_locals(locals: &[LocalCandidate]) -> Vec<RankedLocal> {
-    locals
-        .iter()
-        .cloned()
-        .map(|candidate| RankedLocal {
-            candidate,
-            score: 0,
-            reasons: Vec::new(),
-        })
-        .collect()
-}
-
 impl AppState {
-    /// Filtered owned/starred gist file rows (no ranking/sort). Shared by
-    /// [`Self::ranked_gists`] and [`Self::list_pane_snapshots`].
+    /// Filtered owned/starred gist file rows (no ranking/sort).
     fn filtered_gist_files(&self) -> Vec<GistFile> {
         let query = self.filter_query.to_lowercase();
         self.list_gist_source()
@@ -57,7 +42,7 @@ impl AppState {
         let gists = self.filtered_gist_files();
         let mut ranked = match local_path {
             Some(path) => rank_gist_files(path, &gists, &self.pinned),
-            None => unranked_gists(gists),
+            None => gists.into_iter().map(unranked_gist).collect(),
         };
         self.gist_sort.apply(&mut ranked);
         ranked
@@ -68,7 +53,7 @@ impl AppState {
     fn rank_local_files_for(&self, gist: Option<&GistFile>) -> Vec<RankedLocal> {
         let mut ranked = match gist {
             Some(file) => rank_local_files(file, &self.locals, &self.pinned),
-            None => unranked_locals(&self.locals),
+            None => self.locals.iter().cloned().map(unranked_local).collect(),
         };
         let query = self.local_filter_query.to_lowercase();
         if !query.is_empty() {
@@ -82,14 +67,15 @@ impl AppState {
         ranked
     }
 
+    /// Gist pane order. Single-side: only builds gists (plus a locals peek when the local
+    /// pane is the ranking anchor). Prefer [`Self::list_pane_snapshots`] when both panes
+    /// are needed.
     pub fn ranked_gists(&self) -> Vec<RankedGistFile> {
-        // Anchor-driven ranking: the gist pane is ranked against the selected local file
-        // only while the LOCAL pane is the anchor (anchor == Local). When the gist pane
-        // is the anchor it uses its own sort (no ranking), which also breaks the
-        // otherwise-mutual dependency with `visible_locals`.
-        // NOTE: only evaluate the local selection inside the anchor==Local branch.
-        // Computing it eagerly would recurse: selected_local -> visible_locals ->
-        // selected_gist -> ranked_gists.
+        // Anchor-driven ranking: gists rank against the selected local only while LOCAL
+        // is the anchor. When Gist is the anchor, no reverse rank — also breaks the
+        // mutual dependency with `visible_locals`.
+        // Only evaluate local selection inside the Local-anchor branch (eager compute
+        // would recurse: selected_local → visible_locals → selected_gist → ranked_gists).
         let local_path = if self.anchor == FocusPane::Local {
             self.rank_local_files_for(None)
                 .get(self.local_index)
@@ -100,12 +86,10 @@ impl AppState {
         self.rank_gist_files_for(local_path.as_deref())
     }
 
-    /// The local file list after sorting (and, while the gist pane drives, reverse ranking
-    /// against the selected gist). Single source of truth for the local pane's order,
-    /// selection, and rendering — mirrors `ranked_gists`.
+    /// Local pane order. Single-side: only builds locals (plus a gists peek when the gist
+    /// pane is the ranking anchor). Prefer [`Self::list_pane_snapshots`] when both panes
+    /// are needed.
     pub fn visible_locals(&self) -> Vec<RankedLocal> {
-        // Mirror of `ranked_gists`: only evaluate the gist selection in the anchor==Gist
-        // branch to avoid recursing back through `ranked_gists` -> `selected_local`.
         let gist = if self.anchor == FocusPane::Gist {
             self.rank_gist_files_for(None)
                 .into_iter()
@@ -117,16 +101,12 @@ impl AppState {
         self.rank_local_files_for(gist.as_ref())
     }
 
-    /// Build both list-pane orderings with **one** construction of each list (issue #224 /
-    /// shape #1 from #154). Prefer this when a key/palette/render path needs both sides or
-    /// multiple selected rows — avoids N full filter+rank+sort passes per call site.
+    /// Build both list-pane orderings with **one** construction of each list (issue #224).
+    /// Prefer when a key/palette/render path needs both sides or both selections.
     ///
-    /// Expansion order follows the anchor so the mutual recursion is not entered:
+    /// Expansion order follows the anchor so mutual recursion is not entered:
     /// - `Local` anchor: locals (driver) first, then gists ranked on the selected local
     /// - `Gist` anchor: gists (driver) first, then locals reverse-ranked on the selected gist
-    ///
-    /// Public `ranked_gists` / `visible_locals` / `selected_*` stay pure recomputes so unit
-    /// tests keep the no-stale-cache contract; hot handlers should call this instead.
     pub fn list_pane_snapshots(&self) -> (Vec<RankedLocal>, Vec<RankedGistFile>) {
         match self.anchor {
             FocusPane::Local => {
@@ -155,5 +135,17 @@ impl AppState {
 
     pub fn selected_gist(&self) -> Option<RankedGistFile> {
         self.ranked_gists().into_iter().nth(self.gist_index)
+    }
+
+    /// Both selections from one dual-pane build. Prefer over calling
+    /// [`Self::selected_local`] and [`Self::selected_gist`] separately.
+    pub fn selected_pair(&self) -> (Option<LocalCandidate>, Option<RankedGistFile>) {
+        let (locals, gists) = self.list_pane_snapshots();
+        let local = locals
+            .into_iter()
+            .nth(self.local_index)
+            .map(|r| r.candidate);
+        let gist = gists.into_iter().nth(self.gist_index);
+        (local, gist)
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -2,7 +2,7 @@ use crate::domain::{
     group_gists, GistComment, GistFile, GistFileRef, GistGroup, GistRevision, LocalCandidate,
     PinnedMapping,
 };
-use crate::ranking::{MatchReason, RankedGistFile, RankedLocal};
+use crate::ranking::{RankedGistFile, RankedLocal};
 use anyhow::Result;
 use crossterm::{
     event::{DisableMouseCapture, EnableMouseCapture},
@@ -51,189 +51,83 @@ pub enum Screen {
     Config(Box<ConfigState>),
 }
 
+/// Tag + payload accessors for one `Screen` variant (`is_*` / `*_state` / `*_state_mut`).
+macro_rules! screen_payload {
+    ($is:ident, $variant:ident, $get:ident, $get_mut:ident, $ty:ty) => {
+        pub fn $is(&self) -> bool {
+            matches!(self, Screen::$variant(_))
+        }
+
+        pub fn $get(&self) -> Option<&$ty> {
+            match self {
+                Screen::$variant(p) => Some(p),
+                _ => None,
+            }
+        }
+
+        pub fn $get_mut(&mut self) -> Option<&mut $ty> {
+            match self {
+                Screen::$variant(p) => Some(p),
+                _ => None,
+            }
+        }
+    };
+}
+
 impl Screen {
-    /// Tag equality ignoring payloads (e.g. "are we on Help?" regardless of topic).
-    pub fn is_help(&self) -> bool {
-        matches!(self, Screen::Help(_))
-    }
-
-    pub fn is_config(&self) -> bool {
-        matches!(self, Screen::Config(_))
-    }
-
-    pub fn is_revisions(&self) -> bool {
-        matches!(self, Screen::Revisions(_))
-    }
-
-    pub fn is_pins(&self) -> bool {
-        matches!(self, Screen::Pins(_))
-    }
-
-    pub fn is_gists(&self) -> bool {
-        matches!(self, Screen::Gists(_))
-    }
-
-    pub fn is_gist_detail(&self) -> bool {
-        matches!(self, Screen::GistDetail(_))
-    }
-
-    pub fn is_palette(&self) -> bool {
-        matches!(self, Screen::Palette(_))
-    }
-
-    pub fn is_preview(&self) -> bool {
-        matches!(self, Screen::Preview(_))
-    }
-
-    pub fn is_diff(&self) -> bool {
-        matches!(self, Screen::Diff(_))
-    }
-
-    pub fn is_confirm(&self) -> bool {
-        matches!(self, Screen::Confirm(_))
-    }
-
-    /// Borrow help payload when this is [`Screen::Help`].
-    pub fn help_state(&self) -> Option<&HelpState> {
-        match self {
-            Screen::Help(h) => Some(h),
-            _ => None,
-        }
-    }
-
-    /// Mutable help payload when this is [`Screen::Help`].
-    pub fn help_state_mut(&mut self) -> Option<&mut HelpState> {
-        match self {
-            Screen::Help(h) => Some(h),
-            _ => None,
-        }
-    }
-
-    pub fn config_state(&self) -> Option<&ConfigState> {
-        match self {
-            Screen::Config(c) => Some(c.as_ref()),
-            _ => None,
-        }
-    }
-
-    pub fn config_state_mut(&mut self) -> Option<&mut ConfigState> {
-        match self {
-            Screen::Config(c) => Some(c.as_mut()),
-            _ => None,
-        }
-    }
-
-    pub fn revision_state(&self) -> Option<&RevisionState> {
-        match self {
-            Screen::Revisions(r) => Some(r.as_ref()),
-            _ => None,
-        }
-    }
-
-    pub fn revision_state_mut(&mut self) -> Option<&mut RevisionState> {
-        match self {
-            Screen::Revisions(r) => Some(r.as_mut()),
-            _ => None,
-        }
-    }
-
-    pub fn pins_state(&self) -> Option<&PinsState> {
-        match self {
-            Screen::Pins(p) => Some(p.as_ref()),
-            _ => None,
-        }
-    }
-
-    pub fn pins_state_mut(&mut self) -> Option<&mut PinsState> {
-        match self {
-            Screen::Pins(p) => Some(p.as_mut()),
-            _ => None,
-        }
-    }
-
-    pub fn gists_state(&self) -> Option<&GistsManagerState> {
-        match self {
-            Screen::Gists(g) => Some(g.as_ref()),
-            _ => None,
-        }
-    }
-
-    pub fn gists_state_mut(&mut self) -> Option<&mut GistsManagerState> {
-        match self {
-            Screen::Gists(g) => Some(g.as_mut()),
-            _ => None,
-        }
-    }
-
-    pub fn detail_state(&self) -> Option<&DetailState> {
-        match self {
-            Screen::GistDetail(d) => Some(d.as_ref()),
-            _ => None,
-        }
-    }
-
-    pub fn detail_state_mut(&mut self) -> Option<&mut DetailState> {
-        match self {
-            Screen::GistDetail(d) => Some(d.as_mut()),
-            _ => None,
-        }
-    }
-
-    pub fn palette_state(&self) -> Option<&PaletteState> {
-        match self {
-            Screen::Palette(p) => Some(p.as_ref()),
-            _ => None,
-        }
-    }
-
-    pub fn palette_state_mut(&mut self) -> Option<&mut PaletteState> {
-        match self {
-            Screen::Palette(p) => Some(p.as_mut()),
-            _ => None,
-        }
-    }
-
-    pub fn preview_state(&self) -> Option<&PreviewState> {
-        match self {
-            Screen::Preview(p) => Some(p.as_ref()),
-            _ => None,
-        }
-    }
-
-    pub fn preview_state_mut(&mut self) -> Option<&mut PreviewState> {
-        match self {
-            Screen::Preview(p) => Some(p.as_mut()),
-            _ => None,
-        }
-    }
-
-    pub fn diff_state(&self) -> Option<&DiffState> {
-        match self {
-            Screen::Diff(d) => Some(d.as_ref()),
-            _ => None,
-        }
-    }
-
-    pub fn diff_state_mut(&mut self) -> Option<&mut DiffState> {
-        match self {
-            Screen::Diff(d) => Some(d.as_mut()),
-            _ => None,
-        }
-    }
-
-    pub fn confirm_state(&self) -> Option<&ConfirmState> {
-        match self {
-            Screen::Confirm(c) => Some(c.as_ref()),
-            _ => None,
-        }
-    }
-
-    pub fn confirm_state_mut(&mut self) -> Option<&mut ConfirmState> {
-        match self {
-            Screen::Confirm(c) => Some(c.as_mut()),
-            _ => None,
-        }
-    }
+    // Tag equality ignoring payloads (e.g. "are we on Help?" regardless of topic).
+    screen_payload!(is_help, Help, help_state, help_state_mut, HelpState);
+    screen_payload!(
+        is_config,
+        Config,
+        config_state,
+        config_state_mut,
+        ConfigState
+    );
+    screen_payload!(
+        is_revisions,
+        Revisions,
+        revision_state,
+        revision_state_mut,
+        RevisionState
+    );
+    screen_payload!(is_pins, Pins, pins_state, pins_state_mut, PinsState);
+    screen_payload!(
+        is_gists,
+        Gists,
+        gists_state,
+        gists_state_mut,
+        GistsManagerState
+    );
+    screen_payload!(
+        is_gist_detail,
+        GistDetail,
+        detail_state,
+        detail_state_mut,
+        DetailState
+    );
+    screen_payload!(
+        is_palette,
+        Palette,
+        palette_state,
+        palette_state_mut,
+        PaletteState
+    );
+    screen_payload!(
+        is_preview,
+        Preview,
+        preview_state,
+        preview_state_mut,
+        PreviewState
+    );
+    screen_payload!(is_diff, Diff, diff_state, diff_state_mut, DiffState);
+    screen_payload!(
+        is_confirm,
+        Confirm,
+        confirm_state,
+        confirm_state_mut,
+        ConfirmState
+    );
 }
 
 /// Fields shown on [`Screen::Config`] in order (issue #227).
@@ -1025,7 +919,7 @@ pub struct AppState {
     /// How this binary was installed — resolved once at startup so the update hint can show
     /// the right upgrade command without per-frame IO.
     pub install_method: crate::upgrade::InstallMethod,
-    pub gist_content_cache: crate::lru::LruCache<(String, String), String>,
+    pub(crate) gist_content_cache: crate::lru::LruCache<(String, String), String>,
     pub local_recursive: bool,
     pub skip_dirs: Vec<String>,
     pub scan_depth: u32,
@@ -1931,7 +1825,7 @@ impl AppState {
                 }
             };
         }
-        let (Some(local), Some(gist)) = (self.selected_local(), self.selected_gist()) else {
+        let (Some(local), Some(gist)) = self.selected_pair() else {
             self.status = Some("select a local file and a gist to upload".into());
             return KeyOutcome::None;
         };
@@ -1975,18 +1869,16 @@ impl AppState {
     fn focused_hscroll_max(&self) -> u16 {
         let (visible_locals, ranked) = self.list_pane_snapshots();
         match self.focus {
-            FocusPane::Local => hscroll_max_among(visible_locals.iter().map(|r| {
-                marked_row_text(
-                    local_row_label(&r.candidate.path, &self.cwd),
-                    row_mark(&r.reasons),
-                )
-            })),
-            FocusPane::Gist => hscroll_max_among(ranked.iter().map(|g| {
-                marked_row_text(
-                    gist_row_display(g, self.gist_view, self),
-                    row_mark(&g.reasons),
-                )
-            })),
+            FocusPane::Local => {
+                hscroll_max_among(visible_locals.iter().map(|r| {
+                    marked_row_text(local_row_label(&r.candidate.path, &self.cwd), r.mark)
+                }))
+            }
+            FocusPane::Gist => hscroll_max_among(
+                ranked
+                    .iter()
+                    .map(|g| marked_row_text(gist_row_display(g, self.gist_view, self), g.mark)),
+            ),
         }
     }
 
@@ -2289,11 +2181,11 @@ pub fn load_startup_state(no_mouse: bool, no_update_check: bool) -> Result<AppSt
     state.syntax_highlight = std::env::var_os("NO_COLOR").is_none();
     state.config_mouse = config.mouse;
     state.no_mouse_cli = no_mouse;
-    state.mouse_enabled = crate::config::resolve_mouse_enabled(config.mouse, no_mouse);
+    // `--no-mouse` / `--no-update-check` force off; no flag forces on (edit config instead).
+    state.mouse_enabled = config.mouse && !no_mouse;
     state.config_check_updates = config.check_updates;
     state.no_update_check_cli = no_update_check;
-    state.update_check_enabled =
-        crate::config::resolve_update_check(config.check_updates, no_update_check);
+    state.update_check_enabled = config.check_updates && !no_update_check;
     // Surface a previously-seen newer release immediately (even when the daily check is
     // throttled), so the hint persists across launches without re-hitting the network.
     if state.update_check_enabled {

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -404,29 +404,11 @@ pub(super) fn footer_with_status(status: Option<&str>, hints: &str) -> (String, 
 
 pub(super) use super::text::hscroll_str;
 
-/// How a file-list row should be flagged: 📌 = an existing pinned pair; same-name = bold; else none.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum RowMark {
-    Pinned,
-    SameName,
-    None,
-}
-
-pub(super) fn row_mark(reasons: &[MatchReason]) -> RowMark {
-    if reasons.contains(&MatchReason::Pinned) {
-        RowMark::Pinned
-    } else if reasons.contains(&MatchReason::ExactFilename) {
-        RowMark::SameName
-    } else {
-        RowMark::None
-    }
-}
-
 /// Compose the full list-row string (including pin mark) that paint and hscroll max must share.
-pub(super) fn marked_row_text(base: String, mark: RowMark) -> String {
+pub(super) fn marked_row_text(base: String, mark: crate::ranking::MatchMark) -> String {
     match mark {
-        RowMark::Pinned => format!("📌 {base}"),
-        RowMark::SameName | RowMark::None => base,
+        crate::ranking::MatchMark::Pinned => format!("📌 {base}"),
+        crate::ranking::MatchMark::ExactFilename | crate::ranking::MatchMark::None => base,
     }
 }
 
@@ -659,6 +641,36 @@ pub(super) fn apply_hscroll_spans(spans: Vec<Span<'static>>, hscroll: usize) -> 
     Line::from(visible)
 }
 
+/// Word-level inline highlight for a unified-diff `-`/`+` line.
+/// `bold_tag` is the change side that gets BOLD (`Delete` for del, `Insert` for ins).
+fn inline_change_line(
+    del_line: &str,
+    ins_line: &str,
+    hscroll: usize,
+    color: Color,
+    prefix: char,
+    bold_tag: ChangeTag,
+) -> Line<'static> {
+    let del_content = del_line.get(1..).unwrap_or("");
+    let ins_content = ins_line.get(1..).unwrap_or("");
+    let mut spans = vec![Span::styled(prefix.to_string(), Style::default().fg(color))];
+    for change in TextDiff::from_words(del_content, ins_content).iter_all_changes() {
+        let tag = change.tag();
+        if tag == bold_tag {
+            spans.push(Span::styled(
+                change.value().to_string(),
+                Style::default().fg(color).add_modifier(Modifier::BOLD),
+            ));
+        } else if tag == ChangeTag::Equal {
+            spans.push(Span::styled(
+                change.value().to_string(),
+                Style::default().fg(color),
+            ));
+        }
+    }
+    apply_hscroll_spans(spans, hscroll)
+}
+
 /// Del line with word-level highlighting: changed words bold-red, unchanged words plain red.
 pub(super) fn inline_del_line(
     del_line: &str,
@@ -666,23 +678,14 @@ pub(super) fn inline_del_line(
     hscroll: usize,
     del_color: Color,
 ) -> Line<'static> {
-    let del_content = del_line.get(1..).unwrap_or("");
-    let ins_content = ins_line.get(1..).unwrap_or("");
-    let mut spans = vec![Span::styled("-", Style::default().fg(del_color))];
-    for change in TextDiff::from_words(del_content, ins_content).iter_all_changes() {
-        match change.tag() {
-            ChangeTag::Delete => spans.push(Span::styled(
-                change.value().to_string(),
-                Style::default().fg(del_color).add_modifier(Modifier::BOLD),
-            )),
-            ChangeTag::Equal => spans.push(Span::styled(
-                change.value().to_string(),
-                Style::default().fg(del_color),
-            )),
-            ChangeTag::Insert => {}
-        }
-    }
-    apply_hscroll_spans(spans, hscroll)
+    inline_change_line(
+        del_line,
+        ins_line,
+        hscroll,
+        del_color,
+        '-',
+        ChangeTag::Delete,
+    )
 }
 
 /// Ins line with word-level highlighting: changed words bold-green, unchanged words plain green.
@@ -692,23 +695,14 @@ pub(super) fn inline_ins_line(
     hscroll: usize,
     ins_color: Color,
 ) -> Line<'static> {
-    let del_content = del_line.get(1..).unwrap_or("");
-    let ins_content = ins_line.get(1..).unwrap_or("");
-    let mut spans = vec![Span::styled("+", Style::default().fg(ins_color))];
-    for change in TextDiff::from_words(del_content, ins_content).iter_all_changes() {
-        match change.tag() {
-            ChangeTag::Insert => spans.push(Span::styled(
-                change.value().to_string(),
-                Style::default().fg(ins_color).add_modifier(Modifier::BOLD),
-            )),
-            ChangeTag::Equal => spans.push(Span::styled(
-                change.value().to_string(),
-                Style::default().fg(ins_color),
-            )),
-            ChangeTag::Delete => {}
-        }
-    }
-    apply_hscroll_spans(spans, hscroll)
+    inline_change_line(
+        del_line,
+        ins_line,
+        hscroll,
+        ins_color,
+        '+',
+        ChangeTag::Insert,
+    )
 }
 
 /// Renders a `--- /+++` header line, tinting the leading `local`/`gist` keyword (yellow/blue)

--- a/src/tui/screens/config.rs
+++ b/src/tui/screens/config.rs
@@ -79,16 +79,12 @@ impl AppState {
             }
             ConfigField::Mouse => {
                 self.config_mouse = !self.config_mouse;
-                self.mouse_enabled =
-                    crate::config::resolve_mouse_enabled(self.config_mouse, self.no_mouse_cli);
+                self.mouse_enabled = self.config_mouse && !self.no_mouse_cli;
                 true
             }
             ConfigField::CheckUpdates => {
                 self.config_check_updates = !self.config_check_updates;
-                self.update_check_enabled = crate::config::resolve_update_check(
-                    self.config_check_updates,
-                    self.no_update_check_cli,
-                );
+                self.update_check_enabled = self.config_check_updates && !self.no_update_check_cli;
                 true
             }
             ConfigField::IgnoreTrailingNewline => {

--- a/src/tui/screens/list.rs
+++ b/src/tui/screens/list.rs
@@ -204,8 +204,7 @@ impl AppState {
             // (`dispatch.rs`) checks pin membership downstream and reports "pair is not
             // pinned" there. `list_guard`'s `S` case (used by the palette) is stricter.
             KeyCode::Char('S') => {
-                let (Some(local), Some(gist)) = (self.selected_local(), self.selected_gist())
-                else {
+                let (Some(local), Some(gist)) = self.selected_pair() else {
                     return KeyOutcome::None;
                 };
                 return KeyOutcome::SyncSelectedPair {
@@ -517,11 +516,10 @@ pub(crate) fn build_list_vm(state: &AppState) -> ListVm {
         local_rows = visible_locals
             .iter()
             .map(|r| {
-                let mark = crate::tui::render::row_mark(&r.reasons);
                 let base = crate::tui::text::local_row_label(&r.candidate.path, &state.cwd);
                 ListRowVm {
-                    label: crate::tui::render::marked_row_text(base, mark),
-                    mark,
+                    label: crate::tui::render::marked_row_text(base, r.mark),
+                    mark: r.mark,
                 }
             })
             .collect();
@@ -569,11 +567,10 @@ pub(crate) fn build_list_vm(state: &AppState) -> ListVm {
         gist_rows = ranked
             .iter()
             .map(|g| {
-                let mark = crate::tui::render::row_mark(&g.reasons);
                 let base = crate::tui::gist_row_display(g, state.gist_view, state);
                 ListRowVm {
-                    label: crate::tui::render::marked_row_text(base, mark),
-                    mark,
+                    label: crate::tui::render::marked_row_text(base, g.mark),
+                    mark: g.mark,
                 }
             })
             .collect();
@@ -645,11 +642,10 @@ fn list_pane_items(
             .iter()
             .map(|row| {
                 let item = ListItem::new(crate::tui::render::hscroll_str(&row.label, hscroll));
-                match row.mark {
-                    crate::tui::render::RowMark::SameName => {
-                        item.style(Style::default().add_modifier(Modifier::BOLD))
-                    }
-                    crate::tui::render::RowMark::Pinned | crate::tui::render::RowMark::None => item,
+                if matches!(row.mark, crate::ranking::MatchMark::ExactFilename) {
+                    item.style(Style::default().add_modifier(Modifier::BOLD))
+                } else {
+                    item
                 }
             })
             .collect(),

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -480,8 +480,7 @@ fn gist_row_label_switches_with_view() {
 
             node_id: None,
         },
-        score: 1,
-        reasons: Vec::new(),
+        mark: crate::ranking::MatchMark::None,
     };
     assert_eq!(
         gist_row_label(&g, GistView::Description),
@@ -571,7 +570,7 @@ fn reverse_ranking_orders_locals_by_selected_gist() {
     // The local pane reverse-ranks against the selected gist (gist_index 0).
     let visible = state.visible_locals();
     assert_eq!(visible[0].candidate.path, PathBuf::from("settings.json"));
-    assert!(visible[0].score > 0);
+    assert_ne!(visible[0].mark, crate::ranking::MatchMark::None);
 }
 
 #[test]
@@ -1185,19 +1184,11 @@ fn confirm_prompt_shows_watching_indicator_for_upload() {
 }
 
 #[test]
-fn row_mark_pinned_beats_same_name() {
-    assert_eq!(
-        row_mark(&[MatchReason::Pinned, MatchReason::ExactFilename]),
-        RowMark::Pinned
-    );
-}
-#[test]
-fn row_mark_same_name_when_exact_filename_only() {
-    assert_eq!(row_mark(&[MatchReason::ExactFilename]), RowMark::SameName);
-}
-#[test]
-fn row_mark_none_for_empty_reasons() {
-    assert_eq!(row_mark(&[]), RowMark::None);
+fn marked_row_text_uses_match_mark_pin_prefix() {
+    use crate::ranking::MatchMark;
+    assert_eq!(marked_row_text("x".into(), MatchMark::Pinned), "📌 x");
+    assert_eq!(marked_row_text("x".into(), MatchMark::ExactFilename), "x");
+    assert_eq!(marked_row_text("x".into(), MatchMark::None), "x");
 }
 
 #[test]
@@ -1219,8 +1210,7 @@ fn gist_row_label_falls_back_to_filename_when_description_empty() {
 
             node_id: None,
         },
-        score: 0,
-        reasons: Vec::new(),
+        mark: crate::ranking::MatchMark::None,
     };
     assert_eq!(gist_row_label(&g, GistView::Description), "config");
 }
@@ -1280,7 +1270,7 @@ fn gist_hscroll_caps_at_longest_row() {
     let ranked = state.ranked_gists();
     let row = marked_row_text(
         gist_row_display(&ranked[0], state.gist_view, &state),
-        row_mark(&ranked[0].reasons),
+        ranked[0].mark,
     );
     let max = super::text::hscroll_max_for_text(&row);
     for _ in 0..200 {
@@ -1325,7 +1315,7 @@ fn gist_hscroll_caps_include_star_prefix() {
         super::text::text_len(&label) + 2
     );
 
-    let row = marked_row_text(display, row_mark(&ranked[0].reasons));
+    let row = marked_row_text(display, ranked[0].mark);
     let max = super::text::hscroll_max_for_text(&row);
     let label_only_max = super::text::hscroll_max_for_text(&label);
     assert!(max > label_only_max, "star must raise the hscroll cap");
@@ -1430,8 +1420,7 @@ fn no_local_selected_lists_all_gists_unranked() {
     assert_eq!(ranked.len(), 2);
     // Order preserved (unranked) and no scoring applied.
     assert_eq!(ranked[0].file.filename, "alpha.json");
-    assert_eq!(ranked[0].score, 0);
-    assert!(ranked[0].reasons.is_empty());
+    assert_eq!(ranked[0].mark, crate::ranking::MatchMark::None);
 }
 
 #[test]

--- a/src/tui/view_model.rs
+++ b/src/tui/view_model.rs
@@ -4,8 +4,8 @@
 //! Builders never touch the filesystem or network (issues #241 / #250).
 
 use super::render::{
-    gist_info_line, gist_row_label, is_json_file, spinner_glyph, unix_now, RowMark,
-    CREATE_DESC_PREFIX, CREATE_DESC_SUFFIX,
+    gist_info_line, gist_row_label, is_json_file, spinner_glyph, unix_now, CREATE_DESC_PREFIX,
+    CREATE_DESC_SUFFIX,
 };
 use super::screens::{
     config::build_config_vm as build_config, confirm::build_confirm_vm as build_confirm,
@@ -19,7 +19,7 @@ use super::{
     AppState, DetailFocus, FocusPane, GistView, PaletteMode, PendingAction, Screen, TextInput,
 };
 use crate::domain::SyncStatus;
-use crate::ranking::RankedGistFile;
+use crate::ranking::{MatchMark, RankedGistFile};
 use ratatui::style::Color;
 
 /// Full-frame presentation contract produced by [`build_view_model`].
@@ -258,7 +258,7 @@ pub enum ListPaneEmpty {
 pub struct ListRowVm {
     /// Full row text including pin mark prefix, before horizontal scroll.
     pub label: String,
-    pub mark: RowMark,
+    pub mark: MatchMark,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -787,7 +787,7 @@ mod tests {
                     .iter()
                     .chain(list.gist.rows.iter())
                     .any(|r| {
-                        matches!(r.mark, RowMark::Pinned | RowMark::SameName)
+                        matches!(r.mark, MatchMark::Pinned | MatchMark::ExactFilename)
                             || r.label.contains('📌')
                     });
                 assert!(


### PR DESCRIPTION
## Summary
Implements #327 (ponytail audit cleanup, **self-upgrade kept**).

- Delete dead `load_cached_gists` / `save_cached_gists`, `is_empty_candidate_mode`
- Delete unused gh non-`_with` wrappers (`fetch_gist_fork_count`, fork GraphQL/of-id convenience, `fetch_gist_revision_json`)
- Ranking: shared `match_mark` + `MatchMark` (no score/`Vec<MatchReason>`); list panes go through `list_pane_snapshots`
- Inline mouse/update-check flags; drop `execute_command` alias
- Demote `LruCache` to crate-private; Screen payload accessors via macro
- Merge word-level del/ins highlight into one helper

Net ~−229 lines. Behaviour intended unchanged.

## Test plan
- [x] `mise run check` (fmt + clippy -D warnings + test + check)