### PR TITLE
fix(tui): return to launch screen after deleting a gist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Deleting a gist from its file list view now returns to whichever screen you opened it from (Gist Manager, Pins, etc.) instead of always jumping to the main list.
+
 ## [0.17.1] — 2026-08-04
 
 - Starred gist rows can fully horizontal-scroll again: the scroll limit now uses the same display string as painting (including the `★ ` prefix), so the trailing characters are reachable.

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -18,6 +18,7 @@ Index: [`AGENTS.md`](../../AGENTS.md). Source of truth for types lives in the mo
 - Other variants (`Diff`, `Confirm`, `Preview`, `Help`, `Config`, `Revisions`, `Pins`, `Gists`, `GistDetail`, `Palette`, …) carry payloads (body/scroll/return/origin as needed).
 - **`nav_stack`** (issue #271) holds return targets; Esc pops. Prefer stack ops over parallel “return” root fields for new navigation.
 - Staged root fields (`diff_return` / `preview_return` / `staged_diff_gist` and similar) are consumed on enter only when still present.
+- **`back_to_list()` is a hard reset** (clears `nav_stack`) — reserve it for paths whose only possible origin is `Screen::List` itself. Confirm-execute paths with more than one possible origin (e.g. `ExecuteDelete`, `ExecuteCompactGist` in `dispatch.rs`) use `leave()`/`cancel_confirm()` instead, to return to whichever screen actually launched them; pop an extra time if the popped screen is now stale (e.g. `GistDetail` for a gist just deleted).
 
 ## Key path (pure intent → impure dispatch)
 

--- a/src/tui/dispatch.rs
+++ b/src/tui/dispatch.rs
@@ -324,7 +324,7 @@ pub(super) fn dispatch_outcome(
                 return Ok(LoopFlow::Proceed);
             };
             let plan = crate::actions::delete_command(&gist_id);
-            state.back_to_list();
+            state.cancel_confirm_after_delete();
 
             jobs.spawn_action(state, "Deleting gist…", move || {
                 let result = crate::actions::execute_command(&plan)

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1229,6 +1229,16 @@ impl AppState {
         self.leave();
     }
 
+    /// Leave Confirm after executing a whole-gist delete. Like [`Self::cancel_confirm`], but
+    /// pops once more if that lands on `GistDetail` — the just-deleted gist's own (now-stale)
+    /// detail view, since `GistDetail`'s delete key only ever targets itself.
+    pub fn cancel_confirm_after_delete(&mut self) {
+        self.cancel_confirm();
+        if self.screen.is_gist_detail() {
+            self.leave();
+        }
+    }
+
     pub fn upload_local_path(&self) -> Option<std::path::PathBuf> {
         match self.pending_action() {
             Some(PendingAction::Upload { local_path, .. }) => Some(local_path.clone()),

--- a/src/tui/screens/detail.rs
+++ b/src/tui/screens/detail.rs
@@ -179,7 +179,8 @@ impl AppState {
                 }
             }
             // X deletes the whole gist (y/n confirm). Reuses the shared Delete confirm path,
-            // which lands on the list once the gist is gone. Owned gists only (no-op otherwise).
+            // which returns to whichever screen opened this detail view once the gist is gone.
+            // Owned gists only (no-op otherwise).
             KeyCode::Char('X') if detail_guard(self, code) => {
                 if let Some(group) = self
                     .detail()

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -2466,6 +2466,66 @@ fn delete_confirm_y_returns_execute_delete() {
 }
 
 #[test]
+fn delete_from_list_returns_to_list() {
+    let mut state = initial_state();
+    set_pending(
+        &mut state,
+        PendingAction::Delete {
+            gist_id: "abc123".into(),
+            label: "my notes".into(),
+        },
+    );
+    assert_eq!(
+        state.handle_key(KeyCode::Char('y')),
+        KeyOutcome::ExecuteDelete
+    );
+    state.cancel_confirm_after_delete();
+    assert_eq!(state.screen, Screen::List);
+}
+
+#[test]
+fn delete_from_gist_detail_opened_via_gists_returns_to_gists() {
+    let mut state = initial_state();
+    gists_mut(&mut state);
+    state.enter(Screen::GistDetail(Box::default()));
+    detail_mut(&mut state).gist_id = Some("abc123".into());
+    set_pending(
+        &mut state,
+        PendingAction::Delete {
+            gist_id: "abc123".into(),
+            label: "my notes".into(),
+        },
+    );
+    assert_eq!(
+        state.handle_key(KeyCode::Char('y')),
+        KeyOutcome::ExecuteDelete
+    );
+    state.cancel_confirm_after_delete();
+    assert!(state.screen.is_gists());
+}
+
+#[test]
+fn delete_from_gist_detail_opened_via_pins_returns_to_pins() {
+    let mut state = initial_state();
+    pins_mut(&mut state);
+    state.enter(Screen::GistDetail(Box::default()));
+    detail_mut(&mut state).gist_id = Some("abc123".into());
+    set_pending(
+        &mut state,
+        PendingAction::Delete {
+            gist_id: "abc123".into(),
+            label: "my notes".into(),
+        },
+    );
+    assert_eq!(
+        state.handle_key(KeyCode::Char('y')),
+        KeyOutcome::ExecuteDelete
+    );
+    state.cancel_confirm_after_delete();
+    assert!(state.screen.is_pins());
+}
+
+#[test]
 fn input_line_reverses_the_char_under_the_cursor() {
     let mut input = TextInput::from("abc");
     input.left(); // ab|c → cursor on 'c'


### PR DESCRIPTION
## Summary

- `ExecuteDelete` called `state.back_to_list()` — a hard reset that clears `nav_stack` and always lands on `Screen::List` — so deleting a gist from its `GistDetail` file-list view (opened via the Gist Manager, Pins, etc.) dropped the user onto the main dual-pane screen instead of back where they came from.
- Added `AppState::cancel_confirm_after_delete()`: pops via `leave()` like `ExecuteCompactGist` already does, then pops once more if that lands on `GistDetail` — the just-deleted gist's own now-stale detail view, since `GistDetail`'s `X` key only ever deletes itself. No `gist_id` comparison needed for that reason.
- Audited every other `back_to_list()` call site and all 7 `Confirm`-execute paths (`Download`/`Upload`/`Create`/`Delete`/`RemoveFile`/`CompactGist`/`RestoreRevision`): none of the others share this bug — their only possible origin is already `Screen::List` (e.g. `ExecuteRemoveFile` is only ever staged from `Screen::List`'s dual pane, never from `GistDetail`, so its `back_to_list()` was already correct and is left untouched).
- Documented the `back_to_list()` vs `leave()`/`cancel_confirm()` convention in `docs/agents/architecture.md`'s "Screen state machine" section.

No issue filed — the fix was scoped through a design/grilling session in chat, and this PR body carries the rationale directly.

## Test plan

- [x] `mise run check` (fmt + clippy -D warnings + test + check) passes clean
- [x] New regression tests in `src/tui/tests.rs`, each tracing the resulting `Screen` after a full confirm→execute flow:
  - `delete_from_list_returns_to_list` — delete staged directly from `Screen::List` stays on `List`
  - `delete_from_gist_detail_opened_via_gists_returns_to_gists` — delete staged from `GistDetail` opened via the Gist Manager returns to `Screen::Gists`
  - `delete_from_gist_detail_opened_via_pins_returns_to_pins` — delete staged from `GistDetail` opened via Pins returns to `Screen::Pins`
- [x] Two independent rounds of `/code-review` (Standards + Spec axes) came back clean — no hard violations, no scope creep, no missing requirements