### PR TITLE
fix(tui): keep list pane title state visible when narrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Narrow List panes no longer clip the sort mode, filter, or `⚓` anchor out of their titles: the working directory gives way first and the pane name (`Local` / `Gists`) second, without leaving a dangling `·` behind.
 - Downloading from a diff against a recursively discovered nested file now preserves that file's directory and keeps it visible after the local list refreshes.
 - Deleting a gist from its file list view now returns to whichever screen you opened it from (Gist Manager, Pins, etc.) instead of always jumping to the main list.
 

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1,3 +1,4 @@
+use super::view_model::PaneTitleVm;
 use super::{
     screens::{
         config::render_config_vm as render_config, confirm::render_confirm_vm as render_confirm,
@@ -161,6 +162,135 @@ pub(super) fn count_label(shown: usize, total: usize) -> String {
     } else {
         format!("({total})")
     }
+}
+
+/// Separator between the segments of a pane title.
+const TITLE_SEP: &str = " · ";
+
+/// Shortest elided context worth painting: `…` plus at least three cells.
+const MIN_ELIDED_WIDTH: usize = 4;
+
+/// Width of `text` in terminal cells — the same measure ratatui truncates a title by, so a
+/// double-width glyph (`⚓`) is not silently clipped by the block after we let it through.
+fn cell_width(text: &str) -> usize {
+    ratatui::text::Span::raw(text).width()
+}
+
+/// Join a [`PaneTitleVm`] into at most `width` cells (issue #338) — that type documents which
+/// part gives way first.
+///
+/// A segment that does not fit is dropped whole, together with its separator and everything
+/// after it, so a narrow title never ends in a dangling `·` and never half-shows a state value.
+/// The context is appended last and is the only part that shrinks, keeping its tail behind a
+/// leading `…` — for a path, the half naming the directory.
+///
+/// Below the width the full head needs, an available `short_head` is spent — but only when the
+/// cells it frees actually buy back a state segment. Shortening the head to win nothing but a
+/// longer cwd would trade a label the user reads for context they can already see in the shell.
+pub(super) fn fit_title(title: &PaneTitleVm, width: usize) -> String {
+    let full = fit_segments(&title.segments, width);
+    let fitted = match title.short_head.as_deref() {
+        Some(short) if full.shown < title.segments.len() => {
+            let mut segments = title.segments.clone();
+            segments[0] = short.to_string();
+            let abbreviated = fit_segments(&segments, width);
+            // Ties go to the full head: same state, more of the pane's name.
+            if abbreviated.shown > full.shown {
+                abbreviated
+            } else {
+                full
+            }
+        }
+        _ => full,
+    };
+
+    let mut text = fitted.text;
+    // A head that had to be clipped has already taken the whole width; anything after it would
+    // overflow. An absent or empty context must not leave its separator behind either.
+    if fitted.shown == 0 {
+        return text;
+    }
+    let Some(context) = title.context.as_deref().filter(|c| !c.is_empty()) else {
+        return text;
+    };
+    let sep = if text.is_empty() { "" } else { TITLE_SEP };
+    let room = width.saturating_sub(fitted.used + cell_width(sep));
+    if cell_width(context) <= room {
+        text.push_str(sep);
+        text.push_str(context);
+    } else if room >= MIN_ELIDED_WIDTH {
+        text.push_str(sep);
+        text.push_str(&elide_start(context, room));
+    }
+    text
+}
+
+/// How much of `segments` fits `width`, and what that cost.
+struct FittedSegments {
+    text: String,
+    used: usize,
+    /// Segments joined whole. Fewer than `segments.len()` means state was dropped.
+    shown: usize,
+}
+
+/// Join `segments` greedily, stopping at the first one that does not fit.
+fn fit_segments(segments: &[String], width: usize) -> FittedSegments {
+    let mut text = String::new();
+    let mut used = 0usize;
+    for (i, segment) in segments.iter().enumerate() {
+        let sep = if i == 0 { "" } else { TITLE_SEP };
+        let cost = cell_width(sep) + cell_width(segment);
+        if used + cost > width {
+            // Too narrow even for the head: clip it like the block itself would, rather than
+            // painting a bare border.
+            if i == 0 {
+                text.push_str(&clip_end(segment, width));
+                used = cell_width(&text);
+            }
+            return FittedSegments {
+                text,
+                used,
+                shown: i,
+            };
+        }
+        text.push_str(sep);
+        text.push_str(segment);
+        used += cost;
+    }
+    FittedSegments {
+        text,
+        used,
+        shown: segments.len(),
+    }
+}
+
+/// `text` shortened to `room` cells by dropping its head behind a leading `…`.
+fn elide_start(text: &str, room: usize) -> String {
+    let tail_budget = room.saturating_sub(1);
+    // The leftmost byte offset whose suffix fits is the longest tail we can keep.
+    let start = text
+        .char_indices()
+        .map(|(i, _)| i)
+        .find(|&i| cell_width(&text[i..]) <= tail_budget)
+        .unwrap_or(text.len());
+    format!("…{}", &text[start..])
+}
+
+/// The longest prefix of `text` fitting `width` cells, trimmed so it cannot end in a space.
+fn clip_end(text: &str, width: usize) -> String {
+    let mut clipped = String::new();
+    let mut used = 0usize;
+    let mut buf = [0u8; 4];
+    for ch in text.chars() {
+        let cells = cell_width(ch.encode_utf8(&mut buf));
+        if used + cells > width {
+            break;
+        }
+        clipped.push(ch);
+        used += cells;
+    }
+    clipped.truncate(clipped.trim_end().len());
+    clipped
 }
 
 fn gist_badge_prefix(starred: bool, forked: bool) -> String {
@@ -1201,6 +1331,249 @@ mod tests {
         assert!(text.contains("(P)ins"));
         assert!(text.contains("(C)onfig"));
         assert!(text.contains("(?)Help"));
+    }
+
+    /// The Local pane title from the bug report, anchored and filtered.
+    fn local_title() -> PaneTitleVm {
+        let mut title = PaneTitleVm::new("[1] Local (6/15) ⚓".into());
+        title.short_head = Some("[1] (6/15) ⚓".into());
+        title.push("sort:match");
+        title.push_filter("md");
+        title.context = Some("~/code/gistui".into());
+        title
+    }
+
+    /// A sweep probe: the width at or above which `fit_title` still shows `needle`.
+    fn narrowest_width_showing(title: &PaneTitleVm, needle: &str) -> usize {
+        (0..=80)
+            .find(|&w| fit_title(title, w).contains(needle))
+            .expect("needle never appears")
+    }
+
+    /// #338 follow-up: the pane *name* is the head's cheapest part to lose — `[1]` and the
+    /// layout still say which pane this is — so a narrow title spends it on `sort:`.
+    #[test]
+    fn fit_title_drops_the_pane_name_to_keep_a_state_segment() {
+        // 26 cells: too narrow for `[1] Local (6/15) ⚓ · sort:match` (32), wide enough once
+        // the name goes.
+        assert_eq!(fit_title(&local_title(), 26), "[1] (6/15) ⚓ · sort:match");
+        assert_eq!(narrowest_width_showing(&local_title(), "sort:match"), 26);
+    }
+
+    /// The name is spent on state, never on more cwd — dropping it to widen re-derivable
+    /// context would trade something the reader needs for something they already know.
+    #[test]
+    fn fit_title_keeps_the_pane_name_when_dropping_it_buys_no_state() {
+        for width in 19..=25 {
+            let fitted = fit_title(&local_title(), width);
+            assert_eq!(fitted, "[1] Local (6/15) ⚓", "width {width}");
+        }
+        // Wide enough for everything: the name is back even though eliding it would leave
+        // room for a longer path.
+        assert!(fit_title(&local_title(), 38).starts_with("[1] Local (6/15) ⚓"));
+    }
+
+    /// Below the full head's own width the short head is a better answer than a clipped one:
+    /// a whole abbreviated head beats `[1] Local (6`.
+    #[test]
+    fn fit_title_prefers_a_whole_short_head_over_a_clipped_full_one() {
+        for width in 13..=18 {
+            assert_eq!(
+                fit_title(&local_title(), width),
+                "[1] (6/15) ⚓",
+                "width {width}"
+            );
+        }
+    }
+
+    /// A title with no short head keeps the original single-head behaviour.
+    #[test]
+    fn fit_title_without_a_short_head_is_unchanged() {
+        let mut title = local_title();
+        title.short_head = None;
+        assert_eq!(fit_title(&title, 26), "[1] Local (6/15) ⚓ · …tui");
+    }
+
+    #[test]
+    fn fit_title_joins_every_segment_when_it_fits() {
+        let full = "[1] Local (6/15) ⚓ · sort:match · /md · ~/code/gistui";
+        assert_eq!(fit_title(&local_title(), 200), full);
+        // `⚓` is two cells wide, so the exact fit is one wider than the character count.
+        assert_eq!(fit_title(&local_title(), cell_width(full)), full);
+        assert_ne!(fit_title(&local_title(), full.chars().count()), full);
+    }
+
+    /// #338: the state a keypress just changed outlives the cwd when the title is too narrow.
+    #[test]
+    fn fit_title_drops_the_cwd_before_the_state_segments() {
+        assert_eq!(
+            fit_title(&local_title(), 38),
+            "[1] Local (6/15) ⚓ · sort:match · /md"
+        );
+    }
+
+    #[test]
+    fn fit_title_elides_the_context_when_part_of_it_fits() {
+        let mut title = PaneTitleVm::new("[1] Local (6/15)".into());
+        title.push("sort:match");
+        title.context = Some("~/code/some-org/proj".into());
+        let fitted = fit_title(&title, 40);
+        assert_eq!(fitted, "[1] Local (6/15) · sort:match · …rg/proj");
+        assert_eq!(cell_width(&fitted), 40);
+    }
+
+    /// #338: only the context shrinks. A pane with none (the Gists pane) drops whole segments,
+    /// so a sort mode or filter is never half-shown — no segment here carries a `…` of its own,
+    /// so any `…` in the output could only have come from eliding one.
+    #[test]
+    fn fit_title_never_elides_a_state_segment() {
+        let mut title = PaneTitleVm::new("[2] Gists (2)".into());
+        title.push("all");
+        title.push("match");
+        title.push_filter("somequery");
+        for width in 0..60 {
+            let fitted = fit_title(&title, width);
+            assert!(
+                !fitted.contains('…'),
+                "state segment elided at width {width}: {fitted:?}"
+            );
+        }
+        assert_eq!(fit_title(&title, 24), "[2] Gists (2) · all");
+    }
+
+    #[test]
+    fn fit_title_never_ends_in_a_dangling_separator() {
+        let mut blank_context = local_title();
+        blank_context.context = Some(String::new());
+        for title in [local_title(), blank_context] {
+            for width in 0..80 {
+                let fitted = fit_title(&title, width);
+                assert!(cell_width(&fitted) <= width, "overflowed at width {width}");
+                assert!(
+                    !fitted.ends_with('·') && !fitted.ends_with(' '),
+                    "dangling separator at width {width}: {fitted:?}"
+                );
+                assert!(
+                    !fitted.starts_with('·') && !fitted.starts_with(' '),
+                    "leading separator at width {width}: {fitted:?}"
+                );
+            }
+        }
+    }
+
+    /// #338: too narrow even for the head clips it, rather than painting an empty title.
+    #[test]
+    fn fit_title_clips_the_head_when_nothing_fits() {
+        assert_eq!(fit_title(&local_title(), 0), "");
+        // Narrower than the short head too, so there is nothing left but a clipped head.
+        assert_eq!(fit_title(&local_title(), 9), "[1] Local");
+        // The anchor is two cells wide and will not split, but at 17 cells the short head
+        // fits whole — keeping the marker costs the pane name rather than the marker.
+        assert_eq!(fit_title(&local_title(), 17), "[1] (6/15) ⚓");
+    }
+
+    /// #338: the anchor lives in the head, so flipping it changes the title at every width the
+    /// head itself survives.
+    #[test]
+    fn fit_title_keeps_the_anchor_marker_at_every_width_the_head_fits() {
+        let anchored = local_title();
+        let mut plain = anchored.clone();
+        // The real builder derives both heads from the same state, so a control that strips the
+        // anchor has to strip it from the fallback too — otherwise the short head smuggles it
+        // back in at the widths where it is used.
+        plain.segments[0] = "[1] Local (6/15)".into();
+        plain.short_head = Some("[1] (6/15)".into());
+        for width in cell_width(&anchored.segments[0])..80 {
+            let with = fit_title(&anchored, width);
+            let without = fit_title(&plain, width);
+            assert!(
+                with.contains('⚓'),
+                "anchor dropped at width {width}: {with}"
+            );
+            assert!(!without.contains('⚓'), "phantom anchor at width {width}");
+        }
+    }
+
+    /// #338: in the terminal width from the bug report the Local title keeps sort / filter /
+    /// anchor and lets the cwd take the truncation, so flipping the anchor is visible on screen.
+    #[test]
+    fn render_screen_vm_list_title_keeps_state_over_cwd() {
+        let mut state = initial_state();
+        state.cwd = std::path::PathBuf::from("/cwd/some-org/some-project");
+        state.locals = vec![
+            crate::domain::LocalCandidate {
+                path: state.cwd.join("notes.md"),
+                pinned: false,
+                modified: None,
+            },
+            crate::domain::LocalCandidate {
+                path: state.cwd.join("a.txt"),
+                pinned: false,
+                modified: None,
+            },
+        ];
+        state.local_filter_query = "md".into();
+        state.anchor = FocusPane::Local;
+
+        // 137 columns as reported; the Local pane gets 40% of that.
+        let backend = TestBackend::new(137, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let vm = super::super::build_view_model(&state);
+        let mut layout = MouseLayout::default();
+        terminal
+            .draw(|frame| render_screen_vm(frame, &state, &vm.screen, &vm.chrome, &mut layout))
+            .unwrap();
+        let text = buffer_text(terminal.backend().buffer());
+
+        // A wide glyph owns two cells, so the anchor is followed by a filler cell in the dump.
+        assert!(
+            text.contains("[1] Local (1/2) ⚓"),
+            "local title missing the anchor: {text}"
+        );
+        assert!(
+            text.contains("· sort:match · /md ·"),
+            "local title missing state segments: {text}"
+        );
+        // The cwd is what shortened: only its tail survived, behind an ellipsis.
+        assert!(text.contains("…some-project"), "cwd not elided: {text}");
+    }
+
+    /// #338 follow-up: in a terminal too narrow for the full head, the pane *name* is what the
+    /// title gives up — `sort:` and the anchor survive, and `[1]` still says which pane it is.
+    #[test]
+    fn render_screen_vm_list_title_drops_the_pane_name_when_narrow() {
+        let mut state = initial_state();
+        state.cwd = std::path::PathBuf::from("/cwd/some-org/some-project");
+        state.locals = vec![crate::domain::LocalCandidate {
+            path: state.cwd.join("notes.md"),
+            pinned: false,
+            modified: None,
+        }];
+        state.anchor = FocusPane::Local;
+
+        // 70 columns: the Local pane's 40% share cannot hold `[1] Local (1) ⚓ · sort:match`.
+        let backend = TestBackend::new(70, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let vm = super::super::build_view_model(&state);
+        let mut layout = MouseLayout::default();
+        terminal
+            .draw(|frame| render_screen_vm(frame, &state, &vm.screen, &vm.chrome, &mut layout))
+            .unwrap();
+        let text = buffer_text(terminal.backend().buffer());
+
+        // A wide glyph owns two cells, so the anchor is followed by a filler cell in the dump.
+        assert!(
+            text.contains("[1] (1) ⚓"),
+            "narrow local title lost the anchor: {text}"
+        );
+        assert!(
+            text.contains("· sort:match"),
+            "narrow local title lost the sort mode: {text}"
+        );
+        assert!(
+            !text.contains("[1] Local"),
+            "pane name should have given way: {text}"
+        );
     }
 
     #[test]

--- a/src/tui/screens/list.rs
+++ b/src/tui/screens/list.rs
@@ -3,7 +3,7 @@
 
 use crate::tui::keys::{apply_filter_edit, diff_pair_previewable, point_in, FilterKey, NavAction};
 use crate::tui::view_model::{
-    ChromeVm, ListFooterVm, ListPaneEmpty, ListPaneVm, ListRowVm, ListVm,
+    ChromeVm, ListFooterVm, ListPaneEmpty, ListPaneVm, ListRowVm, ListVm, PaneTitleVm,
 };
 use crate::tui::{
     AppState, FocusPane, GistView, HelpTopic, KeyOutcome, MouseLayout, PaneHit, PendingAction,
@@ -493,6 +493,15 @@ impl AppState {
     }
 }
 
+/// The ` ⚓` suffix for whichever pane drives the match ranking, empty for the other one.
+fn anchor_marker(state: &AppState, pane: FocusPane) -> &'static str {
+    if state.anchor == pane {
+        " ⚓"
+    } else {
+        ""
+    }
+}
+
 /// List body only — usable while `state.screen` is List **or** Palette-over-List (#250).
 pub(crate) fn build_list_vm(state: &AppState) -> ListVm {
     let (visible_locals, ranked) = state.list_pane_snapshots();
@@ -532,20 +541,24 @@ pub(crate) fn build_list_vm(state: &AppState) -> ListVm {
 
     let recursive_marker = if state.local_recursive { " [↓]" } else { "" };
     let scanning_marker = if state.local_scanning { " …" } else { "" };
-    let mut local_title = format!(
-        "[1] Local {} · {}{}{} · sort:{}",
-        crate::tui::render::count_label(visible_locals.len(), state.locals.len()),
-        crate::config::display_path(&state.cwd),
-        recursive_marker,
-        scanning_marker,
-        state.local_sort.label()
-    );
-    if !state.local_filter_query.is_empty() {
-        local_title.push_str(&format!(" · /{}", state.local_filter_query));
-    }
-    if state.anchor == FocusPane::Local {
-        local_title.push_str(" · ⚓");
-    }
+    // Order per `PaneTitleVm` (#338): the anchor rides in the head so pressing `a` always shows,
+    // the state a keypress just changed follows, and the cwd is the context that gives way.
+    // The pane name is the one part of the head a reader can re-derive from `[1]` and the
+    // layout, so it is what a narrow pane gives up to keep `sort:` visible.
+    let local_head = |name: &str| {
+        format!(
+            "[1] {name}{}{}{}{}",
+            crate::tui::render::count_label(visible_locals.len(), state.locals.len()),
+            anchor_marker(state, FocusPane::Local),
+            recursive_marker,
+            scanning_marker
+        )
+    };
+    let mut local_title = PaneTitleVm::new(local_head("Local "));
+    local_title.short_head = Some(local_head(""));
+    local_title.push(format!("sort:{}", state.local_sort.label()));
+    local_title.push_filter(&state.local_filter_query);
+    local_title.context = Some(crate::config::display_path(&state.cwd));
 
     let gist_empty;
     let gist_empty_message;
@@ -581,18 +594,20 @@ pub(crate) fn build_list_vm(state: &AppState) -> ListVm {
             .collect();
     }
 
-    let mut gist_title = format!(
-        "[2] Gists {} · {} · {}",
-        crate::tui::render::count_label(ranked.len(), state.gists.len()),
-        state.gist_type_filter.label(),
-        state.gist_sort.label()
-    );
-    if !state.filter_query.is_empty() {
-        gist_title.push_str(&format!(" · /{}", state.filter_query));
-    }
-    if state.anchor == FocusPane::Gist {
-        gist_title.push_str(" · ⚓");
-    }
+    // Same order as the Local pane (#338). No re-derivable context here, so nothing is ever
+    // shortened — a segment either fits whole or is dropped.
+    let gist_head = |name: &str| {
+        format!(
+            "[2] {name}{}{}",
+            crate::tui::render::count_label(ranked.len(), state.gists.len()),
+            anchor_marker(state, FocusPane::Gist)
+        )
+    };
+    let mut gist_title = PaneTitleVm::new(gist_head("Gists "));
+    gist_title.short_head = Some(gist_head(""));
+    gist_title.push(state.gist_type_filter.label());
+    gist_title.push(state.gist_sort.label());
+    gist_title.push_filter(&state.filter_query);
 
     let footer = if state.filtering {
         let query = match state.focus {
@@ -664,13 +679,16 @@ fn list_pane_items(
 fn render_pane(
     frame: &mut Frame,
     area: ratatui::layout::Rect,
-    title: &str,
+    title: &PaneTitleVm,
     items: Vec<ListItem>,
     focused: bool,
     selected: Option<usize>,
     theme: &crate::tui::Theme,
 ) -> usize {
     let item_count = items.len();
+    // Titles sit between the two border corners; segments that do not fit are dropped here
+    // rather than clipped mid-word by the block (#338).
+    let title = crate::tui::render::fit_title(title, area.width.saturating_sub(2) as usize);
     let border_style = if focused {
         Style::default().fg(theme.accent)
     } else {
@@ -690,7 +708,7 @@ fn render_pane(
     let list = List::new(items)
         .block(
             Block::default()
-                .title(title)
+                .title(title.as_str())
                 // Pin title to theme fg so it stays legible in both dark and light modes.
                 .title_style(Style::default().fg(theme.fg))
                 .borders(Borders::ALL)
@@ -940,6 +958,68 @@ mod tests {
         if state.screen.is_confirm() {
             state.screen = Screen::List;
         }
+    }
+
+    /// #338: the Local pane title keeps the anchor in its head, puts the sort and filter next,
+    /// and hands the cwd to `context` — the only part a narrow pane shortens.
+    #[test]
+    fn local_title_puts_the_cwd_in_the_shrinkable_context() {
+        let mut state = state_with_local_paths(&["/cwd/notes.md", "/cwd/a.txt"]);
+        state.cwd = std::path::PathBuf::from("/cwd/some-org/some-project");
+        state.local_filter_query = "md".into();
+        state.anchor = FocusPane::Local;
+
+        let title = build_list_vm(&state).local.title;
+        assert_eq!(
+            title.segments,
+            vec![
+                "[1] Local (1/2) ⚓".to_string(),
+                "sort:match".to_string(),
+                "/md".to_string(),
+            ]
+        );
+        assert_eq!(
+            title.context.as_deref(),
+            Some(crate::config::display_path(&state.cwd).as_str())
+        );
+    }
+
+    /// #338: flipping the anchor must change the pane title. The marker rides in the head, so it
+    /// survives at every width the head does — `render::fit_title` owns the width side of that.
+    #[test]
+    fn anchor_key_puts_the_marker_in_the_title_head() {
+        let mut state = state_with_local_paths(&["/cwd/notes.md", "/cwd/a.txt"]);
+        state.cwd = std::path::PathBuf::from("/cwd/some-org/some-project");
+        state.local_filter_query = "md".into();
+        state.anchor = FocusPane::Gist;
+
+        let before = build_list_vm(&state).local.title;
+        state.handle_key(KeyCode::Char('a'));
+        let after = build_list_vm(&state).local.title;
+
+        assert_eq!(state.anchor, FocusPane::Local);
+        assert!(!before.segments[0].contains('⚓'), "{:?}", before.segments);
+        assert!(after.segments[0].contains('⚓'), "{:?}", after.segments);
+    }
+
+    /// #338: the Gist pane title is built from the same ordered segments, with no context.
+    #[test]
+    fn gist_title_segments_follow_the_same_order() {
+        let mut state = state_with_gists();
+        state.filter_query = "a".into();
+        state.anchor = FocusPane::Gist;
+
+        let title = build_list_vm(&state).gist.title;
+        assert_eq!(
+            title.segments,
+            vec![
+                "[2] Gists (1/2) ⚓".to_string(),
+                "all".to_string(),
+                "match".to_string(),
+                "/a".to_string(),
+            ]
+        );
+        assert_eq!(title.context, None);
     }
 
     #[test]

--- a/src/tui/view_model.rs
+++ b/src/tui/view_model.rs
@@ -234,9 +234,49 @@ pub struct ListVm {
     pub footer: ListFooterVm,
 }
 
+/// A pane title split into the parts that must survive and the one part that may shrink,
+/// joined to the pane width at paint time by `render::fit_title` (#338).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PaneTitleVm {
+    /// Joined with ` · `, most- to least-important. A segment that does not fit is dropped
+    /// whole — never half-shown — together with everything after it.
+    pub segments: Vec<String>,
+    /// Trailing re-derivable context (the Local pane's working directory). The only part that
+    /// may be shortened behind a `…`, and the first to give way when the title is too narrow.
+    pub context: Option<String>,
+    /// Abbreviated `head`, used only when spending the difference buys back a state segment
+    /// the full head would have dropped. Drop the pane's *name*, never its number, count, or
+    /// markers — the head still has to identify the pane it labels.
+    pub short_head: Option<String>,
+}
+
+impl PaneTitleVm {
+    /// A title whose first segment — pane label, count, and the markers that must never be
+    /// clipped — is `head`.
+    pub fn new(head: String) -> Self {
+        Self {
+            segments: vec![head],
+            context: None,
+            short_head: None,
+        }
+    }
+
+    /// Append one more segment, less important than everything already pushed.
+    pub fn push(&mut self, segment: impl Into<String>) {
+        self.segments.push(segment.into());
+    }
+
+    /// Append the active filter as `/query`; a blank query adds nothing.
+    pub fn push_filter(&mut self, query: &str) {
+        if !query.is_empty() {
+            self.push(format!("/{query}"));
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ListPaneVm {
-    pub title: String,
+    pub title: PaneTitleVm,
     pub focused: bool,
     pub selected: Option<usize>,
     pub empty: ListPaneEmpty,


### PR DESCRIPTION
## What

The Local pane title put the cwd before the sort mode, filter, and anchor marker, so the state a keypress had just changed was the first thing a narrow pane clipped. Pressing `a` could flip the ranking with no visible feedback at all, and truncation left a dangling separator behind.

```
before: [1] Local (6/15) · ~/code/gistui · sort:match · /md · ─╮
after:  [1] Local (6/15) ⚓ · sort:match · /md · …ode/gistui
```

## How

Titles are now built as a `PaneTitleVm`: an ordered list of segments that must survive, plus one optional trailing `context` (the cwd) that is the only part allowed to shrink. `render::fit_title` joins them to the real pane width at paint time.

- A segment that does not fit is dropped whole, with its separator — never half-shown, so a filter never degrades into `…uery` and a title never ends in a dangling `·`.
- The `⚓` anchor marker rides in the head segment, so flipping it is visible at any width the head itself survives.
- Only the cwd is elided, keeping the tail that names the directory.
- Widths are measured in terminal cells via ratatui's own `Span::width()` — `⚓` is double-width, so counting characters under-measures by one and lets the block clip it.
- The Gist pane uses the same ordering; it has no context, so nothing there is ever shortened.

### The pane name is the last thing spent

Below the width the full head needs, the head has a short form: `[1] Local (6/15) ⚓` degrades to `[1] (6/15) ⚓`. The pane number and the layout already identify the pane, so the name is the head's cheapest part to lose.

It is spent only when those cells buy back a **state** segment, never merely to show more cwd — trading a label the reader needs for context they can already see in their shell would be a bad deal. Ties go to the full head.

```
13–18  [1] (6/15) ⚓                              a whole short head beats a clipped full one
19–25  [1] Local (6/15) ⚓                        name back: dropping it buys nothing here
26–31  [1] (6/15) ⚓ · sort:match                 name spent to keep the sort mode
32–37  [1] (6/15) ⚓ · sort:match · /md           and the filter
38+    [1] Local (6/15) ⚓ · sort:match · /md …   everything fits
```

`sort:` now survives from 26 cells instead of 32, and the anchor from 13 instead of 19.

## Testing

`mise run check` — fmt, clippy `-D warnings`, 639 unit + 12 integration tests.

Coverage at three levels: `fit_title` width sweeps (0..80) asserting no overflow, no dangling separator and no elided state segment, plus the exact head chosen at each band above; view-model tests for segment order and the anchor living in the head; and `TestBackend` draws at both the 137-column width from the report and a 70-column terminal, asserting the narrow one keeps `⚓` and `sort:` while `[1] Local` is gone.

## Known limit

Below 26 cells the sort mode is still dropped — there is no room for it even with the pane name gone, and shortening `[1]` or the count would cost identity or state rather than a label. The cwd gives way first throughout, as the issue asked.

Closes #338
