### PR TITLE
fix(tui): correct quit prompt, gists mnemonic, and palette empty state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- The quit prompt now names every key that confirms it (`q` and `Esc`), the top-bar `(g)ists` mnemonic now matches the lowercase key that actually opens it, and a command-palette query with no matches now shows an explicit "no matches" message instead of an empty frame.
 - Gist detail now shows every file's size and type, the total size in its Files title, and the comment total in its tab.
 - Saving configuration now records only changed settings (plus pinned mappings), so later default changes apply to users who have not overridden them.
 - Recursive file discovery now includes hidden files and directories like the flat view, skips only configured directories plus `.git`, `.hg`, and `.svn`, and collapses symlink aliases without losing pinned paths.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Press **`?`** anytime for the **full, contextual keymap** — it opens the curre
 topic; `Tab` browses all topics (List, Pins, Gist manager, Settings, …), where `1`–`9`,
 `g` (General), and `0` (About) select their displayed topic.
 Idle footers show contextual screen actions; every screen also shows a
-`(G)ists (P)ins (C)onfig (?)Help` shortcut bar in the top-right corner (click, or use the
+`(g)ists (P)ins (C)onfig (?)Help` shortcut bar in the top-right corner (click, or use the
 underlying key). Press `;` (or right-click) for a context menu of actions valid on
 the current screen and selection; press `Ctrl+p` for the full command palette with
 fuzzy-filter search and cross-screen navigation (`Go to Pins`, `Open settings`, `Toggle theme`, `Quit`, …).
@@ -95,7 +95,7 @@ The app version, the GitHub repo link, and update-check status live in `?` Help'
 | Double-click a row | open it — List diff, gist detail, pin diff, revision diff, file preview, or Help topic (same as `Enter`) |
 | Click a tab (Gist details) | switch between Files / Comments (the tab shows the comment count; newest 30 comments load first; `m` or clicking the top line loads 30 older comments) |
 | Click `[✕]` button (pop-up screens) | close / go back |
-| Click `(G)ists` / `(P)ins` / `(C)onfig` / `(?)Help` (top bar) | jump to that screen, from anywhere — same as pressing `g` / `P` / `C` / `?` |
+| Click `(g)ists` / `(P)ins` / `(C)onfig` / `(?)Help` (top bar) | jump to that screen, from anywhere — same as pressing `g` / `P` / `C` / `?` |
 | Right-click | open the context menu at the click (same as `;`) |
 | Click a menu / palette row | run that action (same as selecting it and pressing `Enter`) |
 | Click the repository URL (`?` Help → About) | open the GitHub repository in the system's default browser |

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -367,7 +367,7 @@ impl AppState {
                         };
                     }
                 }
-                // Top-bar (G)ists / (P)ins / (C)onfig / (?)Help — same effect as pressing
+                // Top-bar (g)ists / (P)ins / (C)onfig / (?)Help — same effect as pressing
                 // the key, from any screen (not just wherever that key happens to be bound).
                 if let Some(rect) = layout.top_bar_gists {
                     if point_in(rect, col, row) {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -672,7 +672,7 @@ pub struct MouseLayout {
     /// to honour a one-shot scroll-to-bottom after the newest page loads).
     pub comments_max_scroll: Option<u16>,
     pub repo_link: Option<Rect>,
-    /// Cross-screen top-bar shortcut hit-rects — `(G)ists`, `(P)ins`, `(C)onfig`, `(?)Help`.
+    /// Cross-screen top-bar shortcut hit-rects — `(g)ists`, `(P)ins`, `(C)onfig`, `(?)Help`.
     /// Set by `render_top_bar` on every screen except the transient `Confirm` y/n modal.
     pub top_bar_gists: Option<Rect>,
     pub top_bar_pins: Option<Rect>,

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -83,16 +83,17 @@ pub(super) fn render_close_button(frame: &mut Frame, outer: Rect, theme: &Theme)
 /// Cross-screen top-bar shortcuts: bracketed hotkey letter + label. Kept in one place so the
 /// click hit-rect math and the rendered text can never drift apart. Order matches the
 /// right-aligned strip: Gists · Pins · Config · Help (Config sits immediately left of Help,
-/// same as duodiff).
+/// same as duodiff). Gists uses lowercase `g` because that is the actual key (unlike Pins/Config,
+/// which require Shift) — see `handle_key_list` in `screens/list.rs`.
 const TOP_BAR_ITEMS: [(&str, &str); 4] =
-    [("G", "ists"), ("P", "ins"), ("C", "onfig"), ("?", "Help")];
+    [("g", "ists"), ("P", "ins"), ("C", "onfig"), ("?", "Help")];
 
 /// Height of the persistent top bar rendered on every screen except the transient `Confirm`
 /// y/n modal (which keeps its full-bleed diff/gist-info background — see `render_confirm`).
 const TOP_BAR_HEIGHT: u16 = 1;
 
 /// Renders the cross-screen top bar — ` gistui` on the left,
-/// `(G)ists (P)ins (C)onfig (?)Help` right-aligned — into the top row of `area`, then returns
+/// `(g)ists (P)ins (C)onfig (?)Help` right-aligned — into the top row of `area`, then returns
 /// the remaining rect below it for the caller's existing content/footer layout (otherwise
 /// unchanged). The icons render as plain text even with the mouse disabled, so the shortcuts
 /// stay visible; their hit-rects are only recorded in `layout` when `mouse_enabled`, matching
@@ -1690,10 +1691,26 @@ mod tests {
         let state = initial_state();
         let text = render_state(&state);
         assert!(text.contains("gistui"));
-        assert!(text.contains("(G)ists"));
+        assert!(text.contains("(g)ists"));
         assert!(text.contains("(P)ins"));
         assert!(text.contains("(C)onfig"));
         assert!(text.contains("(?)Help"));
+    }
+
+    /// Issue #346: a command-palette query matching nothing must not render as an empty
+    /// frame under the input — it needs an explicit "no matches" message.
+    #[test]
+    fn render_screen_vm_command_palette_no_matches_shows_empty_state() {
+        let mut state = initial_state();
+        state.open_palette_command();
+        state
+            .palette_mut()
+            .unwrap()
+            .query
+            .set("zzz_no_such_command");
+        assert!(state.palette_visible_items().is_empty());
+        let text = render_state(&state);
+        assert!(text.contains("no matches"));
     }
 
     /// The Local pane title from the bug report, anchored and filtered.

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -279,7 +279,7 @@ Mouse (on by default; disable with mouse = false in config or --no-mouse)
   Dbl-click  open the clicked row (diff / detail / pin diff / preview)
   Tab click  switch Files / Comments on the Gist details screen
   [✕] btn    close / go back on any pop-up screen
-  Top bar    click (G)ists / (P)ins / (C)onfig / (?)Help (top-right, every screen)
+  Top bar    click (g)ists / (P)ins / (C)onfig / (?)Help (top-right, every screen)
   Right-click  open the context menu at the click (same as ;)
   ; / Ctrl+p   open the menu / command palette from the keyboard (see General)"
         }

--- a/src/tui/screens/list.rs
+++ b/src/tui/screens/list.rs
@@ -149,7 +149,7 @@ impl AppState {
                     return KeyOutcome::Quit;
                 }
                 self.quit_armed = true;
-                self.status = Some("Press q again to quit (any other key cancels)".into());
+                self.status = Some("Press q or Esc again to quit (any other key cancels)".into());
             }
             KeyCode::Tab => {
                 self.focus = match self.focus {

--- a/src/tui/screens/palette.rs
+++ b/src/tui/screens/palette.rs
@@ -195,7 +195,10 @@ pub(crate) fn render_palette_vm(
     }
 
     let area = frame.area();
-    let body_lines = palette.items.len() + usize::from(palette.has_query);
+    // A query with no matches still paints one "(no matches)" placeholder row, so the height
+    // budget must reserve a line for it — otherwise the panel sizes to fit only the query input
+    // and the placeholder is clipped, leaving what looks like an empty frame.
+    let body_lines = palette.items.len().max(1) + usize::from(palette.has_query);
     let longest_row = palette
         .items
         .iter()

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -2107,7 +2107,11 @@ fn q_in_list_quits_on_second_press() {
     // First press only arms the quit (and surfaces a hint); it must not exit.
     assert_eq!(state.handle_key(KeyCode::Char('q')), KeyOutcome::None);
     assert!(state.quit_armed);
-    assert!(state.status.is_some());
+    // Issue #346: the hint must name every key that confirms the quit, not just `q`.
+    assert_eq!(
+        state.status.as_deref(),
+        Some("Press q or Esc again to quit (any other key cancels)")
+    );
     // Second press confirms.
     assert_eq!(state.handle_key(KeyCode::Char('q')), KeyOutcome::Quit);
 }


### PR DESCRIPTION
## Summary
- Quit confirmation now names both `q` and `Esc`, since either key arms and confirms the pending quit.
- Top-bar mnemonic is now `(g)ists` (lowercase), matching the actual key — unlike `(P)ins`/`(C)onfig`, which genuinely require Shift.
- Command palette's existing "(no matches)" placeholder row was being clipped by a height calculation that didn't reserve space for it when the filtered list was empty; fixed the height budget so the placeholder now renders.
- `?` help and `README.md` updated to match the corrected mnemonic.
- Added/updated tests asserting the exact quit prompt text and the palette empty-state render.

Closes #346

## Test plan
- [x] `mise run check` (fmt, clippy, full test suite, cargo check) — all pass
- [x] Two-axis code review (Standards + Spec) — no blocking findings