### PR TITLE
fix(tui): scroll only the selected list row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Horizontal scroll in list panes now moves only the selected row, capped to that row's content. Other rows stay readable from their start, and a leading ellipsis (`…`) marks when the selection is offset.
 - Clipped list rows and pane titles now end in an ellipsis (`…`) instead of looking like the real, complete value. Truncation follows display width, so wide characters are never split.
 - Narrow List panes no longer clip the sort mode, filter, or `⚓` anchor out of their titles: the working directory gives way first and the pane name (`Local` / `Gists`) second, without leaving a dangling `·` behind.
 - Downloading from a diff against a recursively discovered nested file now preserves that file's directory and keeps it visible after the local list refreshes.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ without resetting order. Pinned pairs show `📌`; same-filename candidates are 
 
 | Key | Action |
 |-----|--------|
-| `Tab` / `1`/`2` | switch or jump panes · `↑`/`↓` or `j`/`k` move · `PgUp`/`PgDn` or `Ctrl+b`/`Ctrl+f` page · `←`/`→` or `h`/`l` scroll a long row |
+| `Tab` / `1`/`2` | switch or jump panes · `↑`/`↓` or `j`/`k` move · `PgUp`/`PgDn` or `Ctrl+b`/`Ctrl+f` page · `←`/`→` or `h`/`l` scroll the selected long row |
 | `Enter` | diff local ↔ gist (then `d` download / `u` upload) |
 | `Space` | preview gist content (syntax-highlighted; binary blocked) |
 | `d` / `u` | download gist file / upload local file into gist |

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -51,6 +51,8 @@ Two ellipsis operations — different jobs, do not merge:
 - **`truncate_end`** (issue #340) — keep the head, append `…`. List rows (`visible_list_row`), pane/overlay titles (`fit_block_title`), and a `fit_title` head that itself cannot fit.
 - **`elide_start`** (issue #338) — keep the tail, leading `…`. Only `fit_title`'s trailing context (the Local pane cwd).
 
+List-row horizontal scroll (issue #341) is **per selected row**, not pane-wide: `row_hscroll` applies the pane offset only to the highlighted index; `focused_hscroll_max` / Pins / Gists caps are that row's painted string. A non-zero offset prefixes `…` in `visible_list_row` (then `truncate_end` may still mark a clipped tail). Unselected rows stay at column 0.
+
 List-row budget: inner pane width minus borders+padding (`LIST_CHROME_CELLS`) minus `LIST_HIGHLIGHT_SYMBOL`. ratatui's default `HighlightSpacing::WhenSelected` indents **every** row once any row is selected — these lists always `select(...)` when they have rows, so unselected rows still pay the `▶ ` indent. Keep the widget's `highlight_symbol` and the budget on `LIST_HIGHLIGHT_SYMBOL` so they cannot drift.
 
 ## Terminal lifecycle

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1554,35 +1554,41 @@ impl AppState {
         self.visible_gist_groups().into_iter().nth(idx)
     }
 
-    /// Highest horizontal-scroll offset for the gist-level view, based on its longest
-    /// visible row (mirrors `focused_hscroll_max` for the main panes).
+    /// Highest horizontal-scroll offset for the gist-level view, based on its selected
+    /// visible row (mirrors `focused_hscroll_max` for the main panes; issue #341).
     fn gists_hscroll_max(&self) -> u16 {
         let sort = self.gist_manager().map(|g| g.sort).unwrap_or_default();
-        hscroll_max_among(self.visible_gist_groups().iter().map(|g| {
-            gist_group_row_label(
-                g,
-                unix_now(),
-                sort,
-                (
-                    self.gist_comment_counts.get(&g.id).copied().unwrap_or(0),
-                    self.gist_star_counts.get(&g.id).copied().unwrap_or(0),
-                    self.gist_fork_counts.get(&g.id).copied().unwrap_or(0),
-                ),
-                self.gist_is_starred(&g.id),
-                self.current_user_login.as_deref(),
-            )
-        }))
+        let idx = self.gist_manager().map(|g| g.cursor.index).unwrap_or(0);
+        self.visible_gist_groups()
+            .get(idx)
+            .map(|g| {
+                gist_group_row_label(
+                    g,
+                    unix_now(),
+                    sort,
+                    (
+                        self.gist_comment_counts.get(&g.id).copied().unwrap_or(0),
+                        self.gist_star_counts.get(&g.id).copied().unwrap_or(0),
+                        self.gist_fork_counts.get(&g.id).copied().unwrap_or(0),
+                    ),
+                    self.gist_is_starred(&g.id),
+                    self.current_user_login.as_deref(),
+                )
+            })
+            .map(|t| hscroll_max_for_text(&t))
+            .unwrap_or(0)
     }
 
-    /// Highest horizontal-scroll offset for the Pins screen, bounded by the longest
-    /// displayed local path (the only variable-length, overflow-prone field in a pin row).
+    /// Highest horizontal-scroll offset for the Pins screen, bounded by the selected
+    /// row's displayed local path (the only variable-length, overflow-prone field).
     /// Pure helper modeled on `gists_hscroll_max`.
     fn pins_hscroll_max(&self) -> u16 {
-        hscroll_max_among(
-            self.pinned
-                .iter()
-                .map(|m| crate::config::display_path(&m.local_path)),
-        )
+        let idx = self.pins().map(|p| p.cursor.index).unwrap_or(0);
+        self.visible_pin_indices()
+            .get(idx)
+            .and_then(|&i| self.pinned.get(i))
+            .map(|m| hscroll_max_for_text(&crate::config::display_path(&m.local_path)))
+            .unwrap_or(0)
     }
 
     /// Indices into `self.pinned` that match the Pins-screen text filter, in sort order.
@@ -1870,26 +1876,24 @@ impl AppState {
         }
     }
 
-    /// Highest horizontal-scroll offset for the focused pane, based on its longest row
+    /// Highest horizontal-scroll offset for the focused pane's **selected** row
     /// (viewport width is unknown to the pure key logic, mirroring the diff scroll cap).
     ///
     /// Must measure the **same** string the list paint path draws (`gist_row_display` /
     /// local label + pin mark), not a star-less or mark-less variant — otherwise starred
     /// or pinned rows cannot scroll far enough to reveal their trailing characters (#247).
+    /// Capping to the selected row (not the longest in the pane) is issue #341.
     fn focused_hscroll_max(&self) -> u16 {
         let (visible_locals, ranked) = self.list_pane_snapshots();
-        match self.focus {
-            FocusPane::Local => {
-                hscroll_max_among(visible_locals.iter().map(|r| {
-                    marked_row_text(local_row_label(&r.candidate.path, &self.cwd), r.mark)
-                }))
-            }
-            FocusPane::Gist => hscroll_max_among(
-                ranked
-                    .iter()
-                    .map(|g| marked_row_text(gist_row_display(g, self.gist_view, self), g.mark)),
-            ),
-        }
+        let text = match self.focus {
+            FocusPane::Local => visible_locals
+                .get(self.local_index)
+                .map(|r| marked_row_text(local_row_label(&r.candidate.path, &self.cwd), r.mark)),
+            FocusPane::Gist => ranked
+                .get(self.gist_index)
+                .map(|g| marked_row_text(gist_row_display(g, self.gist_view, self), g.mark)),
+        };
+        text.map(|t| hscroll_max_for_text(&t)).unwrap_or(0)
     }
 
     fn scroll_focused_right(&mut self) {
@@ -2272,7 +2276,7 @@ use render::*;
 mod screens;
 pub use screens::detail::InitialComments;
 mod text;
-use text::{hscroll_max_among, local_row_label};
+use text::{hscroll_max_among, hscroll_max_for_text, local_row_label};
 mod bg;
 mod dispatch;
 mod keys;

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -322,12 +322,33 @@ pub(super) fn fit_block_title(title: &str, area_width: u16) -> String {
     truncate_end(title, area_width.saturating_sub(2) as usize)
 }
 
+/// Horizontal offset applied to one list row: only the selected row moves (issue #341).
+pub(super) fn row_hscroll(selected: Option<usize>, index: usize, hscroll: u16) -> u16 {
+    if selected == Some(index) {
+        hscroll
+    } else {
+        0
+    }
+}
+
 /// Visible list-row text: horizontal scroll first, then truncate to the inner content
 /// width (borders, padding, and the highlight symbol) so ratatui cannot silently clip.
+/// A non-zero offset keeps a leading `…` so the skip is visible (issue #341).
 pub(super) fn visible_list_row(label: &str, hscroll: u16, pane_width: u16) -> String {
     let inner = pane_width.saturating_sub(LIST_CHROME_CELLS) as usize;
     let room = inner.saturating_sub(cell_width(LIST_HIGHLIGHT_SYMBOL));
-    truncate_end(&hscroll_str(label, hscroll), room)
+    let scrolled = hscroll_str(label, hscroll);
+    if hscroll == 0 {
+        return truncate_end(&scrolled, room);
+    }
+    let ellipsis_width = cell_width(ELLIPSIS);
+    if room < ellipsis_width {
+        return String::new();
+    }
+    format!(
+        "{ELLIPSIS}{}",
+        truncate_end(&scrolled, room - ellipsis_width)
+    )
 }
 
 fn gist_badge_prefix(starred: bool, forked: bool) -> String {
@@ -1351,6 +1372,55 @@ mod tests {
         assert_eq!(truncate_end("hello", 5), "hello");
         assert_eq!(truncate_end("hello", 10), "hello");
         assert_eq!(truncate_end("日本語", 6), "日本語");
+    }
+
+    fn list_row_pane_width(content_cells: u16) -> u16 {
+        LIST_CHROME_CELLS + cell_width(LIST_HIGHLIGHT_SYMBOL) as u16 + content_cells
+    }
+
+    /// Issue #341: horizontal scroll is applied before end-truncation; an unscrolled
+    /// row that fits is returned unchanged.
+    #[test]
+    fn visible_list_row_leaves_an_unscrolled_value_intact() {
+        let width = list_row_pane_width(20);
+        assert_eq!(visible_list_row("AGENTS.md", 0, width), "AGENTS.md");
+    }
+
+    /// Issue #341: a horizontally offset row keeps a leading `…` so the skip is visible.
+    #[test]
+    fn visible_list_row_marks_a_horizontal_offset_with_a_leading_ellipsis() {
+        let width = list_row_pane_width(20);
+        assert_eq!(visible_list_row("AGENTS.md", 6, width), "….md");
+    }
+
+    /// Issue #341: scrolling the selected long path must not eat the start of its siblings.
+    #[test]
+    fn list_hscroll_leaves_unselected_rows_readable_from_their_start() {
+        let mut state = crate::tui::tests::state_with_local_paths(&[
+            "/cwd/AGENTS.md",
+            "/cwd/docs/adr/0001-appstate-field-visibility.md",
+            "/cwd/CHANGELOG.md",
+        ]);
+        state.focus = FocusPane::Local;
+        state.local_index = 1;
+        state.local_hscroll = 6;
+        let text = render_state(&state);
+        assert!(
+            text.contains("AGENTS.md"),
+            "unselected short row lost its start: {text}"
+        );
+        assert!(
+            text.contains("CHANGELOG.md"),
+            "unselected short row lost its start: {text}"
+        );
+        assert!(
+            text.contains("…dr/0001"),
+            "selected row must show a leading ellipsis at this offset: {text}"
+        );
+        assert!(
+            !text.contains("docs/adr/0001-appstate-field-visibility.md"),
+            "selected row should have scrolled past its head: {text}"
+        );
     }
 
     /// Issue #340: clipping appends `…` and never splits a wide glyph.

--- a/src/tui/screens/gists.rs
+++ b/src/tui/screens/gists.rs
@@ -245,10 +245,11 @@ pub(crate) fn render_gists_vm(
         GistsEmptyKind::HasRows => gists
             .rows
             .iter()
-            .map(|row| {
+            .enumerate()
+            .map(|(i, row)| {
                 ListItem::new(crate::tui::render::visible_list_row(
                     &row.label,
-                    gists.hscroll,
+                    crate::tui::render::row_hscroll(gists.selected, i, gists.hscroll),
                     chunks[0].width,
                 ))
             })

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -226,7 +226,7 @@ Navigation
   Tab        switch pane (Local / Gists)
   1 / 2      jump to the Local / Gist pane
   Up/Down    move the selection (also j / k)
-  Left/Right scroll a long row horizontally (also h / l)
+  Left/Right scroll the selected long row horizontally (also h / l)
   Ctrl+b/f   page up / down by 10 (also PageUp / PageDown)
 
 List screen
@@ -277,7 +277,7 @@ Mouse (on by default; disable with mouse = false in config or --no-mouse)
             "\
   Up/Down    move between pins (also j / k)
   PageUp/Dn  page by 10 (also Ctrl+b / Ctrl+f)
-  Left/Right scroll a long local path horizontally (also h / l; ~ = home)
+  Left/Right scroll the selected long local path horizontally (also h / l; ~ = home)
   /          filter pins by path or filename (↑↓ move · PgUp/PgDn page · Enter apply · Esc clear)
              ←/→/Home/End move the text cursor · Del deletes ahead
   o          cycle sort: default / local path / gist filename
@@ -293,7 +293,7 @@ Mouse (on by default; disable with mouse = false in config or --no-mouse)
             "\
   Up/Down    move between gists (also j / k)
   PageUp/Dn  page by 10 (also Ctrl+b / Ctrl+f)
-  Left/Right scroll a long description horizontally (also h / l)
+  Left/Right scroll the selected long description horizontally (also h / l)
   /          filter gists by description or id (↑↓ move · PgUp/PgDn page · Enter apply · Esc clear)
   s          cycle sort: updated / created
   v          cycle visibility: all / public / secret / starred / forked

--- a/src/tui/screens/list.rs
+++ b/src/tui/screens/list.rs
@@ -661,9 +661,12 @@ fn list_pane_items(
         ListPaneEmpty::HasRows => pane
             .rows
             .iter()
-            .map(|row| {
+            .enumerate()
+            .map(|(i, row)| {
                 let item = ListItem::new(crate::tui::render::visible_list_row(
-                    &row.label, hscroll, pane_width,
+                    &row.label,
+                    crate::tui::render::row_hscroll(pane.selected, i, hscroll),
+                    pane_width,
                 ));
                 if matches!(row.mark, crate::ranking::MatchMark::ExactFilename) {
                     item.style(Style::default().add_modifier(Modifier::BOLD))

--- a/src/tui/screens/pins.rs
+++ b/src/tui/screens/pins.rs
@@ -289,10 +289,11 @@ pub(crate) fn render_pins_vm(
         PinsEmptyKind::HasRows => pins
             .rows
             .iter()
-            .map(|row| {
+            .enumerate()
+            .map(|(i, row)| {
                 let item = ListItem::new(crate::tui::render::visible_list_row(
                     &row.label,
-                    pins.hscroll,
+                    crate::tui::render::row_hscroll(pins.selected, i, pins.hscroll),
                     chunks[0].width,
                 ));
                 if row.status == crate::domain::SyncStatus::Missing {

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1246,7 +1246,7 @@ fn left_right_scrolls_focused_gist_pane() {
 }
 
 #[test]
-fn gist_hscroll_caps_at_longest_row() {
+fn gist_hscroll_caps_at_painted_row() {
     let mut state = initial_state();
     state.gists = vec![GistFile {
         gist_id: "a".into(),
@@ -1277,6 +1277,106 @@ fn gist_hscroll_caps_at_longest_row() {
         state.handle_key(KeyCode::Right);
     }
     assert_eq!(state.gist_hscroll, max);
+}
+
+#[test]
+fn gist_hscroll_follows_the_selected_row() {
+    let mut state = initial_state();
+    state.gist_sort = GistSort::Name;
+    state.gists = vec![
+        GistFile {
+            gist_id: "short".into(),
+            description: "ab".into(),
+            filename: "a.txt".into(),
+            public: false,
+            updated_at: "x".into(),
+            created_at: "x".into(),
+            owner_login: String::new(),
+            fork_of_id: None,
+            raw_url: None,
+            content_type: None,
+            node_id: None,
+        },
+        GistFile {
+            gist_id: "long".into(),
+            description: "a fairly long description for scrolling".into(),
+            filename: "b.txt".into(),
+            public: false,
+            updated_at: "x".into(),
+            created_at: "x".into(),
+            owner_login: String::new(),
+            fork_of_id: None,
+            raw_url: None,
+            content_type: None,
+            node_id: None,
+        },
+    ];
+    state.focus = FocusPane::Gist;
+    let ranked = state.ranked_gists();
+    let short_max = super::text::hscroll_max_for_text(&marked_row_text(
+        gist_row_display(&ranked[0], state.gist_view, &state),
+        ranked[0].mark,
+    ));
+    let long_max = super::text::hscroll_max_for_text(&marked_row_text(
+        gist_row_display(&ranked[1], state.gist_view, &state),
+        ranked[1].mark,
+    ));
+    assert!(
+        short_max < long_max,
+        "fixture must make a.txt shorter than b.txt"
+    );
+    for _ in 0..200 {
+        state.handle_key(KeyCode::Right);
+    }
+    assert_eq!(
+        state.gist_hscroll, short_max,
+        "Right must stop at the selected row, not the longest row in the pane"
+    );
+    state.handle_key(KeyCode::Down);
+    for _ in 0..200 {
+        state.handle_key(KeyCode::Right);
+    }
+    assert_eq!(state.gist_hscroll, long_max);
+    state.handle_key(KeyCode::Up);
+    assert_eq!(state.gist_index, 0);
+    assert!(
+        state.gist_hscroll <= short_max,
+        "selected row must not stay scrolled past its own content (hscroll {}, max {})",
+        state.gist_hscroll,
+        short_max
+    );
+}
+
+#[test]
+fn local_hscroll_caps_at_selected_row_not_the_longest() {
+    let mut state = state_with_local_paths(&[
+        "/cwd/ab.txt",
+        "/cwd/a-fairly-long-filename-for-scrolling.md",
+    ]);
+    state.focus = FocusPane::Local;
+    state.local_index = 0;
+    let locals = state.visible_locals();
+    let short_row = marked_row_text(
+        super::text::local_row_label(&locals[0].candidate.path, &state.cwd),
+        locals[0].mark,
+    );
+    let long_row = marked_row_text(
+        super::text::local_row_label(&locals[1].candidate.path, &state.cwd),
+        locals[1].mark,
+    );
+    let short_max = super::text::hscroll_max_for_text(&short_row);
+    let long_max = super::text::hscroll_max_for_text(&long_row);
+    assert!(
+        short_max < long_max,
+        "fixture must make the selected row shorter than its sibling"
+    );
+    for _ in 0..200 {
+        state.handle_key(KeyCode::Right);
+    }
+    assert_eq!(
+        state.local_hscroll, short_max,
+        "Right must stop at the selected local row, not the longest row in the pane"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Horizontal scroll in the Local and Gist list panes (and the Pins / Gists manager lists that share the same paint helper) now offsets only the selected row.

- Other rows stay readable from their start.
- The offset is capped to the selected row's painted string, not the longest row in the pane.
- Moving onto a shorter row cannot leave that row scrolled past its own content (existing vertical-move reset, plus the new per-row cap).
- A leading `…` marks when the selected row is horizontally offset.

## Test plan

- [x] `mise run check` (`fmt`, `clippy -D warnings`, `cargo test --locked`, `cargo check`)
- [x] Unit tests for selected-row caps on both list panes, leftover offset after moving to a shorter row, leading-ellipsis paint, and a rendered list that keeps unselected names intact

Closes #341