### PR TITLE
fix(local): include dotfiles in recursive scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Recursive file discovery now includes hidden files and directories like the flat view, skips only configured directories plus `.git`, `.hg`, and `.svn`, and collapses symlink aliases without losing pinned paths.
 - Help's topic index now gives General a working `g` shortcut, keeps every shortcut to one key, and aligns topic names.
 - List, Pinned Mappings, and Gist manager now show contextual action hints; Pinned Mappings also explains its sync-status glyphs in the footer.
 - Light theme now clearly distinguishes focused-pane and inactive-pane borders, and keeps the diff `gist` label distinct from subdued text.

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ pin a file or toggle the theme with `T`. All fields are optional.
 | `mouse` | `bool` | Enable mouse support (wheel scroll, click/double-click, close button). Default `true`; `--no-mouse` forces it off for one session. |
 | `check_updates` | `bool` | Check GitHub once a day on startup for a newer release and surface it on the `?` Help → About topic. Default `true`; `--no-update-check` forces it off for one session. |
 | `ignore_trailing_newline` | `bool` | Treat a difference that is *only* a file-final newline as no change in the diff view and the overwrite-confirm gate. Default `true`; set `false` for strict, byte-exact diffs. |
-| `skip_dirs` | `[string]` | Directory names skipped during recursive discovery (`r` key). Defaults to common build/dependency dirs (`node_modules`, `target`, …). Hidden dirs (`.`-prefix) are always skipped. |
+| `skip_dirs` | `[string]` | Directory names skipped during recursive discovery (`r` key). Defaults to common build/dependency dirs (`node_modules`, `target`, …). Hidden files and directories are included; `.git`, `.hg`, and `.svn` are always skipped. |
 | `[[pinned]]` | `table array` | Local-file ↔ gist mappings managed by the `p`/`P` keys. Can also be edited by hand. |
 
 Copy [`config.example.toml`](config.example.toml) from the repo for an annotated

--- a/config.example.toml
+++ b/config.example.toml
@@ -35,8 +35,8 @@ check_updates = true
 ignore_trailing_newline = true
 
 # Directories skipped when recursive local file discovery is active (r key).
-# Hidden directories (names starting with ".") are always skipped regardless
-# of this list. Add project-specific build output dirs here as needed.
+# Hidden directories are included unless listed here. Git metadata directories
+# (.git, .hg, .svn) are always skipped. Add project-specific output dirs here.
 skip_dirs = [
   "node_modules",
   "target",       # Rust

--- a/src/local.rs
+++ b/src/local.rs
@@ -1,14 +1,18 @@
 use crate::domain::{LocalCandidate, PinnedMapping};
 use anyhow::Result;
+use std::collections::BTreeMap;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+const VCS_METADATA_DIRS: [&str; 3] = [".git", ".hg", ".svn"];
 
 /// Lists local file candidates under `cwd`.
 ///
 /// When `recursive` is false only the immediate children of `cwd` are
 /// returned (original behaviour). When `recursive` is true the tree is
-/// walked up to 10 levels deep; hidden directories (name starts with `.`)
-/// and names in `skip_dirs` are skipped.
+/// walked up to `max_depth`; only version-control metadata and names in
+/// `skip_dirs` are skipped. Paths resolving to the same file collapse to one
+/// candidate, preferring a pinned path, then the shallowest path.
 /// File modification time as Unix seconds, or `None` when it can't be read
 /// (missing file, permission error, or a pre-epoch timestamp).
 pub fn file_mtime_secs(path: &Path) -> Option<u64> {
@@ -39,8 +43,10 @@ pub fn discover_local_candidates(
         }
     }
 
+    if recursive {
+        paths = deduplicate_resolved_paths(paths, cwd, pinned);
+    }
     paths.sort();
-    paths.dedup();
 
     Ok(paths
         .into_iter()
@@ -72,11 +78,8 @@ fn walk_recursive(
     for entry in entries.filter_map(|e| e.ok()) {
         let path = entry.path();
         let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-        if name.starts_with('.') {
-            continue;
-        }
         if path.is_dir() {
-            if skip_dirs.iter().any(|d| d == name) {
+            if VCS_METADATA_DIRS.contains(&name) || skip_dirs.iter().any(|d| d == name) {
                 continue;
             }
             walk_recursive(&path, paths, depth + 1, skip_dirs, max_depth);
@@ -84,6 +87,47 @@ fn walk_recursive(
             paths.push(path);
         }
     }
+}
+
+fn deduplicate_resolved_paths(
+    paths: Vec<PathBuf>,
+    cwd: &Path,
+    pinned: &[PinnedMapping],
+) -> Vec<PathBuf> {
+    let mut paths_by_target: BTreeMap<PathBuf, Vec<PathBuf>> = BTreeMap::new();
+
+    for path in paths {
+        let target = fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+        paths_by_target.entry(target).or_default().push(path);
+    }
+
+    paths_by_target
+        .into_values()
+        .map(|aliases| {
+            aliases
+                .into_iter()
+                .min_by(|left, right| {
+                    path_priority(left, cwd, pinned).cmp(&path_priority(right, cwd, pinned))
+                })
+                .expect("each target has at least one path")
+        })
+        .collect()
+}
+
+fn path_priority<'a>(
+    path: &'a Path,
+    cwd: &Path,
+    pinned: &[PinnedMapping],
+) -> (bool, usize, &'a Path) {
+    (
+        !pinned.iter().any(|mapping| mapping.local_path == path),
+        path_depth(path, cwd),
+        path,
+    )
+}
+
+fn path_depth(path: &Path, cwd: &Path) -> usize {
+    path.strip_prefix(cwd).unwrap_or(path).components().count()
 }
 
 #[cfg(test)]
@@ -185,18 +229,104 @@ mod tests {
     }
 
     #[test]
-    fn recursive_skips_hidden_dirs() {
+    #[cfg(unix)]
+    fn recursive_includes_hidden_paths_excludes_vcs_and_deduplicates_aliases() {
         let dir = tempfile::tempdir().unwrap();
+        let hidden_file = dir.path().join(".hidden-file");
+        let hidden_dir_file = dir.path().join(".config/settings.toml");
+        let pinned_file = dir.path().join("nested/pinned.toml");
+        let alias = dir.path().join(".aliases/pinned.toml");
+        fs::create_dir_all(dir.path().join(".config")).unwrap();
+        fs::create_dir_all(dir.path().join(".aliases")).unwrap();
         fs::create_dir_all(dir.path().join(".git/objects")).unwrap();
+        fs::create_dir_all(dir.path().join(".hg/store")).unwrap();
+        fs::create_dir_all(dir.path().join(".svn/pristine")).unwrap();
+        fs::create_dir_all(dir.path().join(".ignored")).unwrap();
+        fs::create_dir_all(dir.path().join("nested")).unwrap();
+        fs::write(&hidden_file, "").unwrap();
+        fs::write(&hidden_dir_file, "").unwrap();
+        fs::write(&pinned_file, "").unwrap();
         fs::write(dir.path().join(".git/objects/abc"), "").unwrap();
-        fs::write(dir.path().join("visible.rs"), "").unwrap();
+        fs::write(dir.path().join(".hg/store/abc"), "").unwrap();
+        fs::write(dir.path().join(".svn/pristine/abc"), "").unwrap();
+        fs::write(dir.path().join(".ignored/file"), "").unwrap();
+        std::os::unix::fs::symlink(&pinned_file, &alias).unwrap();
+        let pinned = vec![PinnedMapping {
+            local_path: pinned_file.clone(),
+            gist_id: "gist".into(),
+            gist_filename: "pinned.toml".into(),
+            direction: None,
+            last_seen_hash: None,
+        }];
+        let skip_dirs = vec![".ignored".to_string()];
+
+        let candidates =
+            discover_local_candidates(dir.path(), &pinned, true, &skip_dirs, 10).unwrap();
+        let paths: Vec<_> = candidates
+            .iter()
+            .map(|candidate| candidate.path.clone())
+            .collect();
+        let flat_candidates =
+            discover_local_candidates(dir.path(), &pinned, false, &skip_dirs, 10).unwrap();
+
+        assert!(paths.contains(&hidden_file));
+        assert!(paths.contains(&hidden_dir_file));
+        assert!(paths.contains(&pinned_file));
+        assert!(!paths.contains(&alias));
+        assert!(!paths
+            .iter()
+            .any(|path| path.starts_with(dir.path().join(".git"))));
+        assert!(!paths
+            .iter()
+            .any(|path| path.starts_with(dir.path().join(".hg"))));
+        assert!(!paths
+            .iter()
+            .any(|path| path.starts_with(dir.path().join(".svn"))));
+        assert!(!paths
+            .iter()
+            .any(|path| path.starts_with(dir.path().join(".ignored"))));
+        assert!(candidates
+            .iter()
+            .any(|candidate| candidate.path == pinned_file && candidate.pinned));
+        assert!(flat_candidates
+            .iter()
+            .all(|candidate| paths.contains(&candidate.path)));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn recursive_deduplication_prefers_the_shallowest_unpinned_alias() {
+        let dir = tempfile::tempdir().unwrap();
+        let direct = dir.path().join("shared.toml");
+        let alias = dir.path().join("nested/alias.toml");
+        fs::create_dir_all(dir.path().join("nested")).unwrap();
+        fs::write(&direct, "").unwrap();
+        std::os::unix::fs::symlink(&direct, &alias).unwrap();
 
         let candidates =
             discover_local_candidates(dir.path(), &[], true, &default_skip(), 10).unwrap();
-        let paths: Vec<_> = candidates.iter().map(|c| c.path.clone()).collect();
+        let paths: Vec<_> = candidates.iter().map(|candidate| &candidate.path).collect();
 
-        assert!(paths.contains(&dir.path().join("visible.rs")));
-        assert!(!paths.iter().any(|p| p.to_string_lossy().contains(".git")));
+        assert_eq!(paths, vec![&direct]);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn recursive_discovery_deduplicates_flat_aliases_by_path_priority() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("a.toml");
+        let alias = dir.path().join("b.toml");
+        fs::write(&file, "").unwrap();
+        std::os::unix::fs::symlink(&file, &alias).unwrap();
+
+        let flat = discover_local_candidates(dir.path(), &[], false, &default_skip(), 10).unwrap();
+        let recursive =
+            discover_local_candidates(dir.path(), &[], true, &default_skip(), 10).unwrap();
+        let flat_paths: Vec<_> = flat.iter().map(|candidate| &candidate.path).collect();
+        let recursive_paths: Vec<_> = recursive.iter().map(|candidate| &candidate.path).collect();
+
+        assert_eq!(flat_paths, vec![&file, &alias]);
+        assert_eq!(recursive_paths, vec![&file]);
     }
 
     #[test]

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -240,7 +240,7 @@ Navigation
 
 List screen
   Footer     shows the primary screen actions; narrow terminals keep whole hints and the leave key
-  r          toggle recursive file discovery (skips hidden + configured dirs)
+  r          toggle recursive file discovery (includes hidden paths; skips configured dirs)
   /          filter the focused pane (Local = path/filename, Gist = description/id)
              while filtering: type to match · ↑↓ move · PgUp/PgDn page · Tab apply + switch pane
              · Enter apply · Esc clear · ←/→/Home/End move · Del


### PR DESCRIPTION
## Summary
- include hidden files and directories in recursive discovery
- always skip VCS metadata directories and deduplicate symlink aliases by pin, depth, then path
- document the unified recursive behaviour and cover it with local discovery tests

## Testing
- mise run check

Closes #345