### PR TITLE
feat(tui): mark clipped rows and titles with an ellipsis

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Toolchains and task wrappers live in [`mise.toml`](mise.toml); run `mise install
 
 ## Pointers
 
-- Architecture, state-machine, jobs, IO boundaries, and safety seams: `@docs/agents/architecture.md`
+- Architecture, state-machine, jobs, IO boundaries, safety seams, and truncation: `@docs/agents/architecture.md`
 - Agent-only contribution and release conventions: `@docs/agents/conventions.md`
 - Human contribution flow: `@CONTRIBUTING.md`
 - Release runbook: `@RELEASING.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Clipped list rows and pane titles now end in an ellipsis (`…`) instead of looking like the real, complete value. Truncation follows display width, so wide characters are never split.
 - Narrow List panes no longer clip the sort mode, filter, or `⚓` anchor out of their titles: the working directory gives way first and the pane name (`Local` / `Gists`) second, without leaving a dangling `·` behind.
 - Downloading from a diff against a recursively discovered nested file now preserves that file's directory and keeps it visible after the local list refreshes.
 - Deleting a gist from its file list view now returns to whichever screen you opened it from (Gist Manager, Pins, etc.) instead of always jumping to the main list.

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -44,6 +44,15 @@ handle_key (pure) → KeyOutcome → run_loop / dispatch_outcome (IO)
 - Action dispatch may call `compute_pin_sync_status` one-shot; paint uses `cached_pin_sync_status` / the VM only.
 - No mtime watch: staying on Pins after an external editor edit can leave badges stale until the next refresh.
 
+## List-row and title truncation (`@src/tui/render.rs`)
+
+Two ellipsis operations — different jobs, do not merge:
+
+- **`truncate_end`** (issue #340) — keep the head, append `…`. List rows (`visible_list_row`), pane/overlay titles (`fit_block_title`), and a `fit_title` head that itself cannot fit.
+- **`elide_start`** (issue #338) — keep the tail, leading `…`. Only `fit_title`'s trailing context (the Local pane cwd).
+
+List-row budget: inner pane width minus borders+padding (`LIST_CHROME_CELLS`) minus `LIST_HIGHLIGHT_SYMBOL`. ratatui's default `HighlightSpacing::WhenSelected` indents **every** row once any row is selected — these lists always `select(...)` when they have rows, so unselected rows still pay the `▶ ` indent. Keep the widget's `highlight_symbol` and the budget on `LIST_HIGHLIGHT_SYMBOL` so they cannot drift.
+
 ## Terminal lifecycle
 
 `run()` wraps `run_loop()` so raw mode / alternate-screen teardown **always** runs. Keep fallible startup/IO inside `run_loop`, never between `enable_raw_mode` and teardown.

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -241,10 +241,10 @@ fn fit_segments(segments: &[String], width: usize) -> FittedSegments {
         let sep = if i == 0 { "" } else { TITLE_SEP };
         let cost = cell_width(sep) + cell_width(segment);
         if used + cost > width {
-            // Too narrow even for the head: clip it like the block itself would, rather than
+            // Too narrow even for the head: clip it (marked with `…`, #340) rather than
             // painting a bare border.
             if i == 0 {
-                text.push_str(&clip_end(segment, width));
+                text.push_str(&truncate_end(segment, width));
                 used = cell_width(&text);
             }
             return FittedSegments {
@@ -273,24 +273,61 @@ fn elide_start(text: &str, room: usize) -> String {
         .map(|(i, _)| i)
         .find(|&i| cell_width(&text[i..]) <= tail_budget)
         .unwrap_or(text.len());
-    format!("…{}", &text[start..])
+    format!("{ELLIPSIS}{}", &text[start..])
 }
 
-/// The longest prefix of `text` fitting `width` cells, trimmed so it cannot end in a space.
-fn clip_end(text: &str, width: usize) -> String {
+/// Ellipsis marking that a value was clipped (issue #340). One cell in `cell_width`.
+const ELLIPSIS: &str = "…";
+
+/// Highlight prefix every row list paints (`▶` plus a space). Kept in one place so the
+/// truncation budget and the widget's `highlight_symbol` cannot drift.
+pub(super) const LIST_HIGHLIGHT_SYMBOL: &str = "▶ ";
+
+/// Borders (2) + `Padding::horizontal(1)` (2) around a list pane's inner rows.
+const LIST_CHROME_CELLS: u16 = 4;
+
+/// Width-aware end truncation (issue #340): a value that fits is returned unchanged; a
+/// value that does not is cut on a character boundary and marked with `…`. Wide glyphs
+/// are never split — a leftover cell is left empty rather than showing half a character.
+pub(super) fn truncate_end(text: &str, width: usize) -> String {
+    if cell_width(text) <= width {
+        return text.to_string();
+    }
+    if width == 0 {
+        return String::new();
+    }
+    let ellipsis_width = cell_width(ELLIPSIS);
+    if width < ellipsis_width {
+        return String::new();
+    }
+    let budget = width - ellipsis_width;
     let mut clipped = String::new();
     let mut used = 0usize;
     let mut buf = [0u8; 4];
     for ch in text.chars() {
         let cells = cell_width(ch.encode_utf8(&mut buf));
-        if used + cells > width {
+        if used + cells > budget {
             break;
         }
         clipped.push(ch);
         used += cells;
     }
     clipped.truncate(clipped.trim_end().len());
+    clipped.push_str(ELLIPSIS);
     clipped
+}
+
+/// Title sitting on a bordered block: the two corner glyphs are not available.
+pub(super) fn fit_block_title(title: &str, area_width: u16) -> String {
+    truncate_end(title, area_width.saturating_sub(2) as usize)
+}
+
+/// Visible list-row text: horizontal scroll first, then truncate to the inner content
+/// width (borders, padding, and the highlight symbol) so ratatui cannot silently clip.
+pub(super) fn visible_list_row(label: &str, hscroll: u16, pane_width: u16) -> String {
+    let inner = pane_width.saturating_sub(LIST_CHROME_CELLS) as usize;
+    let room = inner.saturating_sub(cell_width(LIST_HIGHLIGHT_SYMBOL));
+    truncate_end(&hscroll_str(label, hscroll), room)
 }
 
 fn gist_badge_prefix(starred: bool, forked: bool) -> String {
@@ -508,7 +545,7 @@ pub(super) fn render_compact_gist_bg_vm(
     frame.render_widget(
         Paragraph::new(lines).style(theme.base_style()).block(
             Block::default()
-                .title(bg.block_title.clone())
+                .title(fit_block_title(&bg.block_title, area.width))
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
                 .border_style(Style::default().fg(theme.accent))
@@ -1014,7 +1051,7 @@ pub(super) fn render_diff_pane_vm(
     theme: &Theme,
 ) {
     let block = Block::default()
-        .title(diff.title.clone())
+        .title(fit_block_title(&diff.title, area.width))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .style(theme.base_style())
@@ -1078,9 +1115,9 @@ fn centered_modal_rect(area: Rect, body: &str) -> Rect {
     }
 }
 
-fn modal_block(title: &str, border: Color, theme: &Theme) -> Block<'static> {
+fn modal_block(title: &str, area_width: u16, border: Color, theme: &Theme) -> Block<'static> {
     Block::default()
-        .title(title.to_string())
+        .title(fit_block_title(title, area_width))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(border))
@@ -1101,7 +1138,7 @@ pub(super) fn render_centered_modal(
         Paragraph::new(body.to_string())
             .style(theme.base_style())
             .wrap(Wrap { trim: true })
-            .block(modal_block(title, border, theme)),
+            .block(modal_block(title, rect.width, border, theme)),
         rect,
     );
     rect
@@ -1126,7 +1163,7 @@ pub(super) fn render_centered_modal_input(
         Paragraph::new(input_line(prefix, input, suffix))
             .style(theme.base_style())
             .wrap(Wrap { trim: true })
-            .block(modal_block(title, border, theme)),
+            .block(modal_block(title, rect.width, border, theme)),
         rect,
     );
     rect
@@ -1307,6 +1344,28 @@ mod tests {
         buffer.content().iter().map(|c| c.symbol()).collect()
     }
 
+    /// Issue #340: a value that fits, including exactly, is left untouched.
+    #[test]
+    fn truncate_end_leaves_a_fitting_value_untouched() {
+        assert_eq!(truncate_end("", 0), "");
+        assert_eq!(truncate_end("hello", 5), "hello");
+        assert_eq!(truncate_end("hello", 10), "hello");
+        assert_eq!(truncate_end("日本語", 6), "日本語");
+    }
+
+    /// Issue #340: clipping appends `…` and never splits a wide glyph.
+    #[test]
+    fn truncate_end_marks_a_clipped_value_with_an_ellipsis() {
+        assert_eq!(truncate_end("hello", 0), "");
+        assert_eq!(truncate_end("hello", 1), "…");
+        assert_eq!(truncate_end("hello", 4), "hel…");
+        // Each CJK cell is two wide; a leftover cell is not filled by splitting the next glyph.
+        assert_eq!(truncate_end("日本語テスト", 5), "日本…");
+        assert_eq!(truncate_end("日本語", 2), "…");
+        assert_eq!(truncate_end("日本語", 3), "日…");
+        assert_eq!(cell_width(&truncate_end("日本語テスト", 5)), 5);
+    }
+
     /// Builds a real `ScreenVm` from `state` (same seam `render()` uses) and paints it through
     /// `render_screen_vm` — the dispatch under test. Panics (e.g. an unreachable match arm, an
     /// out-of-bounds slice on empty data) fail the test; the returned buffer text lets callers
@@ -1423,8 +1482,8 @@ mod tests {
     }
 
     /// #338: only the context shrinks. A pane with none (the Gists pane) drops whole segments,
-    /// so a sort mode or filter is never half-shown — no segment here carries a `…` of its own,
-    /// so any `…` in the output could only have come from eliding one.
+    /// so a sort mode or filter is never half-shown. #340: a head that itself cannot fit is
+    /// marked with a trailing `…` — that is the only ellipsis this pane can produce.
     #[test]
     fn fit_title_never_elides_a_state_segment() {
         let mut title = PaneTitleVm::new("[2] Gists (2)".into());
@@ -1433,10 +1492,12 @@ mod tests {
         title.push_filter("somequery");
         for width in 0..60 {
             let fitted = fit_title(&title, width);
-            assert!(
-                !fitted.contains('…'),
-                "state segment elided at width {width}: {fitted:?}"
-            );
+            if fitted.contains('…') {
+                assert!(
+                    fitted.ends_with('…') && !fitted.contains(" · "),
+                    "state segment elided at width {width}: {fitted:?}"
+                );
+            }
         }
         assert_eq!(fit_title(&title, 24), "[2] Gists (2) · all");
     }
@@ -1462,11 +1523,12 @@ mod tests {
     }
 
     /// #338: too narrow even for the head clips it, rather than painting an empty title.
+    /// #340: that clipped head is marked with `…` so it does not read as the real value.
     #[test]
     fn fit_title_clips_the_head_when_nothing_fits() {
         assert_eq!(fit_title(&local_title(), 0), "");
         // Narrower than the short head too, so there is nothing left but a clipped head.
-        assert_eq!(fit_title(&local_title(), 9), "[1] Local");
+        assert_eq!(fit_title(&local_title(), 9), "[1] Loca…");
         // The anchor is two cells wide and will not split, but at 17 cells the short head
         // fits whole — keeping the marker costs the pane name rather than the marker.
         assert_eq!(fit_title(&local_title(), 17), "[1] (6/15) ⚓");
@@ -1573,6 +1635,128 @@ mod tests {
         assert!(
             !text.contains("[1] Local"),
             "pane name should have given way: {text}"
+        );
+    }
+
+    fn gist_file(filename: &str, description: &str) -> crate::domain::GistFile {
+        crate::domain::GistFile {
+            gist_id: "abc123def".into(),
+            description: description.into(),
+            filename: filename.into(),
+            public: false,
+            updated_at: "2024-01-01T00:00:00Z".into(),
+            created_at: "2024-01-01T00:00:00Z".into(),
+            owner_login: String::new(),
+            fork_of_id: None,
+            raw_url: None,
+            content_type: None,
+            node_id: None,
+        }
+    }
+
+    fn render_state_size(state: &AppState, width: u16, height: u16) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let vm = super::super::build_view_model(state);
+        let mut layout = MouseLayout::default();
+        terminal
+            .draw(|frame| render_screen_vm(frame, state, &vm.screen, &vm.chrome, &mut layout))
+            .unwrap();
+        buffer_text(terminal.backend().buffer())
+    }
+
+    /// Issue #340: a long gist-pane description is marked with `…` instead of reading as
+    /// the real value. Reproduces on the 137-column terminal from the report.
+    #[test]
+    fn render_screen_vm_list_row_marks_clipped_description() {
+        let mut state = initial_state();
+        state.gists = vec![gist_file(
+            "MicrosoftDateTimeJsonConverter.cs",
+            "System.Text.Json deserialize legacy JSON data TAILMARKER",
+        )];
+        let text = render_state_size(&state, 137, 20);
+        assert!(
+            text.contains("MicrosoftDateTimeJsonConverter.cs"),
+            "filename missing: {text}"
+        );
+        assert!(text.contains('…'), "clipped row has no ellipsis: {text}");
+        assert!(
+            !text.contains("TAILMARKER"),
+            "clipped tail still visible: {text}"
+        );
+    }
+
+    /// Issue #340: a wide-character filename is clipped on a character boundary, not mid-glyph.
+    #[test]
+    fn render_screen_vm_list_row_does_not_split_a_wide_character() {
+        let mut state = initial_state();
+        state.gists = vec![gist_file(
+            "日本語テストファイル名前がとても長いです.txt",
+            "desc",
+        )];
+        let text = render_state_size(&state, 80, 16);
+        assert!(text.contains('…'), "wide-char row has no ellipsis: {text}");
+        assert!(
+            !text.contains("です.txt"),
+            "wide-char tail still visible (or a split glyph leaked the suffix): {text}"
+        );
+    }
+
+    /// Issue #340: a value that fits the pane is left untouched — no ellipsis.
+    #[test]
+    fn render_screen_vm_list_row_leaves_a_fitting_label_untouched() {
+        let mut state = initial_state();
+        state.gists = vec![gist_file("a.txt", "short")];
+        let text = render_state_size(&state, 137, 20);
+        assert!(
+            text.contains("a.txt — short"),
+            "fitting label missing: {text}"
+        );
+        assert!(!text.contains('…'), "fitting label was clipped: {text}");
+    }
+
+    /// Issue #340: Gist manager rows use the same truncation as the List pane.
+    #[test]
+    fn render_screen_vm_gists_row_marks_clipped_description() {
+        let mut state = initial_state();
+        state.screen = Screen::Gists(Box::default());
+        state.gists = vec![gist_file(
+            "file.txt",
+            "a very long gist description that must not survive a narrow manager row TAILMARKER",
+        )];
+        let text = render_state_size(&state, 60, 16);
+        assert!(
+            text.contains('…'),
+            "clipped gist row has no ellipsis: {text}"
+        );
+        assert!(
+            !text.contains("TAILMARKER"),
+            "clipped gist tail still visible: {text}"
+        );
+    }
+
+    /// Issue #340: Pinned Mappings rows use the same truncation as the List pane.
+    #[test]
+    fn render_screen_vm_pins_row_marks_clipped_path() {
+        let mut state = initial_state();
+        state.screen = Screen::Pins(Box::default());
+        state.pinned = vec![crate::domain::PinnedMapping {
+            local_path: std::path::PathBuf::from(
+                "/cwd/very/deeply/nested/project/with/a/long/path/config.json",
+            ),
+            gist_id: "abc123def456".into(),
+            gist_filename: "config.json".into(),
+            direction: None,
+            last_seen_hash: None,
+        }];
+        let text = render_state_size(&state, 50, 16);
+        assert!(
+            text.contains('…'),
+            "clipped pin row has no ellipsis: {text}"
+        );
+        assert!(
+            !text.contains("config.json"),
+            "clipped pin tail still visible: {text}"
         );
     }
 

--- a/src/tui/screens/config.rs
+++ b/src/tui/screens/config.rs
@@ -204,7 +204,10 @@ pub(crate) fn render_config_vm(
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .title(" Settings ")
+        .title(crate::tui::render::fit_block_title(
+            " Settings ",
+            chunks[0].width,
+        ))
         .title_bottom(Line::from(
             " Esc close · Enter/←/→ change · saved on change ",
         ))

--- a/src/tui/screens/detail.rs
+++ b/src/tui/screens/detail.rs
@@ -721,7 +721,10 @@ fn render_detail_header_vm(
     frame.render_widget(
         Paragraph::new(lines).style(theme.base_style()).block(
             Block::default()
-                .title(detail.block_title.clone())
+                .title(crate::tui::render::fit_block_title(
+                    &detail.block_title,
+                    area.width,
+                ))
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
                 .border_style(Style::default().fg(theme.accent))
@@ -762,7 +765,10 @@ fn render_gist_file_list_vm(
     frame.render_widget(
         Paragraph::new(lines).style(theme.base_style()).block(
             Block::default()
-                .title(format!("Files ({})", files.len()))
+                .title(crate::tui::render::fit_block_title(
+                    &format!("Files ({})", files.len()),
+                    area.width,
+                ))
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
                 .border_style(Style::default().fg(theme.accent))
@@ -859,7 +865,7 @@ fn render_gist_comments_vm(
             .wrap(Wrap { trim: false })
             .block(
                 Block::default()
-                    .title(title)
+                    .title(crate::tui::render::fit_block_title(&title, area.width))
                     .borders(Borders::ALL)
                     .border_type(BorderType::Rounded)
                     .style(theme.base_style()),

--- a/src/tui/screens/gists.rs
+++ b/src/tui/screens/gists.rs
@@ -245,7 +245,13 @@ pub(crate) fn render_gists_vm(
         GistsEmptyKind::HasRows => gists
             .rows
             .iter()
-            .map(|row| ListItem::new(crate::tui::render::hscroll_str(&row.label, gists.hscroll)))
+            .map(|row| {
+                ListItem::new(crate::tui::render::visible_list_row(
+                    &row.label,
+                    gists.hscroll,
+                    chunks[0].width,
+                ))
+            })
             .collect(),
         _ => {
             let msg = gists.empty_message.clone().unwrap_or_else(|| "  ".into());
@@ -256,7 +262,10 @@ pub(crate) fn render_gists_vm(
     let list = List::new(items)
         .block(
             Block::default()
-                .title(gists.title.clone())
+                .title(crate::tui::render::fit_block_title(
+                    &gists.title,
+                    chunks[0].width,
+                ))
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
                 .border_style(Style::default().fg(state.theme.accent))
@@ -270,7 +279,7 @@ pub(crate) fn render_gists_vm(
                 .fg(state.theme.fg_on_accent)
                 .add_modifier(Modifier::BOLD),
         )
-        .highlight_symbol("▶ ");
+        .highlight_symbol(crate::tui::render::LIST_HIGHLIGHT_SYMBOL);
 
     let mut list_state = ListState::default();
     list_state.select(gists.selected);

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -427,7 +427,10 @@ pub(crate) fn render_help_vm(
             let list = List::new(list_items)
                 .block(
                     Block::default()
-                        .title("Help — pick a topic (1-9,0 / ↑↓ Enter · Esc back)")
+                        .title(crate::tui::render::fit_block_title(
+                            "Help — pick a topic (1-9,0 / ↑↓ Enter · Esc back)",
+                            area.width,
+                        ))
                         .borders(Borders::ALL)
                         .border_type(BorderType::Rounded)
                         .style(state.theme.base_style())
@@ -440,7 +443,7 @@ pub(crate) fn render_help_vm(
                         .fg(state.theme.fg_on_accent)
                         .add_modifier(Modifier::BOLD),
                 )
-                .highlight_symbol("▶ ");
+                .highlight_symbol(crate::tui::render::LIST_HIGHLIGHT_SYMBOL);
             let mut list_state = ListState::default();
             list_state.select(Some(*selected));
             frame.render_stateful_widget(list, area, &mut list_state);
@@ -485,7 +488,7 @@ pub(crate) fn render_help_vm(
                     .scroll((*scroll, 0))
                     .block(
                         Block::default()
-                            .title(title.clone())
+                            .title(crate::tui::render::fit_block_title(title, area.width))
                             .borders(Borders::ALL)
                             .border_type(BorderType::Rounded)
                             .style(state.theme.base_style())

--- a/src/tui/screens/list.rs
+++ b/src/tui/screens/list.rs
@@ -655,13 +655,16 @@ fn list_pane_items(
     pane: &ListPaneVm,
     hscroll: u16,
     theme: &crate::tui::Theme,
+    pane_width: u16,
 ) -> Vec<ListItem<'static>> {
     match pane.empty {
         ListPaneEmpty::HasRows => pane
             .rows
             .iter()
             .map(|row| {
-                let item = ListItem::new(crate::tui::render::hscroll_str(&row.label, hscroll));
+                let item = ListItem::new(crate::tui::render::visible_list_row(
+                    &row.label, hscroll, pane_width,
+                ));
                 if matches!(row.mark, crate::ranking::MatchMark::ExactFilename) {
                     item.style(Style::default().add_modifier(Modifier::BOLD))
                 } else {
@@ -719,7 +722,7 @@ fn render_pane(
         )
         .style(theme.base_style())
         .highlight_style(highlight_style)
-        .highlight_symbol("▶ ");
+        .highlight_symbol(crate::tui::render::LIST_HIGHLIGHT_SYMBOL);
 
     let mut list_state = ListState::default();
     list_state.select(selected);
@@ -781,7 +784,12 @@ pub(crate) fn render_list_vm(
         .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
         .split(chunks[0]);
 
-    let local_items = list_pane_items(&list.local, list.local_hscroll, &state.theme);
+    let local_items = list_pane_items(
+        &list.local,
+        list.local_hscroll,
+        &state.theme,
+        columns[0].width,
+    );
     let local_offset = render_pane(
         frame,
         columns[0],
@@ -798,7 +806,12 @@ pub(crate) fn render_list_vm(
         });
     }
 
-    let gist_items = list_pane_items(&list.gist, list.gist_hscroll, &state.theme);
+    let gist_items = list_pane_items(
+        &list.gist,
+        list.gist_hscroll,
+        &state.theme,
+        columns[1].width,
+    );
     let gist_offset = render_pane(
         frame,
         columns[1],

--- a/src/tui/screens/palette.rs
+++ b/src/tui/screens/palette.rs
@@ -263,7 +263,10 @@ pub(crate) fn render_palette_vm(
     frame.render_widget(
         Paragraph::new(lines).style(state.theme.base_style()).block(
             Block::default()
-                .title(palette.title)
+                .title(crate::tui::render::fit_block_title(
+                    palette.title,
+                    rect.width,
+                ))
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
                 .border_style(Style::default().fg(state.theme.accent))

--- a/src/tui/screens/pins.rs
+++ b/src/tui/screens/pins.rs
@@ -290,7 +290,11 @@ pub(crate) fn render_pins_vm(
             .rows
             .iter()
             .map(|row| {
-                let item = ListItem::new(crate::tui::render::hscroll_str(&row.label, pins.hscroll));
+                let item = ListItem::new(crate::tui::render::visible_list_row(
+                    &row.label,
+                    pins.hscroll,
+                    chunks[0].width,
+                ));
                 if row.status == crate::domain::SyncStatus::Missing {
                     item.style(Style::default().fg(state.theme.del_color))
                 } else {
@@ -303,7 +307,10 @@ pub(crate) fn render_pins_vm(
     let list = List::new(items)
         .block(
             Block::default()
-                .title(pins.title.clone())
+                .title(crate::tui::render::fit_block_title(
+                    &pins.title,
+                    chunks[0].width,
+                ))
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
                 .border_style(Style::default().fg(state.theme.accent))
@@ -317,7 +324,7 @@ pub(crate) fn render_pins_vm(
                 .fg(state.theme.fg_on_accent)
                 .add_modifier(Modifier::BOLD),
         )
-        .highlight_symbol("▶ ");
+        .highlight_symbol(crate::tui::render::LIST_HIGHLIGHT_SYMBOL);
 
     let mut list_state = ListState::default();
     list_state.select(pins.selected);

--- a/src/tui/screens/preview.rs
+++ b/src/tui/screens/preview.rs
@@ -121,7 +121,10 @@ pub(crate) fn render_preview_vm(
     // When wrapping, horizontal scroll is meaningless — pin the x offset to 0 so long lines
     // wrap into view instead of being scrolled off-screen.
     let block = Block::default()
-        .title(preview.title.clone())
+        .title(crate::tui::render::fit_block_title(
+            &preview.title,
+            chunks[0].width,
+        ))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .style(state.theme.base_style())

--- a/src/tui/screens/revisions.rs
+++ b/src/tui/screens/revisions.rs
@@ -428,7 +428,10 @@ pub(crate) fn render_revisions_vm(
     let list = List::new(items)
         .block(
             Block::default()
-                .title(revs.title.clone())
+                .title(crate::tui::render::fit_block_title(
+                    &revs.title,
+                    chunks[0].width,
+                ))
                 .borders(Borders::ALL)
                 .border_type(BorderType::Rounded)
                 .border_style(Style::default().fg(state.theme.accent))
@@ -442,7 +445,7 @@ pub(crate) fn render_revisions_vm(
                 .fg(state.theme.fg_on_accent)
                 .add_modifier(Modifier::BOLD),
         )
-        .highlight_symbol("▶ ");
+        .highlight_symbol(crate::tui::render::LIST_HIGHLIGHT_SYMBOL);
 
     let mut list_state = ListState::default();
     list_state.select(revs.selected);


### PR DESCRIPTION
## What

Clipped list rows and pane titles were cut mid-word with no sign that content was lost, so a long gist description read as if that truncated fragment were the real value. Reproduces on a 137-column terminal in the Gist pane.

```
before: MicrosoftDateTimeJsonConverter.cs — System.Text.Json deserialize legacy JSON da
after:  MicrosoftDateTimeJsonConverter.cs — System.Text.Json deserialize legacy JSON d…
```

## How

One shared helper, `render::truncate_end`, measures display width (ratatui `Span::width()`), cuts on a character boundary, and appends `…` when it clips. A value that fits, including exactly, is left untouched.

- List pane rows, Gist manager rows, and Pinned Mappings rows go through `visible_list_row` (hscroll, then truncate to the inner width minus the `▶ ` highlight indent).
- Pane and overlay titles go through `fit_block_title`. List pane titles still use #338's `fit_title`; a head that itself cannot fit now calls `truncate_end` instead of silent `clip_end`.
- #338's `elide_start` (keep the cwd tail, leading `…`) stays a separate operation.

## Testing

`mise run check` — fmt, clippy `-D warnings`, 646 unit + 12 integration tests.

Helper unit tests cover exact-fit, clip-with-ellipsis, and a wide-character case (`日本語`). `TestBackend` draws cover the 137-column gist-pane row from the report, Gist manager and Pins rows, a fitting short label (no ellipsis), and a CJK filename that must not split mid-glyph.

Closes #340