### PR TITLE
chore: release v0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.1] — 2026-08-04
+
 - Starred gist rows can fully horizontal-scroll again: the scroll limit now uses the same display string as painting (including the `★ ` prefix), so the trailing characters are reachable.
 - Context menu / command palette enablement now shares its logic with the real key handlers, fixing a few spots where the two had drifted: `p` (pin) and Pins' `Enter` (diff) now correctly account for gist ownership and file previewability; Detail's `m` (load older comments) and Revisions' `F` (cycle target file) now match their real keys' focus/file-count requirements exactly; List's `S` (smart-sync) is no longer disabled for a not-yet-pinned pair (pressing it still reports "pair is not pinned" as before).
 
@@ -182,7 +184,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Off-thread loading with an on-disk cache.
 - Overwrite-confirm safety gate.
 
-[unreleased]: https://github.com/akunzai/gistui/compare/v0.17.0...HEAD
+[unreleased]: https://github.com/akunzai/gistui/compare/v0.17.1...HEAD
+[0.17.1]: https://github.com/akunzai/gistui/releases/tag/v0.17.1
 [0.17.0]: https://github.com/akunzai/gistui/releases/tag/v0.17.0
 [0.16.0]: https://github.com/akunzai/gistui/releases/tag/v0.16.0
 [0.15.2]: https://github.com/akunzai/gistui/releases/tag/v0.15.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "gistui"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gistui"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2021"
 license = "MIT"
 description = "A terminal UI for managing GitHub Gists"


### PR DESCRIPTION
## Summary

Patch release prep for **v0.17.1** (user-visible fixes only; no new features).

### Included in CHANGELOG

- **#248** — starred gist rows can fully horizontal-scroll again (`★ ` prefix counted in scroll limit).
- **#295** — context menu / command palette enablement shares guards with real key handlers (pin, Pins Enter/diff, Detail `m`, Revisions `F`, List `S`).

### Since v0.17.0 (not in user CHANGELOG)

Large internal refactor wave (ViewModel / Screen payloads / Jobs / `gh` submodules / screen colocate), dependency bumps, and docs/ADR work — all labeled `skip-changelog` or `dependencies`.

### Release checklist (after merge)

Per `RELEASING.md`:

1. CI green on `main`
2. `git tag v0.17.1 && git push origin v0.17.1`
3. Verify GitHub Release binaries, crates.io publish, Homebrew tap + Scoop bucket bumps

## Test plan

- [x] `mise run check` (fmt + clippy -D warnings + test + check)
- [x] `cargo publish --dry-run` clean for v0.17.1