### PR TITLE
feat(tui): add contextual hints to key-dense screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- List, Pinned Mappings, and Gist manager now show contextual action hints; Pinned Mappings also explains its sync-status glyphs in the footer.
 - Light theme now clearly distinguishes focused-pane and inactive-pane borders, and keeps the diff `gist` label distinct from subdued text.
 - Narrow terminals (down to 80 columns) no longer clip the `?` help body mid-word, cut a footer hint in half (the leave key stays; whole hints drop instead), or drop the hanging indent of wrapped gist comments.
 - Horizontal scroll in list panes now moves only the selected row, capped to that row's content. Other rows stay readable from their start, and a leading ellipsis (`…`) marks when the selection is offset.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ without resetting order. Pinned pairs show `📌`; same-filename candidates are 
 
 Press **`?`** anytime for the **full, contextual keymap** — it opens the current screen's
 topic; `Tab` browses all topics (List, Pins, Gist manager, Settings, …).
-The idle footer shows `; Menu · Ctrl+p Palette`; every screen also shows a
+Idle footers show contextual screen actions; every screen also shows a
 `(G)ists (P)ins (C)onfig (?)Help` shortcut bar in the top-right corner (click, or use the
 underlying key). Press `;` (or right-click) for a context menu of actions valid on
 the current screen and selection; press `Ctrl+p` for the full command palette with

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -793,8 +793,9 @@ pub(super) fn footer_height(text: &str, width: u16, title: &str, colored: bool) 
 /// whole label words so e.g. `pins` does not read as the `pin` action.
 pub(super) fn action_color(label: &str, theme: &Theme) -> Color {
     const DESTRUCTIVE: [&str; 3] = ["delete", "remove", "unpin"];
-    const WRITE: [&str; 10] = [
+    const WRITE: [&str; 11] = [
         "download", "upload", "create", "new", "sync", "push", "pull", "pin", "edit", "desc",
+        "star",
     ];
     let mut color = theme.accent;
     for word in label.split_whitespace() {
@@ -2202,6 +2203,22 @@ mod tests {
                 "mid-hint clip in narrow diff footer ({item:?}): {footer:?}"
             );
         }
+    }
+
+    #[test]
+    fn key_dense_screen_footers_keep_whole_hints_at_eighty_columns() {
+        let mut list = initial_state();
+        let list_text = render_rows(&list, 80, 24).join("\n");
+        assert!(list_text.contains("Enter diff") && list_text.contains("Esc/q back"));
+
+        let mut pins = initial_state();
+        pins.screen = Screen::Pins(Box::default());
+        let pins_text = render_rows(&pins, 80, 24).join("\n");
+        assert!(pins_text.contains("✓ synced") && pins_text.contains("Esc/q back"));
+
+        list.screen = Screen::Gists(Box::default());
+        let gists_text = render_rows(&list, 80, 24).join("\n");
+        assert!(gists_text.contains("Enter detail") && gists_text.contains("Esc/q back"));
     }
 
     /// Issue #342: a wrapped comment continuation keeps the source line's indent.

--- a/src/tui/screens/gists.rs
+++ b/src/tui/screens/gists.rs
@@ -13,6 +13,7 @@ use ratatui::{
 };
 
 pub(crate) const HELP_TOPIC: HelpTopic = HelpTopic::GistManager;
+const GISTS_HINTS: &str = "↑↓ move  ·  Enter detail  ·  * star  ·  o browser  ·  y copy URL  ·  H revisions  ·  s sort  ·  v visibility  ·  / filter  ·  Esc/q back";
 
 pub(crate) fn help_topic() -> HelpTopic {
     HELP_TOPIC
@@ -148,7 +149,7 @@ pub(crate) fn build_gists_vm(state: &AppState) -> GistsVm {
         )
     } else {
         let (footer, colored) =
-            crate::tui::footer_with_status(state.status.as_deref(), crate::tui::MINIMAL_HINT);
+            crate::tui::footer_with_status(state.status.as_deref(), GISTS_HINTS);
         (String::new(), footer, colored)
     };
 

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -230,6 +230,7 @@ Navigation
   Ctrl+b/f   page up / down by 10 (also PageUp / PageDown)
 
 List screen
+  Footer     shows the primary screen actions; narrow terminals keep whole hints and the leave key
   r          toggle recursive file discovery (skips hidden + configured dirs)
   /          filter the focused pane (Local = path/filename, Gist = description/id)
              while filtering: type to match · ↑↓ move · PgUp/PgDn page · Tab apply + switch pane
@@ -274,8 +275,7 @@ Mouse (on by default; disable with mouse = false in config or --no-mouse)
   ; / Ctrl+p   open the menu / command palette from the keyboard (see General)"
         }
         HelpTopic::Pins => {
-            "\
-  Up/Down    move between pins (also j / k)
+            r#"  Up/Down    move between pins (also j / k)
   PageUp/Dn  page by 10 (also Ctrl+b / Ctrl+f)
   Left/Right scroll the selected long local path horizontally (also h / l; ~ = home)
   /          filter pins by path or filename (↑↓ move · PgUp/PgDn page · Enter apply · Esc clear)
@@ -286,11 +286,13 @@ Mouse (on by default; disable with mouse = false in config or --no-mouse)
   u          force push  (upload local → gist)
   d          force pull  (download gist → local, diff + y/n confirm)
   x          unpin the selected pair
+  Footer     shows sync actions; the status row explains the glyphs
   status     ✓ synced · ↑ local newer · ↓ remote newer · ✕ missing · ? unknown
-  Each row shows (local <age> · gist <age>) relative modification times."
+  Each row shows (local <age> · gist <age>) relative modification times.
+"#
         }
         HelpTopic::GistManager => {
-            "\
+            r#"  Footer     shows the primary screen actions; narrow terminals keep whole hints and the leave key
   Up/Down    move between gists (also j / k)
   PageUp/Dn  page by 10 (also Ctrl+b / Ctrl+f)
   Left/Right scroll the selected long description horizontally (also h / l)
@@ -305,7 +307,8 @@ Mouse (on by default; disable with mouse = false in config or --no-mouse)
   q / Esc    back to the list
              (edit description, compact, delete: gist detail only, owned gists)
   Rows show ☆ N (stargazers), ⑂ N (forks), 💬 N (comments) when non-zero;
-  ★ prefix = you starred it; ⑂ prefix = this gist is a fork."
+  ★ prefix = you starred it; ⑂ prefix = this gist is a fork.
+"#
         }
         HelpTopic::GistDetail => {
             "\
@@ -537,6 +540,28 @@ mod tests {
     use crate::tui::*;
 
     use crate::tui::tests::{help_mut, help_ref, state_with_gists};
+
+    #[test]
+    fn footer_help_rows_align_with_the_key_column() {
+        let pins = help_topic_body(HelpTopic::Pins);
+        let legend = "✓ synced · ↑ local newer · ↓ remote newer · ✕ missing · ? unknown";
+        assert_eq!(pins.matches(legend).count(), 1);
+
+        let pin_lines: Vec<_> = pins.lines().collect();
+        let footer = pin_lines
+            .iter()
+            .position(|line| {
+                *line == "  Footer     shows sync actions; the status row explains the glyphs"
+            })
+            .expect("Pins footer");
+        let status = pin_lines
+            .iter()
+            .position(|line| line.starts_with("  status"))
+            .expect("Pins status");
+        assert_eq!(footer + 1, status);
+
+        assert!(help_topic_body(HelpTopic::GistManager).starts_with("  Footer"));
+    }
 
     #[test]
     fn help_topic_view_tab_opens_index_at_current_topic() {

--- a/src/tui/screens/list.rs
+++ b/src/tui/screens/list.rs
@@ -12,6 +12,7 @@ use crate::tui::{
 use crossterm::event::KeyCode;
 
 pub(crate) const HELP_TOPIC: HelpTopic = HelpTopic::List;
+const LIST_HINTS: &str = "↑↓ move  ·  Tab panes  ·  Enter diff  ·  d download  ·  u upload  ·  n new gist  ·  p pin  ·  P pins  ·  g gists  ·  / filter  ·  Esc/q back";
 
 pub(crate) fn help_topic() -> HelpTopic {
     HELP_TOPIC
@@ -624,7 +625,7 @@ pub(crate) fn build_list_vm(state: &AppState) -> ListVm {
         }
     } else {
         ListFooterVm::Hints {
-            text: crate::tui::MINIMAL_HINT.to_string(),
+            text: LIST_HINTS.to_string(),
         }
     };
 

--- a/src/tui/screens/pins.rs
+++ b/src/tui/screens/pins.rs
@@ -13,6 +13,9 @@ use ratatui::{
 };
 
 pub(crate) const HELP_TOPIC: HelpTopic = HelpTopic::Pins;
+const PINS_HINTS: &str = "↑↓ move  ·  Enter diff  ·  s sync  ·  u push  ·  d pull  ·  x unpin  ·  o sort  ·  / filter  ·  Esc/q back";
+const PINS_STATUS_LEGEND: &str =
+    "✓ synced · ↑ local newer · ↓ remote newer · ✕ missing · ? unknown";
 
 pub(crate) fn help_topic() -> HelpTopic {
     HELP_TOPIC
@@ -179,9 +182,8 @@ pub(crate) fn build_pins_vm(state: &AppState) -> PinsVm {
             false,
         )
     } else {
-        let (footer, colored) =
-            crate::tui::footer_with_status(state.status.as_deref(), crate::tui::MINIMAL_HINT);
-        (String::new(), footer, colored)
+        let (footer, colored) = crate::tui::footer_with_status(state.status.as_deref(), PINS_HINTS);
+        (PINS_STATUS_LEGEND.to_string(), footer, colored)
     };
 
     let visible = state.visible_pin_indices();

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -420,6 +420,7 @@ fn action_color_matches_whole_words_only() {
     );
     assert_eq!(action_color("remove file", &Theme::DARK), Color::Red);
     assert_eq!(action_color("pin", &Theme::DARK), Color::Green);
+    assert_eq!(action_color("star", &Theme::DARK), Color::Green);
 }
 
 #[test]

--- a/src/tui/view_model.rs
+++ b/src/tui/view_model.rs
@@ -865,6 +865,33 @@ mod tests {
     }
 
     #[test]
+    fn key_dense_screens_expose_contextual_action_hints() {
+        let mut state = initial_state();
+        let ScreenVm::List(list) = build_view_model(&state).screen else {
+            panic!("expected List");
+        };
+        let ListFooterVm::Hints { text } = list.footer else {
+            panic!("expected List hints");
+        };
+        assert!(text.contains("Enter diff") && text.contains("d download"));
+
+        state.screen = Screen::Pins(Box::default());
+        let ScreenVm::Pins(pins) = build_view_model(&state).screen else {
+            panic!("expected Pins");
+        };
+        assert!(pins.footer.contains("s sync") && pins.footer.contains("x unpin"));
+        assert!(
+            pins.footer_title.contains("✓ synced") && pins.footer_title.contains("↓ remote newer")
+        );
+
+        state.screen = Screen::Gists(Box::default());
+        let ScreenVm::Gists(gists) = build_view_model(&state).screen else {
+            panic!("expected Gists");
+        };
+        assert!(gists.footer.contains("Enter detail") && gists.footer.contains("H revisions"));
+    }
+
+    #[test]
     fn gists_vm_empty_and_rows() {
         use crate::domain::GistFile;
 


### PR DESCRIPTION
## Summary
- replace idle minimal footers on List, Pins, and Gist manager with contextual action hints
- add an on-screen Pins sync-status legend
- preserve whole-hint narrowing and classify star as a write action

## Verification
- `mise run check`
- standards/spec review: no remaining findings

Closes #343