### PR TITLE
feat(tui): explain settings options

### DIFF
--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -163,6 +163,7 @@ impl AppState {
                     "off".into()
                 }
             }
+            ConfigField::DiffShowFull => if self.diff_show_full { "on" } else { "off" }.into(),
             ConfigField::IgnoreTrailingNewline => {
                 if self.ignore_trailing_newline {
                     "on".into()

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -136,16 +136,18 @@ pub enum ConfigField {
     Theme,
     Mouse,
     CheckUpdates,
+    DiffShowFull,
     IgnoreTrailingNewline,
     ScanDepth,
     DiffContext,
 }
 
 impl ConfigField {
-    pub const ALL: [ConfigField; 6] = [
+    pub const ALL: [ConfigField; 7] = [
         ConfigField::Theme,
         ConfigField::Mouse,
         ConfigField::CheckUpdates,
+        ConfigField::DiffShowFull,
         ConfigField::IgnoreTrailingNewline,
         ConfigField::ScanDepth,
         ConfigField::DiffContext,
@@ -156,6 +158,7 @@ impl ConfigField {
             ConfigField::Theme => "Theme",
             ConfigField::Mouse => "Mouse support",
             ConfigField::CheckUpdates => "Check for updates",
+            ConfigField::DiffShowFull => "Show full diff",
             ConfigField::IgnoreTrailingNewline => "Ignore trailing newline",
             ConfigField::ScanDepth => "Recursive scan depth",
             ConfigField::DiffContext => "Diff context lines",
@@ -164,6 +167,18 @@ impl ConfigField {
 
     pub fn is_numeric(self) -> bool {
         matches!(self, ConfigField::ScanDepth | ConfigField::DiffContext)
+    }
+
+    pub fn description(self) -> &'static str {
+        match self {
+            ConfigField::Theme => "terminal colours",
+            ConfigField::Mouse => "click and wheel input",
+            ConfigField::CheckUpdates => "daily GitHub version check",
+            ConfigField::DiffShowFull => "open Diff expanded",
+            ConfigField::IgnoreTrailingNewline => "hide newline-only diffs",
+            ConfigField::ScanDepth => "directory levels to scan",
+            ConfigField::DiffContext => "unchanged lines around edits",
+        }
     }
 }
 

--- a/src/tui/screens/config.rs
+++ b/src/tui/screens/config.rs
@@ -87,6 +87,10 @@ impl AppState {
                 self.update_check_enabled = self.config_check_updates && !self.no_update_check_cli;
                 true
             }
+            ConfigField::DiffShowFull => {
+                self.diff_show_full = !self.diff_show_full;
+                true
+            }
             ConfigField::IgnoreTrailingNewline => {
                 self.ignore_trailing_newline = !self.ignore_trailing_newline;
                 true
@@ -172,7 +176,7 @@ pub(crate) fn build_config_vm(state: &AppState) -> ConfigVm {
             } else {
                 "Enter"
             };
-            format!("  {label:<28} {value:<8}  ({hint})")
+            format!("  {label:<23} {value:<5} {} ({hint})", field.description())
         })
         .collect();
     ConfigVm {
@@ -193,7 +197,11 @@ pub(crate) fn render_config_vm(
     let area = crate::tui::render_top_bar(frame, area, &state.theme, chrome.mouse_enabled, layout);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Min(3), Constraint::Length(1)])
+        .constraints([
+            Constraint::Min(3),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
         .split(area);
     let items: Vec<ListItem> = config
         .rows
@@ -240,6 +248,13 @@ pub(crate) fn render_config_vm(
             chunks[1],
         );
     }
+    frame.render_widget(
+        Paragraph::new(
+            " File-only: skip_dirs · ~/.config/gistui/config.toml (or $XDG_CONFIG_HOME)",
+        )
+        .style(Style::default().fg(state.theme.dim)),
+        chunks[2],
+    );
 }
 
 pub(crate) fn config_palette_items() -> Vec<crate::tui::palette::PaletteItem> {
@@ -320,5 +335,18 @@ mod tests {
         assert!(!state.adjust_config_field(false)); // already min
         assert!(state.adjust_config_field(true));
         assert_eq!(state.scan_depth, 1);
+    }
+
+    #[test]
+    fn config_toggles_show_full_diff() {
+        let mut state = initial_state();
+        state.open_config();
+        config_mut(&mut state).index = ConfigField::ALL
+            .iter()
+            .position(|field| *field == ConfigField::DiffShowFull)
+            .unwrap();
+        assert!(!state.diff_show_full);
+        assert!(state.adjust_config_field(true));
+        assert!(state.diff_show_full);
     }
 }

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -398,9 +398,12 @@ Fields
   Theme                  dark / light (also global T)
   Mouse support          on / off (session still respects --no-mouse)
   Check for updates      on / off (session still respects --no-update-check)
+  Show full diff         on / off (opens Diff expanded; c still toggles it)
   Ignore trailing newline  on / off (diff + overwrite confirm)
   Recursive scan depth   0–20 (r recursive discovery)
-  Diff context lines     0–50 (c in Diff still toggles full vs this radius)"
+  Diff context lines     0–50 (c in Diff still toggles full vs this radius)
+
+File-only: skip_dirs — ~/.config/gistui/config.toml (or $XDG_CONFIG_HOME)"
         }
         HelpTopic::General => {
             "\


### PR DESCRIPTION
## Summary
- add the persisted full-diff preference to Settings
- describe each editable setting and point to file-only skip_dirs
- show the configuration file location in Settings and Help

## Testing
- mise run check

Closes #350