### PR TITLE
fix(tui): lead gist rows with description, not the raw id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - The quit prompt now names every key that confirms it (`q` and `Esc`), the top-bar `(g)ists` mnemonic now matches the lowercase key that actually opens it, and a command-palette query with no matches now shows an explicit "no matches" message instead of an empty frame.
+- Preview now titles itself with the gist's description (consistent with Gist detail); Gist manager and Pinned Mappings rows now lead with the description instead of the raw id, which is demoted to a fixed-width, `#`-abbreviated column that stays aligned even with a starred/forked badge or a legacy short id.
 - Gist detail now shows every file's size and type, the total size in its Files title, and the comment total in its tab.
 - Saving configuration now records only changed settings (plus pinned mappings), so later default changes apply to users who have not overridden them.
 - Recursive file discovery now includes hidden files and directories like the flat view, skips only configured directories plus `.git`, `.hg`, and `.svn`, and collapses symlink aliases without losing pinned paths.

--- a/src/tui/dispatch.rs
+++ b/src/tui/dispatch.rs
@@ -271,16 +271,13 @@ pub(super) fn dispatch_outcome(
         KeyOutcome::PreviewContent { mut file } => {
             let key = file.cache_key();
             if let Some(content) = state.gist_content_cache.get(&key).cloned() {
-                state.enter_preview(
-                    format!("Preview: {} / {}", file.gist_id, file.filename),
-                    content,
-                    Some(key),
-                );
+                let preview_title = state.preview_title(&file.gist_id, &file.filename);
+                state.enter_preview(preview_title, content, Some(key));
             } else {
                 if file.raw_url.is_none() {
                     file.raw_url = state.gist_file_raw_url(&file.gist_id, &file.filename);
                 }
-                let preview_title = format!("Preview: {} / {}", file.gist_id, file.filename);
+                let preview_title = state.preview_title(&file.gist_id, &file.filename);
                 jobs.spawn_gist_fetch_action(
                     state,
                     "Loading preview…",
@@ -302,7 +299,7 @@ pub(super) fn dispatch_outcome(
             if file.raw_url.is_none() {
                 file.raw_url = state.gist_file_raw_url(&file.gist_id, &file.filename);
             }
-            let preview_title = format!("Preview: {} / {}", file.gist_id, file.filename);
+            let preview_title = state.preview_title(&file.gist_id, &file.filename);
             jobs.spawn_gist_fetch_action(state, "Loading preview…", file, move |result, file| {
                 BgTaskOutcome::PreviewContent {
                     result,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1804,6 +1804,17 @@ impl AppState {
         group_gists(&files).into_iter().find(|g| g.id == gist_id)
     }
 
+    /// Title for the preview screen: leads with the gist's description, falling back to its id
+    /// when there is none — consistent with the Gist detail screen's title (issue #347).
+    pub fn preview_title(&self, gist_id: &str, filename: &str) -> String {
+        let identity = self
+            .group_by_id(gist_id)
+            .map(|g| g.description)
+            .filter(|d| !d.trim().is_empty())
+            .unwrap_or_else(|| format!("Gist {gist_id}"));
+        format!("Preview: {identity} / {filename}")
+    }
+
     /// The gist the current screen acts on: the gist-level cursor on `Gists`, the
     /// viewed gist on `GistDetail`, otherwise the gist owning the selected file row.
     /// Screen-aware so IO actions (open-in-browser, compact) target what the user sees.

--- a/src/tui/render.rs
+++ b/src/tui/render.rs
@@ -495,6 +495,28 @@ fn gist_badge_prefix(starred: bool, forked: bool) -> String {
     prefix
 }
 
+/// Fixed-width badge column (★ starred, ⑂ forked, or blank) for the Gist manager row, so the
+/// segment that follows — the owner prefix, then the description — starts at the same column
+/// whether or not a row carries a badge (issue #347). Distinct from [`gist_badge_prefix`],
+/// which the List screen's Gist pane uses and which stays variable-width there.
+fn gist_manager_badge_prefix(starred: bool, forked: bool) -> String {
+    let star = if starred { '★' } else { ' ' };
+    let fork = if forked { '⑂' } else { ' ' };
+    format!("{star}{fork} ")
+}
+
+/// Width of the abbreviated-id column used by [`gist_group_row_label`] and the Pins row —
+/// long enough to disambiguate at a glance, fixed so a legacy (shorter) gist id still lines up
+/// with the columns that follow it (issue #347).
+const SHORT_ID_WIDTH: usize = 7;
+
+/// A fixed-width, left-aligned abbreviation of a gist id — the id stays reachable inline
+/// without dominating the row the way the full 32-character id did.
+pub(super) fn short_gist_id(id: &str) -> String {
+    let short: String = id.chars().take(SHORT_ID_WIDTH).collect();
+    format!("{short:<SHORT_ID_WIDTH$}")
+}
+
 fn gist_owner_prefix(group: &GistGroup, current_user: Option<&str>) -> String {
     if group.owner_login.is_empty() {
         return String::new();
@@ -547,11 +569,11 @@ pub(super) fn gist_group_row_label(
         String::new()
     };
     format!(
-        "{}{}{}  {}  📄 {}{}{}{}  🕒 {}",
-        gist_badge_prefix(starred, g.fork_of_id.is_some()),
+        "{}{}{}  #{}  📄 {}{}{}{}  🕒 {}",
+        gist_manager_badge_prefix(starred, g.fork_of_id.is_some()),
         gist_owner_prefix(g, current_user),
-        g.id,
         desc,
+        short_gist_id(&g.id),
         g.file_count,
         comments_seg,
         stars_seg,

--- a/src/tui/screens/pins.rs
+++ b/src/tui/screens/pins.rs
@@ -152,6 +152,7 @@ pub(crate) struct PinLabelParams<'a> {
     pub icon: &'a str,
     pub local_path: &'a std::path::Path,
     pub gist_id: &'a str,
+    pub gist_description: Option<&'a str>,
     pub gist_filename: &'a str,
     pub local_age: &'a str,
     pub gist_age: &'a str,
@@ -160,15 +161,23 @@ pub(crate) struct PinLabelParams<'a> {
 /// Builds a single Pins-screen row. The local path is rendered with `display_path`
 /// (home → `~`) so it stays readable; the full row is horizontally scrollable. Pure so
 /// the path-shortening is unit-testable without a frame.
+///
+/// The gist description leads the identity (falling back to the filename alone when the gist
+/// has none), and the id trails as a fixed-width abbreviation — the full id no longer sits
+/// between the local path and filename dominating the row (issue #347).
 pub(crate) fn pin_row_label(params: PinLabelParams<'_>) -> String {
+    let identity = match params.gist_description.filter(|d| !d.trim().is_empty()) {
+        Some(desc) => format!("{desc} / {}", params.gist_filename),
+        None => params.gist_filename.to_string(),
+    };
     format!(
-        "{}  {}  ↔  {} / {}   (local {} · gist {})",
+        "{}  {}  ↔  {}   (local {} · gist {} · #{})",
         params.icon,
         crate::config::display_path(params.local_path),
-        params.gist_id,
-        params.gist_filename,
+        identity,
         params.local_age,
         params.gist_age,
+        crate::tui::render::short_gist_id(params.gist_id),
     )
 }
 
@@ -212,10 +221,12 @@ pub(crate) fn build_pins_vm(state: &AppState) -> PinsVm {
                 } else {
                     age(entry.local_ts)
                 };
+                let gist_description = state.group_by_id(&m.gist_id).map(|g| g.description);
                 let label = pin_row_label(PinLabelParams {
                     icon: status.icon(),
                     local_path: &m.local_path,
                     gist_id: &m.gist_id,
+                    gist_description: gist_description.as_deref(),
                     gist_filename: &m.gist_filename,
                     local_age: &local_age,
                     gist_age: &age(entry.remote_ts),

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -902,6 +902,25 @@ fn space_on_selected_gist_returns_preview_content() {
     ));
 }
 
+/// Issue #347: the Preview screen titles itself with the gist's description, consistent
+/// with the Gist detail screen, rather than the raw id.
+#[test]
+fn preview_title_uses_gist_description() {
+    let state = state_with_gists();
+    assert_eq!(state.preview_title("g1", "a.txt"), "Preview: demo / a.txt");
+}
+
+/// Issue #347: without a known description, the preview title still identifies the gist
+/// (falling back to its id) instead of silently showing just the filename.
+#[test]
+fn preview_title_falls_back_to_id_without_description() {
+    let state = initial_state();
+    assert_eq!(
+        state.preview_title("unknown-id", "a.txt"),
+        "Preview: Gist unknown-id / a.txt"
+    );
+}
+
 #[test]
 fn space_blocks_preview_for_image_gist_file() {
     let mut state = state_with_two_gists();
@@ -2926,6 +2945,7 @@ fn pin_row_label_shows_home_as_tilde() {
         icon: "✓",
         local_path: &home.join("code/gistui"),
         gist_id: "abc123",
+        gist_description: None,
         gist_filename: "notes.txt",
         local_age: "2h",
         gist_age: "3h",
@@ -2935,6 +2955,51 @@ fn pin_row_label_shows_home_as_tilde() {
         "expected ~ home in label, got {label}"
     );
     assert!(!label.contains(home.to_string_lossy().as_ref()));
+}
+
+/// Issue #347: the gist description leads the identity (before the filename), and the full id
+/// is demoted to a trailing, `#`-prefixed abbreviation rather than sitting between the local
+/// path and the filename.
+#[test]
+fn pin_row_label_leads_with_description_and_abbreviates_id() {
+    let label = pin_row_label(PinLabelParams {
+        icon: "✓",
+        local_path: std::path::Path::new("/tmp/x"),
+        gist_id: "abcdef0123456789abcdef0123456789",
+        gist_description: Some("My cool gist"),
+        gist_filename: "notes.txt",
+        local_age: "2h",
+        gist_age: "3h",
+    });
+    assert!(
+        label.contains("My cool gist / notes.txt"),
+        "description should lead the filename: {label}"
+    );
+    assert!(
+        !label.contains("abcdef0123456789abcdef0123456789"),
+        "full id must not appear: {label}"
+    );
+    assert!(
+        label.contains("#abcdef0"),
+        "abbreviated id should still be reachable: {label}"
+    );
+}
+
+/// Issue #347: without a known description, the identity falls back to the filename alone
+/// (not a redundant "filename / filename").
+#[test]
+fn pin_row_label_falls_back_to_filename_without_description() {
+    let label = pin_row_label(PinLabelParams {
+        icon: "✓",
+        local_path: std::path::Path::new("/tmp/x"),
+        gist_id: "abc123",
+        gist_description: None,
+        gist_filename: "notes.txt",
+        local_age: "2h",
+        gist_age: "3h",
+    });
+    assert!(label.contains("↔  notes.txt "), "got {label}");
+    assert!(!label.contains("notes.txt / notes.txt"));
 }
 
 #[test]
@@ -3142,6 +3207,91 @@ fn gist_group_row_shows_star_marker_only_when_present() {
     assert!(
         gist_group_row_label(&group, now, GistGroupSort::Updated, (0, 3, 0), false, None)
             .contains("☆ 3")
+    );
+}
+
+/// Issue #347: the description leads the row (after the fixed-width badge/owner columns), and
+/// the full 32-char id no longer dominates it — only a short, `#`-prefixed abbreviation trails.
+#[test]
+fn gist_group_row_description_leads_and_id_is_abbreviated() {
+    let group = GistGroup {
+        id: "abcdef0123456789abcdef0123456789".into(),
+        description: "My cool gist".into(),
+        public: false,
+        updated_at: "2026-06-10T00:00:00Z".into(),
+        created_at: "2026-06-01T00:00:00Z".into(),
+        file_count: 2,
+        owner_login: String::new(),
+        fork_of_id: None,
+    };
+    let now = crate::domain::parse_rfc3339_to_unix("2026-06-11T00:00:00Z").unwrap();
+    let row = gist_group_row_label(&group, now, GistGroupSort::Updated, (0, 0, 0), false, None);
+    assert!(
+        row.trim_start().starts_with("My cool gist"),
+        "description should lead the row, got {row}"
+    );
+    assert!(!row.contains(&group.id), "full id must not appear: {row}");
+    assert!(
+        row.contains(&format!("#{}", &group.id[..7])),
+        "abbreviated id should still be reachable inline: {row}"
+    );
+}
+
+/// Issue #347: the badge column is fixed-width, so a starred row's description starts at the
+/// same column as an unstarred row's.
+#[test]
+fn gist_group_row_badge_column_is_fixed_width() {
+    let group = GistGroup {
+        id: "g1".into(),
+        description: "demo".into(),
+        public: false,
+        updated_at: "2026-06-10T00:00:00Z".into(),
+        created_at: "2026-06-01T00:00:00Z".into(),
+        file_count: 1,
+        owner_login: String::new(),
+        fork_of_id: None,
+    };
+    let now = crate::domain::parse_rfc3339_to_unix("2026-06-11T00:00:00Z").unwrap();
+    let unbadged =
+        gist_group_row_label(&group, now, GistGroupSort::Updated, (0, 0, 0), false, None);
+    let starred = gist_group_row_label(&group, now, GistGroupSort::Updated, (0, 0, 0), true, None);
+    // Compare by char count, not byte offset — `★` is multi-byte, so a byte-offset comparison
+    // would report misalignment even though the two rows line up on screen.
+    let char_col = |s: &str| s.find("demo").map(|byte_idx| s[..byte_idx].chars().count());
+    assert_eq!(
+        char_col(&unbadged),
+        char_col(&starred),
+        "description column must align with and without a badge: {unbadged:?} vs {starred:?}"
+    );
+}
+
+/// Issue #347: a legacy (shorter than the abbreviation width) gist id still pads the id column
+/// out to its usual width, so the `📄` segment that follows stays aligned across rows.
+#[test]
+fn gist_group_row_legacy_short_id_still_aligns() {
+    let short = GistGroup {
+        id: "abc12".into(),
+        description: "demo".into(),
+        public: false,
+        updated_at: "2026-06-10T00:00:00Z".into(),
+        created_at: "2026-06-01T00:00:00Z".into(),
+        file_count: 1,
+        owner_login: String::new(),
+        fork_of_id: None,
+    };
+    let long = GistGroup {
+        id: "abcdef0123456789".into(),
+        ..short.clone()
+    };
+    let now = crate::domain::parse_rfc3339_to_unix("2026-06-11T00:00:00Z").unwrap();
+    let short_row =
+        gist_group_row_label(&short, now, GistGroupSort::Updated, (0, 0, 0), false, None);
+    let long_row = gist_group_row_label(&long, now, GistGroupSort::Updated, (0, 0, 0), false, None);
+    assert_eq!(
+        short_row.find('📄'),
+        long_row.find('📄'),
+        "the file-count marker must land at the same column regardless of id length: \
+         {short_row:?} vs {long_row:?}"
     );
 }
 


### PR DESCRIPTION
## Summary
- Preview screen now titles itself with the gist's description (falling back to its id), matching the Gist detail screen's title logic — previously it always showed the raw id.
- Gist manager rows now lead with the description; the id trails as a fixed-width, `#`-abbreviated column padded to align even with a legacy (shorter) id.
- Pinned Mappings rows now lead with the gist description (falling back to the filename alone) instead of a full id sitting between the local path and filename.
- The Gist manager's star/fork badge column is now fixed-width, so the description starts at the same column with or without a badge.
- Copying a gist's URL/id is unaffected — the full id was always threaded separately from these display strings.

Closes #347

## Test plan
- [x] `mise run check` (fmt, clippy, full test suite, cargo check) — all pass
- [x] Two-axis code review (Standards + Spec) — no blocking findings
- [x] New tests: description-leads + id-abbreviation for both Gist manager and Pins rows, fixed-width badge column alignment, legacy short-id alignment, preview title description/fallback