### PR TITLE
chore: drop superpowers gitignore leftovers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 /target/
-.superpowers/
 # JetBrains IDE project files
 /.idea/
 # Python bytecode from the demo harness (scripts/demo/)
 __pycache__/
 *.pyc
-# Superpowers workflow artifacts (brainstorm specs / implementation plans) — kept local only
-/docs/superpowers/


### PR DESCRIPTION
## Summary

Remove Superpowers-related `.gitignore` entries now that the workflow is no longer used:

- `.superpowers/`
- `/docs/superpowers/` (and its comment)

No runtime or user-facing change.

## Also cleaned (local only, not in this PR)

- `~/.codex/config.toml`: removed disabled `superpowers@openai-curated` plugin stanza
- `~/.gemini/config/import_manifest.json`: cleared superpowers import
- Removed plugin install dirs under Gemini and Codex plugin caches

## Test plan

- [x] `rg -i superpowers` clean in gistui tracked files
- [ ] CI green