### PR TITLE
fix(tui): preserve nested diff download target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Downloading from a diff against a recursively discovered nested file now preserves that file's directory and keeps it visible after the local list refreshes.
 - Deleting a gist from its file list view now returns to whichever screen you opened it from (Gist Manager, Pins, etc.) instead of always jumping to the main list.
 
 ## [0.17.1] — 2026-08-04

--- a/src/tui/bg.rs
+++ b/src/tui/bg.rs
@@ -931,7 +931,7 @@ pub(super) fn download(state: &mut AppState, mode: crate::actions::DownloadMode)
             if state.screen.is_diff() {
                 state.leave();
             }
-            refresh_locals(state);
+            refresh_locals(state, LocalScanMode::Active, Some(&target));
         }
         Err(error) => {
             state.set_status(format!("download failed: {error}"));
@@ -940,14 +940,24 @@ pub(super) fn download(state: &mut AppState, mode: crate::actions::DownloadMode)
     }
 }
 
-/// Quick flat re-scan used after a download/upload to make the new file visible immediately.
-/// Always non-recursive since downloads only write to cwd root.
-pub(super) fn refresh_locals(state: &mut AppState) {
-    let selected = state.selected_local().map(|c| c.path.clone());
+enum LocalScanMode {
+    Flat,
+    Active,
+}
+
+/// Quick re-scan used after a download/upload to make the target visible immediately.
+fn refresh_locals(
+    state: &mut AppState,
+    scan_mode: LocalScanMode,
+    selection_target: Option<&std::path::Path>,
+) {
+    let selected = selection_target
+        .map(std::path::Path::to_path_buf)
+        .or_else(|| state.selected_local().map(|c| c.path.clone()));
     if let Ok(locals) = crate::local::discover_local_candidates(
         &state.cwd,
         &state.pinned,
-        false,
+        matches!(scan_mode, LocalScanMode::Active) && state.local_recursive,
         &state.skip_dirs,
         state.scan_depth,
     ) {
@@ -1111,7 +1121,7 @@ pub(super) fn unpin_at_pin_index(state: &mut AppState, idx: usize) {
             if let Some(pins) = state.pins_mut() {
                 pins.cursor.clamp_len(len);
             }
-            refresh_locals(state);
+            refresh_locals(state, LocalScanMode::Flat, None);
             state.set_status(format!("Unpinned {label}"));
         }
         Err(error) => state.set_status(format!("unpin failed: {error}")),
@@ -1728,7 +1738,7 @@ impl Jobs {
                                 &remote,
                                 Some(crate::domain::SyncDirection::Download),
                             );
-                            refresh_locals(state);
+                            refresh_locals(state, LocalScanMode::Active, Some(&target));
                         }
                         Err(error) => state.set_status(format!("download failed: {error}")),
                     }
@@ -2593,6 +2603,29 @@ mod tests {
     }
 
     // ---- on_download_selected -------------------------------------------------
+
+    #[test]
+    fn refresh_locals_preserves_nested_selection_in_recursive_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("nested");
+        std::fs::create_dir(&nested).unwrap();
+        let target = nested.join("settings.json");
+        std::fs::write(&target, "body").unwrap();
+        let compared = nested.join("local.json");
+        std::fs::write(&compared, "local").unwrap();
+        let mut state = initial_state();
+        state.cwd = dir.path().to_path_buf();
+        state.local_recursive = true;
+        state.locals = vec![crate::domain::LocalCandidate {
+            path: compared,
+            pinned: false,
+            modified: None,
+        }];
+
+        refresh_locals(&mut state, LocalScanMode::Active, Some(&target));
+
+        assert_eq!(state.selected_local().map(|file| file.path), Some(target));
+    }
 
     #[test]
     fn on_download_selected_err_sets_status() {

--- a/src/tui/screens/list.rs
+++ b/src/tui/screens/list.rs
@@ -287,6 +287,11 @@ impl AppState {
                     .get(self.local_index)
                     .map(|r| r.candidate.path.clone());
                 let filename = gist.file.filename.clone();
+                let target = local_path
+                    .as_deref()
+                    .and_then(std::path::Path::parent)
+                    .unwrap_or(&self.cwd)
+                    .join(&filename);
                 return KeyOutcome::PreviewDiff {
                     local_path,
                     file: crate::domain::GistFileRef::new(
@@ -294,7 +299,7 @@ impl AppState {
                         filename.clone(),
                         gist.file.raw_url.clone(),
                     ),
-                    target: self.cwd.join(&filename),
+                    target,
                     upload_orientation: self.focus == FocusPane::Local,
                 };
             }

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1746,6 +1746,23 @@ fn enter_in_gist_focus_with_selection_returns_preview() {
 }
 
 #[test]
+fn enter_with_nested_local_targets_its_directory() {
+    let mut state = state_with_selection();
+    state.cwd = PathBuf::from("/tmp");
+    state.locals[0].path = PathBuf::from("/tmp/nested/settings.json");
+
+    let KeyOutcome::PreviewDiff {
+        local_path, target, ..
+    } = state.handle_key(KeyCode::Enter)
+    else {
+        panic!("expected PreviewDiff");
+    };
+
+    assert_eq!(local_path, Some(PathBuf::from("/tmp/nested/settings.json")));
+    assert_eq!(target, PathBuf::from("/tmp/nested/settings.json"));
+}
+
+#[test]
 fn enter_in_local_focus_previews_top_gist() {
     let mut state = state_with_selection();
     state.focus = FocusPane::Local;


### PR DESCRIPTION
## Summary

- preserve the selected local file directory when opening a diff download
- refresh nested local files using the active recursive scan mode and select the downloaded target
- keep unrelated flat refresh behavior unchanged

## Verification

- `mise run check`
- `cargo run -- --check`

Closes #335