### PR TITLE
fix(tui): show the gist's real update time in the diff header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The quit prompt now names every key that confirms it (`q` and `Esc`), the top-bar `(g)ists` mnemonic now matches the lowercase key that actually opens it, and a command-palette query with no matches now shows an explicit "no matches" message instead of an empty frame.
 - Preview now titles itself with the gist's description (consistent with Gist detail); Gist manager and Pinned Mappings rows now lead with the description instead of the raw id, which is demoted to a fixed-width, `#`-abbreviated column that stays aligned even with a starred/forked badge or a legacy short id.
+- The diff header now shows the gist file's real update time (matching Gist manager and Pinned Mappings) whenever it's already loaded in memory, instead of always showing `(unknown)`.
 - Gist detail now shows every file's size and type, the total size in its Files title, and the comment total in its tab.
 - Saving configuration now records only changed settings (plus pinned mappings), so later default changes apply to users who have not overridden them.
 - Recursive file discovery now includes hidden files and directories like the flat view, skips only configured directories plus `.git`, `.hg`, and `.svn`, and collapses symlink aliases without losing pinned paths.

--- a/src/tui/bg.rs
+++ b/src/tui/bg.rs
@@ -453,7 +453,8 @@ pub(super) fn spawn_pin_push(
     // Upload Confirm is opened when UploadPreview completes (staged return is Pins).
     let raw_url = state.gist_file_raw_url(&gist_id, &filename);
     let file = crate::domain::GistFileRef::new(gist_id, filename, raw_url);
-    let (local_label, gist_label) = diff_labels(Some(&local_path), &file.to_gist_file());
+    let (local_label, gist_label) =
+        diff_labels(Some(&local_path), &state.gist_file_for_diff(&file));
     jobs.spawn_gist_fetch_action(state, "Loading diff…", file, move |result, file| {
         BgTaskOutcome::UploadPreview {
             result,
@@ -478,7 +479,7 @@ pub(super) fn spawn_pin_pull(
     let filename = m.gist_filename.clone();
     let raw_url = state.gist_file_raw_url(&gist_id, &filename);
     let file = crate::domain::GistFileRef::new(gist_id, filename, raw_url);
-    let (local_label, gist_label) = diff_labels(Some(&target), &file.to_gist_file());
+    let (local_label, gist_label) = diff_labels(Some(&target), &state.gist_file_for_diff(&file));
     jobs.spawn_gist_fetch_action(state, "Downloading…", file, move |result, file| {
         BgTaskOutcome::DownloadSelected {
             result,
@@ -501,22 +502,10 @@ pub(super) fn spawn_pin_diff(
     let filename = m.gist_filename.clone();
     // Stage pin identity so enter_diff copies it onto DiffState (is_pin_diff_context).
     state.staged_diff_gist = Some((gist_id.clone(), filename.clone()));
-    // Pull the real `updated_at` from the loaded gists so the diff header shows the
-    // gist mtime (matching the Pins list) instead of "unknown".
-    let updated_at = state
-        .gists
-        .iter()
-        .find(|g| g.gist_id == gist_id && g.filename == filename)
-        .map(|g| g.updated_at.clone())
-        .unwrap_or_default();
     let raw_url = state.gist_file_raw_url(&gist_id, &filename);
-    let gist_file = GistFile {
-        updated_at,
-        ..GistFile::for_sync(gist_id.clone(), filename.clone(), raw_url.clone())
-    };
-    let (local_label, gist_label) = diff_labels(Some(&local_abs), &gist_file);
-    let target = local_abs.clone();
     let file = crate::domain::GistFileRef::new(gist_id, filename, raw_url);
+    let (local_label, gist_label) = diff_labels(Some(&local_abs), &state.gist_file_for_diff(&file));
+    let target = local_abs.clone();
     jobs.spawn_gist_fetch_action(state, "Loading diff…", file, move |result, _file| {
         BgTaskOutcome::PreviewDiff {
             result,

--- a/src/tui/dispatch.rs
+++ b/src/tui/dispatch.rs
@@ -23,7 +23,7 @@ pub(super) fn dispatch_outcome(
         } => {
             // List-originated diff returns to List on Esc.
             state.pending_return = Some(Screen::List);
-            let gist = file.to_gist_file();
+            let gist = state.gist_file_for_diff(&file);
             let (local_label, gist_label) = diff_labels(local_path.as_deref(), &gist);
 
             jobs.spawn_gist_fetch_action(state, "Loading diff…", file, move |result, _file| {
@@ -46,7 +46,7 @@ pub(super) fn dispatch_outcome(
             }
         }
         KeyOutcome::DownloadGist { file, target } => {
-            let gist = file.to_gist_file();
+            let gist = state.gist_file_for_diff(&file);
             let (local_label, gist_label) = diff_labels(Some(&target), &gist);
 
             jobs.spawn_gist_fetch_action(state, "Downloading…", file, move |result, file| {
@@ -176,12 +176,7 @@ pub(super) fn dispatch_outcome(
             if !from_pin_diff {
                 state.pending_return = Some(Screen::List);
             }
-            let gist_file = state
-                .gists
-                .iter()
-                .find(|g| g.gist_id == file.gist_id && g.filename == file.filename)
-                .cloned()
-                .unwrap_or_else(|| file.to_gist_file());
+            let gist_file = state.gist_file_for_diff(&file);
             let (local_label, gist_label) = diff_labels(Some(&local_path), &gist_file);
             // Prefer list-row raw_url when present (may be richer than the outcome's ref).
             let mut file = file;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1476,11 +1476,29 @@ impl AppState {
             .unwrap_or_default()
     }
 
-    /// `raw_url` from the in-memory gist lists for a `(gist_id, filename)` pair.
-    pub fn gist_file_raw_url(&self, gist_id: &str, filename: &str) -> Option<String> {
+    /// The in-memory owned/starred gist-file row for a `(gist_id, filename)` pair, shared by
+    /// every lookup that needs one field or another off the real list row.
+    fn find_gist_file(&self, gist_id: &str, filename: &str) -> Option<&GistFile> {
         self.all_gist_files()
             .find(|g| g.gist_id == gist_id && g.filename == filename)
+    }
+
+    /// `raw_url` from the in-memory gist lists for a `(gist_id, filename)` pair.
+    pub fn gist_file_raw_url(&self, gist_id: &str, filename: &str) -> Option<String> {
+        self.find_gist_file(gist_id, filename)
             .and_then(|g| g.raw_url.clone())
+    }
+
+    /// Resolves a throwaway `GistFileRef` (the diff/sync identity, which carries none of the
+    /// list-row metadata — see its doc comment) into a full `GistFile` for diff-header display:
+    /// the matching row from the in-memory owned/starred lists when one exists (carrying its
+    /// real `updated_at`, `raw_url`, etc.), else the bare `to_gist_file()` fallback. Without
+    /// this, the diff header's gist side always showed `(unknown)` even when the same gist's
+    /// age was visible in the Gist manager or Pinned Mappings (issue #348).
+    pub fn gist_file_for_diff(&self, file: &GistFileRef) -> GistFile {
+        self.find_gist_file(&file.gist_id, &file.filename)
+            .cloned()
+            .unwrap_or_else(|| file.to_gist_file())
     }
 
     pub fn gist_is_owned(&self, gist_id: &str) -> bool {

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -144,6 +144,61 @@ pub(super) fn state_with_local_paths(paths: &[&str]) -> AppState {
     state
 }
 
+/// Issue #348: the diff header's gist side must show the real update time when the gist is
+/// already loaded in memory (e.g. it's listed in Gist manager or Pinned Mappings), not
+/// `(unknown)` — the throwaway `GistFileRef` used to fetch/sync carries no `updated_at` of
+/// its own, so `gist_file_for_diff` must fill it in from the owned/starred lists.
+#[test]
+fn gist_file_for_diff_fills_updated_at_from_loaded_gists() {
+    let state = state_with_gists();
+    let file = GistFileRef::id_name("g1", "a.txt");
+    let resolved = state.gist_file_for_diff(&file);
+    assert_eq!(resolved.updated_at, "2026-06-10T00:00:00Z");
+
+    let (_, gist_label) = diff_labels(None, &resolved);
+    assert!(
+        gist_label.contains("2026-06-10 00:00 UTC"),
+        "expected the real timestamp in the header, got {gist_label}"
+    );
+    assert!(!gist_label.contains("unknown"), "got {gist_label}");
+}
+
+/// Issue #348: `(unknown)` is still shown, but only when the gist genuinely isn't loaded
+/// anywhere in memory — not as the default for every diff.
+#[test]
+fn gist_file_for_diff_falls_back_to_unknown_for_an_unloaded_gist() {
+    let state = initial_state();
+    let file = GistFileRef::id_name("never-loaded", "a.txt");
+    let resolved = state.gist_file_for_diff(&file);
+    let (_, gist_label) = diff_labels(None, &resolved);
+    assert!(gist_label.contains("(unknown)"), "got {gist_label}");
+}
+
+/// Issue #348: the lookup must also cover starred (not just owned) gists — one of the call
+/// sites this fix replaced only checked `state.gists`, so a starred gist's diff header still
+/// showed `(unknown)` even though its age was visible in Pinned Mappings.
+#[test]
+fn gist_file_for_diff_finds_a_starred_gist_too() {
+    let mut state = initial_state();
+    state.starred_gists = vec![GistFile {
+        gist_id: "s1".into(),
+        description: "starred demo".into(),
+        filename: "notes.md".into(),
+        public: true,
+        updated_at: "2026-06-12T08:00:00Z".into(),
+        created_at: "2026-06-01T00:00:00Z".into(),
+        owner_login: "someone-else".into(),
+        fork_of_id: None,
+        raw_url: None,
+        content_type: None,
+        size: 0,
+        node_id: None,
+    }];
+    let file = GistFileRef::id_name("s1", "notes.md");
+    let resolved = state.gist_file_for_diff(&file);
+    assert_eq!(resolved.updated_at, "2026-06-12T08:00:00Z");
+}
+
 #[test]
 fn local_filter_matches_filename_and_relative_path() {
     let mut state =


### PR DESCRIPTION
## Summary
- The diff header's gist side always showed `(unknown)` because the throwaway `GistFileRef` identity used for fetch/sync (deliberately stripped of list-row metadata, issue #276) carries no `updated_at` of its own — even though the same gist's age was already loaded in memory and visible in the Gist manager or Pinned Mappings.
- Added `AppState::gist_file_for_diff`, which resolves a `GistFileRef` against the in-memory owned/starred gist lists (falling back to the bare `to_gist_file()` only when the gist genuinely isn't loaded), and switched every diff/preview/download/upload entry point to use it.
- Two pin-diff paths had already grown ad hoc, narrower versions of this same lookup (owned gists only, missing starred); both now share the one helper via a small private `find_gist_file`.
- Timestamp formatting/timezone convention was already shared with the local side (`gist_time_label`/`file_mtime_label`); this fix is purely about the gist-side data actually being populated.
- The header line renders through the same horizontal-scroll/wrap mechanics as every other diff line, so no new narrow-terminal handling was needed.

Closes #348

## Test plan
- [x] `mise run check` (fmt, clippy, full test suite, cargo check) — all pass
- [x] Two-axis code review (Standards + Spec) — no blocking findings; addressed two follow-ups (extracted a shared `find_gist_file` helper, added a starred-gist coverage test)
- [x] New tests: known-timestamp header, genuinely-unloaded fallback, starred-gist lookup