### PR TITLE
fix(tui): distinguish light theme pane focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Light theme now clearly distinguishes focused-pane and inactive-pane borders, and keeps the diff `gist` label distinct from subdued text.
 - Narrow terminals (down to 80 columns) no longer clip the `?` help body mid-word, cut a footer hint in half (the leave key stays; whole hints drop instead), or drop the hanging indent of wrapped gist comments.
 - Horizontal scroll in list panes now moves only the selected row, capped to that row's content. Other rows stay readable from their start, and a leading ellipsis (`…`) marks when the selection is offset.
 - Clipped list rows and pane titles now end in an ellipsis (`…`) instead of looking like the real, complete value. Truncation follows display width, so wide characters are never split.

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1034,6 +1034,15 @@ fn header_line_tints_local_yellow_and_gist_blue() {
 }
 
 #[test]
+fn light_theme_keeps_focus_and_diff_header_colours_distinct() {
+    let theme = Theme::LIGHT;
+
+    assert_ne!(theme.accent, theme.dim);
+    assert_ne!(theme.accent, theme.gist_label_color);
+    assert_ne!(theme.dim, theme.gist_label_color);
+}
+
+#[test]
 fn preview_diff_text_flips_with_focus() {
     // Download orientation (gist pane focused): old = local, new = gist.
     let dl = preview_diff_text(false, "local: a", "old\n", "gist b", "new\n", false);

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -92,7 +92,9 @@ impl Theme {
     pub const LIGHT: Theme = Theme {
         bg: Color::Gray, // ANSI 7 — light-grey canvas
         fg: Color::Black,
-        accent: Color::DarkGray, // ANSI 8 — selection bar, focused borders
+        // Fixed dark shades keep the focused border and selection bar distinct from dimmed
+        // chrome on the light-grey canvas (bright ANSI hues can be terminal-dependent here).
+        accent: Color::Indexed(24), // #005f87 dark blue — focused borders, selection bar
         fg_on_accent: Color::White,
         dim: Color::DarkGray,
         // Bright ANSI Green / Blue wash out on the grey canvas; pin a fixed dark navy
@@ -101,7 +103,7 @@ impl Theme {
         write_color: Color::Indexed(20),
         ins_color: Color::Indexed(20),
         del_color: Color::Indexed(124), // #af0000 dark red — bright ANSI red is too light here
-        gist_label_color: Color::DarkGray,
+        gist_label_color: Color::Indexed(19), // #0000af dark navy — diff gist header label
         notice_color: Color::Indexed(94), // #875f00 dark amber
         syntax: SyntaxPalette::LIGHT,
     };


### PR DESCRIPTION
## Summary
- give focused light-theme chrome a dark-blue accent distinct from dimmed borders
- give light-theme diff gist headers a distinct dark-navy label
- add a regression test for the three semantic colours

## Verification
- `mise run check`

Closes #339