### PR TITLE
feat(tui): enrich gist detail metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Gist detail now shows every file's size and type, the total size in its Files title, and the comment total in its tab.
 - Saving configuration now records only changed settings (plus pinned mappings), so later default changes apply to users who have not overridden them.
 - Recursive file discovery now includes hidden files and directories like the flat view, skips only configured directories plus `.git`, `.hg`, and `.svn`, and collapses symlink aliases without losing pinned paths.
 - Help's topic index now gives General a working `g` shortcut, keeps every shortcut to one key, and aligns topic names.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ without resetting order. Pinned pairs show `📌`; same-filename candidates are 
 | `d` / `u` | download gist file / upload local file into gist |
 | `n` | create a new gist from the selected local file |
 | `p` / `P` | pin pair / open Pins view |
-| `g` | gist manager (per-gist view; `Enter` for detail, `v` visibility, `*` star) |
+| `g` | gist manager (per-gist view; `Enter` for detail with file size/type, `v` visibility, `*` star) |
 | `a` | flip anchor pane · `/` filter focused pane · `?` help |
 | `C` | open Settings (theme, mouse, update check, scan depth, …) |
 
@@ -93,7 +93,7 @@ The app version, the GitHub repo link, and update-check status live in `?` Help'
 | Wheel up/down | scroll the focused list or content pane |
 | Click a row | select it (List panes also switch focus) |
 | Double-click a row | open it — List diff, gist detail, pin diff, revision diff, file preview, or Help topic (same as `Enter`) |
-| Click a tab (Gist details) | switch between Files / Comments (newest 30 comments load first; `m` or clicking the top line loads 30 older comments) |
+| Click a tab (Gist details) | switch between Files / Comments (the tab shows the comment count; newest 30 comments load first; `m` or clicking the top line loads 30 older comments) |
 | Click `[✕]` button (pop-up screens) | close / go back |
 | Click `(G)ists` / `(P)ins` / `(C)onfig` / `(?)Help` (top bar) | jump to that screen, from anywhere — same as pressing `g` / `P` / `C` / `?` |
 | Right-click | open the context menu at the click (same as `;`) |

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -644,6 +644,8 @@ mod tests {
 
             content_type: None,
 
+            size: 0,
+
             node_id: None,
         }
     }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -78,6 +78,7 @@ mod tests {
             fork_of_id: None,
             raw_url: None,
             content_type: None,
+            size: 0,
             node_id: None,
         }
     }

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -90,6 +90,9 @@ pub struct GistFile {
     /// MIME type from the gist list API (`files[].type`), when present.
     #[serde(default)]
     pub content_type: Option<String>,
+    /// Byte size from the gist list API (`files[].size`), or 0 when unavailable.
+    #[serde(default)]
+    pub size: u64,
     /// GraphQL global id from the gist list API (`node_id`), for stargazer counts.
     #[serde(default)]
     pub node_id: Option<String>,
@@ -288,6 +291,7 @@ impl GistFile {
             fork_of_id: None,
             raw_url,
             content_type: None,
+            size: 0,
             node_id: None,
         }
     }
@@ -599,6 +603,7 @@ mod tests {
 
             raw_url: None,
             content_type: None,
+            size: 0,
             node_id: None,
         }
     }

--- a/src/gh/forks.rs
+++ b/src/gh/forks.rs
@@ -313,6 +313,7 @@ mod tests {
                 fork_of_id: None,
                 raw_url: None,
                 content_type: None,
+                size: 0,
                 node_id: None,
             },
             GistFile {
@@ -326,6 +327,7 @@ mod tests {
                 fork_of_id: None,
                 raw_url: None,
                 content_type: None,
+                size: 0,
                 node_id: None,
             },
         ];

--- a/src/gh/gists.rs
+++ b/src/gh/gists.rs
@@ -81,6 +81,7 @@ pub fn parse_gist_list_json(raw: &str) -> Result<Vec<GistFile>> {
                 fork_of_id: fork_of_id.clone(),
                 raw_url: file.raw_url.clone(),
                 content_type: file.content_type.clone(),
+                size: file.size,
                 node_id: gist.node_id.clone(),
             });
         }
@@ -192,6 +193,7 @@ mod tests {
         assert!(!files[0].public);
         assert_eq!(files[0].owner_login, "akunzai");
         assert_eq!(files[0].content_type.as_deref(), Some("application/json"));
+        assert_eq!(files[0].size, 42);
         assert_eq!(files[1].filename, "statusline.sh");
         assert_eq!(files[1].content_type.as_deref(), Some("text/x-shellscript"));
         let notes = files.iter().find(|f| f.filename == "notes.md").unwrap();

--- a/src/gh/mod.rs
+++ b/src/gh/mod.rs
@@ -45,6 +45,8 @@ struct GhGistFile {
     raw_url: Option<String>,
     #[serde(default, rename = "type")]
     content_type: Option<String>,
+    #[serde(default)]
+    size: u64,
 }
 
 /// Plan for `gh --version` (used to confirm `gh` is installed and runnable).

--- a/src/ranking.rs
+++ b/src/ranking.rs
@@ -149,6 +149,7 @@ mod tests {
             fork_of_id: None,
             raw_url: None,
             content_type: None,
+            size: 0,
             node_id: None,
         }
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1719,14 +1719,23 @@ impl AppState {
 
     /// Detail-view file labels; non-text files are tagged `(binary)`.
     pub fn gist_file_display_names(&self, gist_id: &str) -> Vec<String> {
-        self.gist_filenames(gist_id)
-            .into_iter()
-            .map(|f| {
-                if self.gist_file_is_text_previewable(gist_id, &f) {
-                    f
+        self.all_gist_files()
+            .filter(|file| file.gist_id == gist_id)
+            .map(|file| {
+                let kind = file.content_type.as_deref().unwrap_or("unknown type");
+                let binary = if crate::domain::gist_file_is_text_previewable(
+                    &file.filename,
+                    file.content_type.as_deref(),
+                ) {
+                    ""
                 } else {
-                    format!("{f} (binary)")
-                }
+                    " · binary"
+                };
+                format!(
+                    "{} · {} · {kind}{binary}",
+                    file.filename,
+                    format_file_size(file.size)
+                )
             })
             .collect()
     }
@@ -2120,6 +2129,14 @@ impl AppState {
         } else {
             Some(self.diff_context as usize)
         }
+    }
+}
+
+pub(crate) fn format_file_size(bytes: u64) -> String {
+    match bytes {
+        0..=1023 => format!("{bytes} B"),
+        1024..=1_048_575 => format!("{:.1} KiB", bytes as f64 / 1024.0),
+        _ => format!("{:.1} MiB", bytes as f64 / 1_048_576.0),
     }
 }
 

--- a/src/tui/palette.rs
+++ b/src/tui/palette.rs
@@ -277,6 +277,7 @@ mod tests {
             fork_of_id: None,
             raw_url: None,
             content_type: None,
+            size: 0,
             node_id: None,
         }
     }

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -1954,6 +1954,7 @@ mod tests {
             fork_of_id: None,
             raw_url: None,
             content_type: None,
+            size: 0,
             node_id: None,
         }
     }
@@ -2076,6 +2077,24 @@ mod tests {
         let mut state = initial_state();
         state.screen = Screen::GistDetail(Box::default());
         render_state(&state);
+    }
+
+    #[test]
+    fn render_gist_detail_metadata_fits_at_eighty_columns() {
+        let mut state = initial_state();
+        state.screen = Screen::GistDetail(Box::default());
+        state.gists = vec![crate::domain::GistFile {
+            content_type: Some("text/plain".into()),
+            size: 1_536,
+            ..gist_file("notes.txt", "metadata")
+        }];
+        state.detail_mut().unwrap().gist_id = Some("abc123def".into());
+        state.gist_comment_counts.insert("abc123def".into(), 3);
+
+        let text = render_state_size(&state, 80, 24);
+        assert!(text.contains("notes.txt · 1.5 KiB · text/plain"), "{text}");
+        assert!(text.contains("Files (1): 1.5 KiB total"), "{text}");
+        assert!(text.contains("Comments (3)"), "{text}");
     }
 
     #[test]

--- a/src/tui/screens/detail.rs
+++ b/src/tui/screens/detail.rs
@@ -510,7 +510,9 @@ pub(crate) fn build_gist_detail_vm(state: &AppState) -> GistDetailVm {
             info_line: String::new(),
             focus: detail.focus,
             files: Vec::new(),
+            files_title: String::new(),
             file_cursor: 0,
+            comments_count: 0,
             comments: CommentsPaneVm::PromptLoad,
             footer,
             footer_colored,
@@ -526,7 +528,9 @@ pub(crate) fn build_gist_detail_vm(state: &AppState) -> GistDetailVm {
             info_line: String::new(),
             focus: detail.focus,
             files: Vec::new(),
+            files_title: String::new(),
             file_cursor: 0,
+            comments_count: 0,
             comments: CommentsPaneVm::PromptLoad,
             footer,
             footer_colored,
@@ -549,8 +553,19 @@ pub(crate) fn build_gist_detail_vm(state: &AppState) -> GistDetailVm {
         state.gist_counts(gist_id),
     );
     let files = state.gist_file_display_names(gist_id);
+    let total_size: u64 = state
+        .all_gist_files()
+        .filter(|file| file.gist_id == gist_id)
+        .map(|file| file.size)
+        .sum();
+    let files_title = format!(
+        "Files ({}): {} total",
+        files.len(),
+        crate::tui::format_file_size(total_size)
+    );
     let file_cursor = detail.file_cursor.min(files.len().saturating_sub(1));
     let comments = build_comments_pane_vm(state);
+    let comments_count = state.gist_counts(gist_id).0;
 
     let description_input = state
         .editing_description
@@ -562,7 +577,9 @@ pub(crate) fn build_gist_detail_vm(state: &AppState) -> GistDetailVm {
         info_line,
         focus: detail.focus,
         files,
+        files_title,
         file_cursor,
+        comments_count,
         comments,
         footer,
         footer_colored,
@@ -717,7 +734,7 @@ fn render_detail_header_vm(
 ) {
     let lines = vec![
         Line::from(detail.info_line.clone()),
-        detail_focus_tabs_line(detail.focus, theme),
+        detail_focus_tabs_line(detail.focus, detail.comments_count, theme),
     ];
     frame.render_widget(
         Paragraph::new(lines).style(theme.base_style()).block(
@@ -736,13 +753,18 @@ fn render_detail_header_vm(
     );
     if chrome.mouse_enabled {
         // Tab line is the 2nd content row (border + gist-info line above it); content starts
-        // after the left border (1) + horizontal padding (1). Labels: " Files " (7), " │ " (3),
-        // " Comments " (10) — see detail_focus_tabs_line.
+        // after the left border (1) + horizontal padding (1). The comments label includes its
+        // count, so derive its click target from the same formatted label as the renderer.
         let content_x = area.x + 2;
         let tabs_y = area.y + 2;
         layout.detail_tab_files = Some(ratatui::layout::Rect::new(content_x, tabs_y, 7, 1));
-        layout.detail_tab_comments =
-            Some(ratatui::layout::Rect::new(content_x + 10, tabs_y, 10, 1));
+        let comments_width = format!(" Comments ({}) ", detail.comments_count).len() as u16;
+        layout.detail_tab_comments = Some(ratatui::layout::Rect::new(
+            content_x + 10,
+            tabs_y,
+            comments_width,
+            1,
+        ));
     }
 }
 
@@ -755,6 +777,10 @@ fn render_gist_file_list_vm(
     theme: &crate::tui::Theme,
     layout: &mut MouseLayout,
 ) {
+    let file_list_height = u16::try_from(detail.files.len().saturating_add(2))
+        .unwrap_or(u16::MAX)
+        .clamp(3, area.height.max(3));
+    let area = ratatui::layout::Rect::new(area.x, area.y, area.width, file_list_height);
     let files = &detail.files;
     let cursor = detail.file_cursor.min(files.len().saturating_sub(1));
     let visible_rows = (area.height as usize).saturating_sub(2);
@@ -767,7 +793,7 @@ fn render_gist_file_list_vm(
         Paragraph::new(lines).style(theme.base_style()).block(
             Block::default()
                 .title(crate::tui::render::fit_block_title(
-                    &format!("Files ({})", files.len()),
+                    &detail.files_title,
                     area.width,
                 ))
                 .borders(Borders::ALL)
@@ -901,6 +927,7 @@ pub(crate) fn detail_focus_tab(focus: DetailFocus) -> usize {
 /// strip, so the active focus is visible without a disconnected top row.
 pub(crate) fn detail_focus_tabs_line(
     focus: DetailFocus,
+    comments_count: u32,
     theme: &crate::tui::Theme,
 ) -> Line<'static> {
     let active = detail_focus_tab(focus);
@@ -910,7 +937,8 @@ pub(crate) fn detail_focus_tabs_line(
         .add_modifier(Modifier::BOLD);
     let idle_style = Style::default().fg(theme.dim);
     let mut spans = Vec::new();
-    for (i, label) in ["Files", "Comments"].iter().enumerate() {
+    let comments = format!("Comments ({comments_count})");
+    for (i, label) in ["Files".to_string(), comments].iter().enumerate() {
         if i > 0 {
             spans.push(Span::styled(" │ ", idle_style));
         }
@@ -1016,6 +1044,8 @@ mod tests {
                 raw_url: None,
 
                 content_type: None,
+
+                size: 0,
 
                 node_id: None,
             })
@@ -1302,6 +1332,8 @@ mod tests {
 
             content_type: None,
 
+            size: 0,
+
             node_id: None,
         }];
         assert!(matches!(
@@ -1330,6 +1362,8 @@ mod tests {
 
             content_type: None,
 
+            size: 0,
+
             node_id: None,
         }];
         assert_eq!(state.handle_key(KeyCode::Char('F')), KeyOutcome::None);
@@ -1353,6 +1387,7 @@ mod tests {
             fork_of_id: None,
             raw_url: None,
             content_type: None,
+            size: 0,
             node_id: None,
         }];
         assert_eq!(state.handle_key(KeyCode::Char('e')), KeyOutcome::None);

--- a/src/tui/screens/diff.rs
+++ b/src/tui/screens/diff.rs
@@ -321,6 +321,8 @@ mod tests {
 
             content_type: None,
 
+            size: 0,
+
             node_id: None,
         }];
         state.screen = Screen::Diff(Box::default());

--- a/src/tui/screens/gists.rs
+++ b/src/tui/screens/gists.rs
@@ -512,6 +512,8 @@ mod tests {
 
                 content_type: None,
 
+                size: 0,
+
                 node_id: None,
             },
             GistFile {
@@ -527,6 +529,8 @@ mod tests {
                 raw_url: None,
 
                 content_type: None,
+
+                size: 0,
 
                 node_id: None,
             },
@@ -571,6 +575,8 @@ mod tests {
 
                 content_type: None,
 
+                size: 0,
+
                 node_id: None,
             },
             GistFile {
@@ -586,6 +592,8 @@ mod tests {
                 raw_url: None,
 
                 content_type: None,
+
+                size: 0,
 
                 node_id: None,
             },
@@ -645,6 +653,7 @@ mod tests {
                 fork_of_id: None,
                 raw_url: None,
                 content_type: None,
+                size: 0,
                 node_id: None,
             })
             .collect();
@@ -671,6 +680,8 @@ mod tests {
             raw_url: None,
 
             content_type: None,
+
+            size: 0,
 
             node_id: None,
         }];

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -321,13 +321,13 @@ Mouse (on by default; disable with mouse = false in config or --no-mouse)
         }
         HelpTopic::GistDetail => {
             "\
-  Tab        switch tab: Files / Comments (one shows at a time; opens on Files)
+  Tab        switch tab: Files / Comments (Comments shows its total; opens on Files)
   Up/Down    move the file cursor (Files tab) or scroll comments (also j / k)
   PageUp/Dn  page comments / file cursor by 10 (also Ctrl+b / Ctrl+f)
   m          load 30 older comments (Comments tab; also click the top line)
   Enter      preview the cursor-selected file (file list focused; blocked for binary)
   1-9        preview the content of the Nth file (full-screen; R refresh, q back)
-             non-text files are tagged (binary) in the list
+             rows show each file's size and type; non-text files are tagged binary
   H          open revision history for this gist (target = cursor file)
   *          star / unstar this gist
   o          open the gist in your web browser

--- a/src/tui/screens/list.rs
+++ b/src/tui/screens/list.rs
@@ -1198,6 +1198,8 @@ mod tests {
 
             content_type: None,
 
+            size: 0,
+
             node_id: None,
         }];
         // Removing the only file would leave a fileless gist, which GitHub forbids.

--- a/src/tui/screens/revisions.rs
+++ b/src/tui/screens/revisions.rs
@@ -663,6 +663,8 @@ mod tests {
 
             content_type: None,
 
+            size: 0,
+
             node_id: None,
         }];
         state.screen = Screen::Revisions(Box::default());

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -103,6 +103,8 @@ pub(super) fn state_with_gists() -> AppState {
 
             content_type: None,
 
+            size: 0,
+
             node_id: None,
         },
         GistFile {
@@ -118,6 +120,8 @@ pub(super) fn state_with_gists() -> AppState {
             raw_url: None,
 
             content_type: None,
+
+            size: 0,
 
             node_id: None,
         },
@@ -206,6 +210,8 @@ pub(super) fn list_state_with_matches() -> AppState {
 
             content_type: None,
 
+            size: 0,
+
             node_id: None,
         },
         GistFile {
@@ -221,6 +227,8 @@ pub(super) fn list_state_with_matches() -> AppState {
             raw_url: None,
 
             content_type: None,
+
+            size: 0,
 
             node_id: None,
         },
@@ -479,6 +487,8 @@ fn gist_row_label_switches_with_view() {
 
             content_type: None,
 
+            size: 0,
+
             node_id: None,
         },
         mark: crate::ranking::MatchMark::None,
@@ -553,6 +563,8 @@ fn reverse_ranking_orders_locals_by_selected_gist() {
         raw_url: None,
 
         content_type: None,
+
+        size: 0,
 
         node_id: None,
     }];
@@ -651,6 +663,8 @@ fn ranking_helpers_terminate_in_either_anchor() {
 
         content_type: None,
 
+        size: 0,
+
         node_id: None,
     }];
     state.locals = vec![LocalCandidate {
@@ -685,6 +699,8 @@ fn sort_by_name_and_recent_reorders_gists() {
 
             content_type: None,
 
+            size: 0,
+
             node_id: None,
         },
         GistFile {
@@ -700,6 +716,8 @@ fn sort_by_name_and_recent_reorders_gists() {
             raw_url: None,
 
             content_type: None,
+
+            size: 0,
 
             node_id: None,
         },
@@ -733,6 +751,8 @@ fn gist_type_filter_limits_ranked_gists() {
 
             content_type: None,
 
+            size: 0,
+
             node_id: None,
         },
         GistFile {
@@ -748,6 +768,8 @@ fn gist_type_filter_limits_ranked_gists() {
             raw_url: None,
 
             content_type: None,
+
+            size: 0,
 
             node_id: None,
         },
@@ -782,6 +804,8 @@ pub(super) fn state_with_two_gists() -> AppState {
 
             content_type: None,
 
+            size: 0,
+
             node_id: None,
         },
         GistFile {
@@ -797,6 +821,8 @@ pub(super) fn state_with_two_gists() -> AppState {
             raw_url: None,
 
             content_type: None,
+
+            size: 0,
 
             node_id: None,
         },
@@ -1219,6 +1245,8 @@ fn gist_row_label_falls_back_to_filename_when_description_empty() {
 
             content_type: None,
 
+            size: 0,
+
             node_id: None,
         },
         mark: crate::ranking::MatchMark::None,
@@ -1242,6 +1270,8 @@ fn left_right_scrolls_focused_gist_pane() {
         raw_url: None,
 
         content_type: None,
+
+        size: 0,
 
         node_id: None,
     }];
@@ -1272,6 +1302,8 @@ fn gist_hscroll_caps_at_painted_row() {
         raw_url: None,
 
         content_type: None,
+
+        size: 0,
 
         node_id: None,
     }];
@@ -1306,6 +1338,7 @@ fn gist_hscroll_follows_the_selected_row() {
             fork_of_id: None,
             raw_url: None,
             content_type: None,
+            size: 0,
             node_id: None,
         },
         GistFile {
@@ -1319,6 +1352,7 @@ fn gist_hscroll_follows_the_selected_row() {
             fork_of_id: None,
             raw_url: None,
             content_type: None,
+            size: 0,
             node_id: None,
         },
     ];
@@ -1404,6 +1438,7 @@ fn gist_hscroll_caps_include_star_prefix() {
         fork_of_id: None,
         raw_url: None,
         content_type: None,
+        size: 0,
         node_id: None,
     }];
     state.starred_gist_ids.insert("starred-id".into());
@@ -1458,6 +1493,8 @@ fn moving_gist_selection_resets_hscroll() {
 
             content_type: None,
 
+            size: 0,
+
             node_id: None,
         },
         GistFile {
@@ -1473,6 +1510,8 @@ fn moving_gist_selection_resets_hscroll() {
             raw_url: None,
 
             content_type: None,
+
+            size: 0,
 
             node_id: None,
         },
@@ -1508,6 +1547,8 @@ fn no_local_selected_lists_all_gists_unranked() {
 
             content_type: None,
 
+            size: 0,
+
             node_id: None,
         },
         GistFile {
@@ -1523,6 +1564,8 @@ fn no_local_selected_lists_all_gists_unranked() {
             raw_url: None,
 
             content_type: None,
+
+            size: 0,
 
             node_id: None,
         },
@@ -1550,6 +1593,8 @@ fn enter_with_no_local_but_gist_selected_returns_preview() {
         raw_url: None,
 
         content_type: None,
+
+        size: 0,
 
         node_id: None,
     }];
@@ -1591,6 +1636,8 @@ fn local_selection_changes_ranked_gists() {
 
             content_type: None,
 
+            size: 0,
+
             node_id: None,
         },
         GistFile {
@@ -1606,6 +1653,8 @@ fn local_selection_changes_ranked_gists() {
             raw_url: None,
 
             content_type: None,
+
+            size: 0,
 
             node_id: None,
         },
@@ -1648,6 +1697,7 @@ fn selected_accessors_track_recomputed_lists_with_no_cache() {
             fork_of_id: None,
             raw_url: None,
             content_type: None,
+            size: 0,
             node_id: None,
         },
         GistFile {
@@ -1661,6 +1711,7 @@ fn selected_accessors_track_recomputed_lists_with_no_cache() {
             fork_of_id: None,
             raw_url: None,
             content_type: None,
+            size: 0,
             node_id: None,
         },
     ];
@@ -1736,6 +1787,7 @@ fn list_pane_snapshots_match_public_accessors() {
             fork_of_id: None,
             raw_url: None,
             content_type: None,
+            size: 0,
             node_id: None,
         },
         GistFile {
@@ -1749,6 +1801,7 @@ fn list_pane_snapshots_match_public_accessors() {
             fork_of_id: None,
             raw_url: None,
             content_type: None,
+            size: 0,
             node_id: None,
         },
     ];
@@ -1823,6 +1876,8 @@ fn state_with_selection() -> AppState {
         raw_url: None,
 
         content_type: None,
+
+        size: 0,
 
         node_id: None,
     }];
@@ -2170,6 +2225,8 @@ fn u_adds_when_gist_lacks_filename() {
 
         content_type: None,
 
+        size: 0,
+
         node_id: None,
     }];
     state.focus = FocusPane::Gist;
@@ -2200,6 +2257,8 @@ fn u_previews_when_gist_has_same_filename() {
         raw_url: None,
 
         content_type: None,
+
+        size: 0,
 
         node_id: None,
     }];
@@ -2528,6 +2587,8 @@ fn x_removes_selected_file_from_a_multifile_gist() {
 
             content_type: None,
 
+            size: 0,
+
             node_id: None,
         },
         GistFile {
@@ -2543,6 +2604,8 @@ fn x_removes_selected_file_from_a_multifile_gist() {
             raw_url: None,
 
             content_type: None,
+
+            size: 0,
 
             node_id: None,
         },
@@ -2945,6 +3008,8 @@ fn list_screen_capital_s_syncs_selected_pair() {
 
         content_type: None,
 
+        size: 0,
+
         node_id: None,
     }];
     assert!(matches!(
@@ -3115,6 +3180,7 @@ fn gist_filenames_dedupes_owned_gist_that_is_also_starred() {
         fork_of_id: None,
         raw_url: None,
         content_type: None,
+        size: 0,
         node_id: None,
     };
     let mut state = initial_state();
@@ -3582,6 +3648,8 @@ fn forked_filter_shows_only_forks() {
 
             content_type: None,
 
+            size: 0,
+
             node_id: None,
         },
         GistFile {
@@ -3597,6 +3665,8 @@ fn forked_filter_shows_only_forks() {
             raw_url: None,
 
             content_type: None,
+
+            size: 0,
 
             node_id: None,
         },
@@ -3634,6 +3704,8 @@ fn foreign_gist_blocks_pin() {
 
         content_type: None,
 
+        size: 0,
+
         node_id: None,
     }];
     state.local_index = 0;
@@ -3658,6 +3730,8 @@ fn star_key_returns_toggle_intent() {
         raw_url: None,
 
         content_type: None,
+
+        size: 0,
 
         node_id: None,
     }];
@@ -3684,6 +3758,7 @@ fn starred_filter_lists_only_starred_gists() {
         fork_of_id: None,
         raw_url: None,
         content_type: None,
+        size: 0,
         node_id: None,
     }];
     state.starred_gists = vec![GistFile {
@@ -3697,6 +3772,7 @@ fn starred_filter_lists_only_starred_gists() {
         fork_of_id: None,
         raw_url: None,
         content_type: None,
+        size: 0,
         node_id: None,
     }];
     state.gist_type_filter = GistTypeFilter::Starred;

--- a/src/tui/view_model.rs
+++ b/src/tui/view_model.rs
@@ -156,7 +156,9 @@ pub struct GistDetailVm {
     pub info_line: String,
     pub focus: DetailFocus,
     pub files: Vec<String>,
+    pub files_title: String,
     pub file_cursor: usize,
+    pub comments_count: u32,
     pub comments: CommentsPaneVm,
     pub footer: String,
     pub footer_colored: bool,
@@ -989,6 +991,8 @@ mod tests {
         state.gists = vec![
             GistFile {
                 description: "demo".into(),
+                content_type: Some("text/plain".into()),
+                size: 1_536,
                 ..GistFile::for_sync("g1".into(), "a.txt".into(), None)
             },
             GistFile::for_sync("g1".into(), "b.txt".into(), None),
@@ -998,6 +1002,7 @@ mod tests {
             d.focus = DetailFocus::Files;
             d.file_cursor = 1;
         }
+        state.gist_comment_counts.insert("g1".into(), 3);
 
         match build_view_model(&state).screen {
             ScreenVm::GistDetail(d) => {
@@ -1009,6 +1014,9 @@ mod tests {
                         || d.info_line.contains("public")
                 );
                 assert_eq!(d.files.len(), 2);
+                assert_eq!(d.files[0], "a.txt · 1.5 KiB · text/plain");
+                assert_eq!(d.files_title, "Files (2): 1.5 KiB total");
+                assert_eq!(d.comments_count, 3);
                 assert_eq!(d.file_cursor, 1);
                 assert_eq!(d.focus, DetailFocus::Files);
                 assert!(matches!(d.comments, CommentsPaneVm::PromptLoad));

--- a/tests/fixtures/gh/gist-list.json
+++ b/tests/fixtures/gh/gist-list.json
@@ -8,7 +8,7 @@
     "comments": 2,
     "owner": { "login": "akunzai" },
     "files": {
-      "settings.json": { "filename": "settings.json", "type": "application/json" },
+      "settings.json": { "filename": "settings.json", "type": "application/json", "size": 42 },
       "statusline.sh": { "filename": "statusline.sh", "type": "text/x-shellscript" }
     }
   },

--- a/tests/gh_integration.rs
+++ b/tests/gh_integration.rs
@@ -146,6 +146,7 @@ fn run_command_executes_planned_write_action() {
         fork_of_id: None,
         raw_url: None,
         content_type: None,
+        size: 0,
         node_id: None,
     };
     let plan = upload_command(PathBuf::from("/tmp/settings.json").as_path(), &target);


### PR DESCRIPTION
## Summary
- show each gist file's size and MIME type in the detail view
- surface aggregate size in the compact Files title and comments count in its tab
- cover API parsing and 80-column rendering, and update Help, README, and changelog

Closes #349

## Verification
- mise run check