### PR TITLE
refactor(tui): one keymap table, three derived renderings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- The `?` help now documents `Tab` on the Help screen (it opens the topic index), and the
+  command palette accents `Smart-sync`, `Fork gist`, and `Restore revision` as the writes they
+  are — `Pin / unpin pair` no longer reads as a destructive action.
 - Revision history rows now behave like every other list screen: a clipped row ends in an
   ellipsis (`…`) instead of looking complete, rows are clamped to the pane width, and
   `←`/`→` scrolls only the selected row behind a leading `…` rather than shifting the

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -30,6 +30,22 @@ handle_key (pure) → KeyOutcome → run_loop / dispatch_outcome (IO)
 - New IO → `dispatch` / `bg` helpers, not `handle_key`.
 - IO-bearing `KeyOutcome` variants carry payloads (issue #244): `@src/tui/mod.rs` (`KeyOutcome`), `@src/tui/dispatch.rs`.
 
+## Keymap (`@src/tui/keymap.rs`)
+
+`keymap::for_screen` returns one table per screen describing every key it binds (issue #369). The table **describes**; it does not dispatch and it does not gate — `handle_key_*` still executes keys, and `*_guard` still answers "is this available right now" (issue #288). Adding a key means adding a row *and* a `handle_key_*` arm; the tests below make the omission loud.
+
+Three renderings derive from it — do not hand-write any of them again:
+
+- **Palette rows** — `build_palette_items` walks the table and calls the screen's guard. There are no per-screen `*_palette_items` builders any more.
+- **Footer hints** — `keymap::footer_hints`, ordered by `FooterHint::rank`. Only the three screens with a `footer` column get one; the rest paint `MINIMAL_HINT`, and `footer_hints` returns `""` for them.
+- **Action colour** — `Category` → `category_color`. Paint never infers a category from wording.
+
+Two columns exist because the two surfaces genuinely disagree, not by oversight: `FooterHint::rank` is separate because footer order leads with navigation while palette order leads with actions, and `FooterHint::key` is separate because the footer names every key that leaves a screen (`Esc/q`) where the palette names the one it executes (`q`).
+
+**`Category` is about the user's data, not about persistence.** Changing a setting writes `config.toml` and is still `Nav`; `Write` means a gist, a local file, or the pin list moves; `Destructive` means something does not come back.
+
+Help topics and `README.md` stay hand-written — the List topic is fifty lines of sectioned prose, and generating it would flatten explanation to win a check a test can do instead. `keymap::docs_tests` is that check, in both directions: every bound key must appear in its help topic or in General (#344's direction), and every key `README.md`'s Key/Action table promises must be bound (#346's direction).
+
 ## Background jobs
 
 - **`Jobs`** is the single registry: spawn / absorb / cancel (`@src/tui/bg.rs`, issue #243).

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -1,0 +1,416 @@
+//! One table per screen describing every key that screen binds (issue #369).
+//!
+//! The table is a *description*, not a dispatcher and not a gate: `handle_key_*` still executes
+//! keys, and `*_guard` still decides whether an action is available right now (issue #288). What
+//! lives here is the wording and the classification that used to be hand-written once per
+//! rendering — the palette row, the footer hint, and the action colour — so the four copies of
+//! "what does `d` do" cannot drift apart again (#344, #346).
+//!
+//! Help topics and `README.md` stay hand-written prose: the List topic is fifty lines of
+//! sectioned explanation, and flattening it into a generated key list would cost more than the
+//! consistency it buys. Tests check them against this table instead.
+
+use super::Screen;
+use crossterm::event::KeyCode;
+
+/// What a key risks, which is what its accent colour tells the reader — the fact `action_color`
+/// used to infer by word-splitting the label, with a comment admitting the guess was fragile.
+///
+/// The line is drawn at *the user's data*, not at "does anything persist": changing a setting
+/// writes `config.toml` but is still [`Nav`](Category::Nav), because no gist and no local file
+/// moves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Category {
+    /// Moving around, switching panes, opening or leaving a screen, changing what is displayed,
+    /// adjusting a setting.
+    Nav,
+    /// Looking at content, or copying it out, without changing it.
+    Read,
+    /// Changing a gist, a local file, or the pin list.
+    Write,
+    /// Removing something that does not come back.
+    Destructive,
+}
+
+/// A binding's place in its screen's footer. `None` on [`Binding::footer`] keeps the key off the
+/// footer entirely — most keys are palette-only.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct FooterHint {
+    /// Position in the footer, which is deliberately not the palette's order: the footer leads
+    /// with navigation, the palette leads with actions.
+    pub rank: u8,
+    /// How the footer writes the key. Not always [`Binding::key_hint`] — the footer names every
+    /// key that leaves a screen (`Esc/q`), the palette names only the one it executes (`q`).
+    pub key: &'static str,
+    /// Footer wording. The footer paints `"{key} {text}"`.
+    pub text: &'static str,
+}
+
+/// One key on one screen, described once.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Binding {
+    /// How the palette and help write the key: `"d"`, `"Tab"`, `"h/l"`, `"↑↓"`.
+    pub key_hint: &'static str,
+    /// The key the palette executes for this row, and the key its guard is asked about.
+    ///
+    /// `None` is a binding the palette never shows — pure navigation (`↑↓`, `Esc/q`), described
+    /// here only for the footer and help. Where `key_hint` covers several keys (`"h/l"`), this
+    /// is the one the palette sends; the table describes bindings, so which keys reach
+    /// `handle_key_*` is that function's business, not this one's.
+    pub code: Option<KeyCode>,
+    /// Palette row text: `"Download gist → cwd"`.
+    pub label: &'static str,
+    pub category: Category,
+    pub footer: Option<FooterHint>,
+    /// Whether the screen's `*_guard` decides this key's availability. `false` means the palette
+    /// row is always enabled.
+    pub guarded: bool,
+}
+
+impl Binding {
+    /// A palette action gated by the screen's `*_guard`.
+    const fn action(
+        key_hint: &'static str,
+        code: KeyCode,
+        label: &'static str,
+        category: Category,
+    ) -> Self {
+        Self {
+            key_hint,
+            code: Some(code),
+            label,
+            category,
+            footer: None,
+            guarded: true,
+        }
+    }
+
+    /// A palette action that is always available.
+    const fn always(
+        key_hint: &'static str,
+        code: KeyCode,
+        label: &'static str,
+        category: Category,
+    ) -> Self {
+        Self {
+            guarded: false,
+            ..Self::action(key_hint, code, label, category)
+        }
+    }
+
+    /// Navigation described for the footer and help, with no palette row and so no key for the
+    /// palette to send.
+    const fn nav(key_hint: &'static str, label: &'static str) -> Self {
+        Self {
+            code: None,
+            ..Self::always(key_hint, KeyCode::Null, label, Category::Nav)
+        }
+    }
+
+    /// Put this binding on the footer at `rank`, worded `"{key} {text}"`.
+    const fn footer(mut self, rank: u8, key: &'static str, text: &'static str) -> Self {
+        self.footer = Some(FooterHint { rank, key, text });
+        self
+    }
+}
+
+/// Every key `screen` binds, in palette order. Screens with no palette of their own (the palette
+/// itself, the confirm modal) return an empty table.
+pub(crate) fn for_screen(screen: &Screen) -> &'static [Binding] {
+    match screen {
+        Screen::List => LIST,
+        Screen::Pins(_) => PINS,
+        Screen::Gists(_) => GISTS,
+        Screen::GistDetail(_) => DETAIL,
+        Screen::Revisions(_) => REVISIONS,
+        Screen::Diff(_) => DIFF,
+        Screen::Preview(_) => PREVIEW,
+        Screen::Help(_) => HELP,
+        Screen::Config(_) => CONFIG,
+        Screen::Confirm(_) | Screen::Palette(_) => &[],
+    }
+}
+
+/// The screen's footer hint string, in `rank` order — the wording the footer used to carry as a
+/// hand-written `*_HINTS` constant. Screens whose bindings all sit off the footer get `""`; they
+/// paint `MINIMAL_HINT` instead.
+pub(crate) fn footer_hints(screen: &Screen) -> String {
+    let mut hints: Vec<FooterHint> = for_screen(screen)
+        .iter()
+        .filter_map(|binding| binding.footer)
+        .collect();
+    hints.sort_unstable_by_key(|hint| hint.rank);
+    hints
+        .iter()
+        .map(|hint| format!("{} {}", hint.key, hint.text))
+        .collect::<Vec<_>>()
+        .join(FOOTER_SEPARATOR)
+}
+
+/// How the footer joins its items. `fit_hints` splits on the `·` to drop whole items when the
+/// terminal is too narrow (issue #342).
+pub(crate) const FOOTER_SEPARATOR: &str = "  ·  ";
+
+/// The category of the binding a footer item's leading key token names, for accenting that key.
+/// A token no binding claims — `;` and `Ctrl+p` in `MINIMAL_HINT`, or
+/// a status message that is not a hint list at all — reads as [`Category::Nav`].
+pub(crate) fn category_for_footer_key(bindings: &[Binding], key: &str) -> Category {
+    bindings
+        .iter()
+        .filter_map(|binding| binding.footer.map(|hint| (hint.key, binding.category)))
+        .find(|(hint_key, _)| *hint_key == key)
+        .map_or(Category::Nav, |(_, category)| category)
+}
+
+use Category::{Destructive, Nav, Read, Write};
+
+const LIST: &[Binding] = &[
+    Binding::action("Enter", KeyCode::Enter, "Diff local ↔ gist", Read).footer(2, "Enter", "diff"),
+    Binding::action("Space", KeyCode::Char(' '), "Preview gist content", Read),
+    Binding::action("d", KeyCode::Char('d'), "Download gist → cwd", Write)
+        .footer(3, "d", "download"),
+    Binding::action("u", KeyCode::Char('u'), "Upload local → gist", Write).footer(4, "u", "upload"),
+    Binding::action("n", KeyCode::Char('n'), "Create gist from local", Write)
+        .footer(5, "n", "new gist"),
+    Binding::action("p", KeyCode::Char('p'), "Pin / unpin pair", Write).footer(6, "p", "pin"),
+    Binding::always("P", KeyCode::Char('P'), "Open Pins view", Nav).footer(7, "P", "pins"),
+    Binding::action("g", KeyCode::Char('g'), "Open Gist manager", Nav).footer(8, "g", "gists"),
+    Binding::action("S", KeyCode::Char('S'), "Smart-sync pinned pair", Write),
+    Binding::action(
+        "X",
+        KeyCode::Char('X'),
+        "Remove file from gist",
+        Destructive,
+    ),
+    Binding::action("e", KeyCode::Char('e'), "Edit local file", Write),
+    Binding::action("y", KeyCode::Char('y'), "Copy gist URL", Read),
+    Binding::action("H", KeyCode::Char('H'), "Revision history", Read),
+    Binding::action("*", KeyCode::Char('*'), "Star / unstar gist", Write),
+    Binding::always("r", KeyCode::Char('r'), "Toggle recursive scan", Nav),
+    Binding::always("/", KeyCode::Char('/'), "Filter focused pane", Nav).footer(9, "/", "filter"),
+    Binding::always("Tab", KeyCode::Tab, "Switch pane", Nav).footer(1, "Tab", "panes"),
+    Binding::always("a", KeyCode::Char('a'), "Flip ranking anchor", Nav),
+    Binding::always("t", KeyCode::Char('t'), "Toggle description / id", Nav),
+    Binding::always("v", KeyCode::Char('v'), "Cycle gist visibility", Nav),
+    Binding::always("s", KeyCode::Char('s'), "Cycle pane sort", Nav),
+    Binding::always("?", KeyCode::Char('?'), "Help", Nav),
+    Binding::nav("↑↓", "Move the selection").footer(0, "↑↓", "move"),
+    Binding::nav("Esc/q", "Leave the screen").footer(10, "Esc/q", "back"),
+];
+
+const GISTS: &[Binding] = &[
+    Binding::action("Enter", KeyCode::Enter, "Open gist detail", Read).footer(1, "Enter", "detail"),
+    Binding::action("o", KeyCode::Char('o'), "Open in browser", Read).footer(3, "o", "browser"),
+    Binding::action("y", KeyCode::Char('y'), "Copy gist URL", Read).footer(4, "y", "copy URL"),
+    Binding::action("H", KeyCode::Char('H'), "Revision history", Read).footer(5, "H", "revisions"),
+    Binding::action("*", KeyCode::Char('*'), "Star / unstar gist", Write).footer(2, "*", "star"),
+    Binding::always("/", KeyCode::Char('/'), "Filter gists", Nav).footer(8, "/", "filter"),
+    Binding::always("s", KeyCode::Char('s'), "Cycle sort", Nav).footer(6, "s", "sort"),
+    Binding::always("v", KeyCode::Char('v'), "Cycle visibility", Nav).footer(7, "v", "visibility"),
+    Binding::always("q", KeyCode::Char('q'), "Back to list", Nav),
+    Binding::always("?", KeyCode::Char('?'), "Help", Nav),
+    Binding::nav("↑↓", "Move the selection").footer(0, "↑↓", "move"),
+    Binding::nav("Esc/q", "Leave the screen").footer(9, "Esc/q", "back"),
+];
+
+const PINS: &[Binding] = &[
+    Binding::action("Enter", KeyCode::Enter, "Diff pinned pair", Read).footer(1, "Enter", "diff"),
+    Binding::action("s", KeyCode::Char('s'), "Smart-sync", Write).footer(2, "s", "sync"),
+    Binding::action("u", KeyCode::Char('u'), "Force push", Write).footer(3, "u", "push"),
+    Binding::action("d", KeyCode::Char('d'), "Force pull", Write).footer(4, "d", "pull"),
+    Binding::action("x", KeyCode::Char('x'), "Unpin pair", Destructive).footer(5, "x", "unpin"),
+    Binding::always("/", KeyCode::Char('/'), "Filter pins", Nav).footer(7, "/", "filter"),
+    Binding::always("o", KeyCode::Char('o'), "Cycle sort", Nav).footer(6, "o", "sort"),
+    Binding::always("q", KeyCode::Char('q'), "Back to list", Nav),
+    Binding::always("?", KeyCode::Char('?'), "Help", Nav),
+    Binding::nav("↑↓", "Move the selection").footer(0, "↑↓", "move"),
+    Binding::nav("Esc/q", "Leave the screen").footer(8, "Esc/q", "back"),
+];
+
+const DETAIL: &[Binding] = &[
+    Binding::action("Enter", KeyCode::Enter, "Preview selected file", Read),
+    Binding::action("o", KeyCode::Char('o'), "Open in browser", Read),
+    Binding::action("y", KeyCode::Char('y'), "Copy gist URL", Read),
+    Binding::action("H", KeyCode::Char('H'), "Revision history", Read),
+    Binding::action("e", KeyCode::Char('e'), "Edit description", Write),
+    Binding::action("c", KeyCode::Char('c'), "Compact revisions", Nav),
+    Binding::action("*", KeyCode::Char('*'), "Star / unstar gist", Write),
+    Binding::action("F", KeyCode::Char('F'), "Fork gist", Write),
+    Binding::action("X", KeyCode::Char('X'), "Delete gist", Destructive),
+    Binding::always("Tab", KeyCode::Tab, "Switch Files / Comments", Nav),
+    Binding::action("m", KeyCode::Char('m'), "Load older comments", Read),
+    Binding::always("q", KeyCode::Char('q'), "Back to Gist manager", Nav),
+    Binding::always("?", KeyCode::Char('?'), "Help", Nav),
+];
+
+const REVISIONS: &[Binding] = &[
+    Binding::action("Enter", KeyCode::Enter, "Diff parent → revision", Read),
+    Binding::action("D", KeyCode::Char('D'), "Diff revision vs head", Read),
+    Binding::action("r", KeyCode::Char('r'), "Restore revision", Write),
+    // The palette *is* gated through `revisions_guard` here, unlike the real handler's own `F`
+    // arm (which stays unconditional — see the comment on that case in `revisions_guard`):
+    // cycling the target file doesn't need the revision list loaded, so `revisions_guard`'s `F`
+    // case checks file count, not `has_entries` (issue #288).
+    Binding::action("F", KeyCode::Char('F'), "Cycle target file", Nav),
+    Binding::always("q", KeyCode::Char('q'), "Back", Nav),
+    Binding::always("?", KeyCode::Char('?'), "Help", Nav),
+];
+
+const DIFF: &[Binding] = &[
+    Binding::action("d", KeyCode::Char('d'), "Download", Write),
+    Binding::action("u", KeyCode::Char('u'), "Upload", Write),
+    Binding::always("c", KeyCode::Char('c'), "Toggle full diff context", Nav),
+    Binding::always("w", KeyCode::Char('w'), "Toggle line wrap", Nav),
+    Binding::always("q", KeyCode::Char('q'), "Back", Nav),
+];
+
+const PREVIEW: &[Binding] = &[
+    Binding::always("R", KeyCode::Char('R'), "Refresh content", Read),
+    Binding::always("w", KeyCode::Char('w'), "Toggle line wrap", Nav),
+    Binding::always("y", KeyCode::Char('y'), "Copy gist URL", Read),
+    Binding::always("Y", KeyCode::Char('Y'), "Copy file content", Read),
+    Binding::always("q", KeyCode::Char('q'), "Back", Nav),
+];
+
+const CONFIG: &[Binding] = &[
+    Binding::always("Enter", KeyCode::Enter, "Toggle / increase value", Nav),
+    Binding::always("h/l", KeyCode::Char('l'), "Decrease / increase value", Nav),
+    Binding::always("Esc", KeyCode::Esc, "Close settings", Nav),
+];
+
+const HELP: &[Binding] = &[
+    Binding::always("Tab", KeyCode::Tab, "Browse topic index", Nav),
+    Binding::always("q", KeyCode::Char('q'), "Close Help", Nav),
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every screen's table, for the invariants that must hold across all of them.
+    fn all_tables() -> Vec<(&'static str, &'static [Binding])> {
+        vec![
+            ("List", LIST),
+            ("Gists", GISTS),
+            ("Pins", PINS),
+            ("Detail", DETAIL),
+            ("Revisions", REVISIONS),
+            ("Diff", DIFF),
+            ("Preview", PREVIEW),
+            ("Config", CONFIG),
+            ("Help", HELP),
+        ]
+    }
+
+    /// A footer is built by sorting on `rank`, so two bindings sharing one would paint in an
+    /// order the table does not pin down.
+    #[test]
+    fn footer_ranks_are_unique_within_a_screen() {
+        for (name, table) in all_tables() {
+            let mut ranks: Vec<u8> = table
+                .iter()
+                .filter_map(|b| b.footer)
+                .map(|f| f.rank)
+                .collect();
+            let count = ranks.len();
+            ranks.sort_unstable();
+            ranks.dedup();
+            assert_eq!(ranks.len(), count, "{name} has a duplicate footer rank");
+        }
+    }
+
+    /// The palette executes `code`, so two rows sharing one would send the same key twice.
+    #[test]
+    fn palette_codes_are_unique_within_a_screen() {
+        for (name, table) in all_tables() {
+            let mut codes: Vec<KeyCode> = table.iter().filter_map(|b| b.code).collect();
+            let count = codes.len();
+            codes.sort_by_key(|c| format!("{c:?}"));
+            codes.dedup();
+            assert_eq!(
+                codes.len(),
+                count,
+                "{name} binds one key to two palette rows"
+            );
+        }
+    }
+
+    /// `for_screen` must answer for every variant; the two screens without a palette of their
+    /// own answer with an empty table rather than a missing arm.
+    #[test]
+    fn for_screen_answers_for_every_variant() {
+        assert!(!for_screen(&Screen::List).is_empty());
+        assert!(!for_screen(&Screen::Pins(Box::default())).is_empty());
+        assert!(!for_screen(&Screen::Gists(Box::default())).is_empty());
+        assert!(!for_screen(&Screen::GistDetail(Box::default())).is_empty());
+        assert!(!for_screen(&Screen::Revisions(Box::default())).is_empty());
+        assert!(!for_screen(&Screen::Diff(Box::default())).is_empty());
+        assert!(!for_screen(&Screen::Preview(Box::default())).is_empty());
+        assert!(!for_screen(&Screen::Help(Box::default())).is_empty());
+        assert!(!for_screen(&Screen::Config(Box::default())).is_empty());
+        assert!(for_screen(&Screen::Confirm(Box::default())).is_empty());
+        assert!(for_screen(&Screen::Palette(Box::default())).is_empty());
+    }
+
+    /// The three footers this table replaced were hand-written constants. Pinning them verbatim
+    /// is what makes the move a refactor: `rank` has to reproduce the old order exactly, and the
+    /// wording has to survive the trip through `FooterHint`.
+    #[test]
+    fn derived_footers_match_the_strings_they_replaced() {
+        assert_eq!(
+            footer_hints(&Screen::List),
+            "↑↓ move  ·  Tab panes  ·  Enter diff  ·  d download  ·  u upload  ·  n new gist  ·  p pin  ·  P pins  ·  g gists  ·  / filter  ·  Esc/q back"
+        );
+        assert_eq!(
+            footer_hints(&Screen::Gists(Box::default())),
+            "↑↓ move  ·  Enter detail  ·  * star  ·  o browser  ·  y copy URL  ·  H revisions  ·  s sort  ·  v visibility  ·  / filter  ·  Esc/q back"
+        );
+        assert_eq!(
+            footer_hints(&Screen::Pins(Box::default())),
+            "↑↓ move  ·  Enter diff  ·  s sync  ·  u push  ·  d pull  ·  x unpin  ·  o sort  ·  / filter  ·  Esc/q back"
+        );
+    }
+
+    /// The eight screens that never had a footer of their own must not grow one: they paint
+    /// `MINIMAL_HINT`, and a stray `footer` on one of their bindings would silently replace it.
+    #[test]
+    fn screens_without_a_footer_derive_an_empty_one() {
+        for screen in [
+            Screen::GistDetail(Box::default()),
+            Screen::Revisions(Box::default()),
+            Screen::Diff(Box::default()),
+            Screen::Preview(Box::default()),
+            Screen::Help(Box::default()),
+            Screen::Config(Box::default()),
+            Screen::Confirm(Box::default()),
+            Screen::Palette(Box::default()),
+        ] {
+            assert_eq!(footer_hints(&screen), "", "{screen:?} grew a footer");
+        }
+    }
+
+    /// A footer key the table does not claim keeps the navigation accent rather than picking up
+    /// whichever binding happens to sort first.
+    #[test]
+    fn an_unclaimed_footer_key_reads_as_navigation() {
+        assert_eq!(category_for_footer_key(LIST, ";"), Category::Nav);
+        assert_eq!(category_for_footer_key(LIST, "d"), Category::Write);
+        // `q` alone is a palette row on some screens; the footer writes the leave key `Esc/q`.
+        assert_eq!(category_for_footer_key(GISTS, "q"), Category::Nav);
+    }
+
+    /// A binding with no palette row has no key for a guard to be asked about, so guarding one
+    /// would be a rule that never runs.
+    #[test]
+    fn navigation_bindings_are_never_guarded() {
+        for (name, table) in all_tables() {
+            for binding in table.iter().filter(|b| b.code.is_none()) {
+                assert!(
+                    !binding.guarded,
+                    "{name}'s {} is not a palette row, so no guard can apply to it",
+                    binding.key_hint
+                );
+            }
+        }
+    }
+}

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -414,3 +414,131 @@ mod tests {
         }
     }
 }
+
+/// The drift nets for the two renderings that stay hand-written prose (issue #369).
+///
+/// Deriving Help and `README.md` from the table would flatten explanation that earns its keep;
+/// checking them against it costs nothing and catches the same drift — the #344 direction (a key
+/// the docs forgot) and the #346 direction (a key the docs invented or mis-cased).
+#[cfg(test)]
+mod docs_tests {
+    use super::*;
+    use crate::tui::screens::help::help_topic_body;
+    use crate::tui::HelpTopic;
+
+    /// The topic that documents each screen's keys. Not `screens::*::HELP_TOPIC`, which answers a
+    /// different question — where `?` jumps to from that screen.
+    fn topics() -> Vec<(&'static str, &'static [Binding], HelpTopic)> {
+        vec![
+            ("List", LIST, HelpTopic::List),
+            ("Gists", GISTS, HelpTopic::GistManager),
+            ("Pins", PINS, HelpTopic::Pins),
+            ("Detail", DETAIL, HelpTopic::GistDetail),
+            ("Revisions", REVISIONS, HelpTopic::Revisions),
+            ("Diff", DIFF, HelpTopic::Diff),
+            ("Preview", PREVIEW, HelpTopic::Preview),
+            ("Config", CONFIG, HelpTopic::Config),
+            ("Help", HELP, HelpTopic::General),
+        ]
+    }
+
+    /// Every key a help body names, read from the key column alone.
+    ///
+    /// A key line is `"<keys>  <description>"`. The double space is what separates the key
+    /// column from the description, and is a more reliable marker than the leading indent, which
+    /// Rust's `\`-continuation strips from a body's first line — the line carrying `Esc / q`.
+    /// `/` separates alternatives (`Esc / q`, `Up/Down`), so it splits too.
+    ///
+    /// Only the key column counts. Reading keys out of descriptions too would let prose vouch
+    /// for a binding: a topic that had lost its `a` line would still pass on the strength of an
+    /// unrelated sentence starting with "a". That is why every key documented here gets its own
+    /// line rather than sharing one behind a `·`.
+    fn documented_keys(topic: HelpTopic) -> Vec<String> {
+        help_topic_body(topic)
+            .lines()
+            .filter_map(|line| line.trim().split_once("  "))
+            .flat_map(|(keys, _)| keys.split('/'))
+            .map(|key| key.trim().to_string())
+            .filter(|key| !key.is_empty())
+            .collect()
+    }
+
+    /// A binding's keys, as the table writes them: `"h/l"` is two keys, `"Esc/q"` is two.
+    fn binding_keys(binding: &Binding) -> Vec<&str> {
+        binding
+            .key_hint
+            .split('/')
+            .map(str::trim)
+            .filter(|k| !k.is_empty())
+            .collect()
+    }
+
+    /// Issue #344's direction: a key the table binds but no help topic mentions is a key the user
+    /// cannot discover. Screen-wide keys (`?`, `Esc`/`q`) live on the General topic rather than
+    /// being repeated on every screen, so both bodies count.
+    #[test]
+    fn every_bound_key_is_documented_in_help() {
+        let general = documented_keys(HelpTopic::General);
+        for (name, table, topic) in topics() {
+            let mut documented = documented_keys(topic);
+            documented.extend(general.iter().cloned());
+            for binding in table.iter().filter(|b| b.code.is_some()) {
+                for key in binding_keys(binding) {
+                    assert!(
+                        documented.iter().any(|d| d == key),
+                        "{name}'s `{key}` ({}) is bound but appears in neither the {topic:?} help \
+                         topic nor General",
+                        binding.label
+                    );
+                }
+            }
+        }
+    }
+
+    /// Issue #346's direction: `README.md`'s key table promises keys the List screen must
+    /// actually bind. Scoped to that one table — the Configuration table below it mentions keys
+    /// inside prose sentences, which is not a promise about the keymap.
+    #[test]
+    fn every_key_readme_promises_is_bound() {
+        let readme = include_str!("../../README.md");
+        // Bounded by the table's own shape rather than by a blank line: `str::lines` normalises
+        // the `\r\n` a Windows checkout leaves behind, whereas a `"\n\n"` search does not, and
+        // an unbounded table would swallow the Configuration table further down the file.
+        let table: Vec<&str> = readme
+            .lines()
+            .skip_while(|line| !line.starts_with("| Key | Action |"))
+            .skip(2)
+            .take_while(|line| line.starts_with("| "))
+            .collect();
+        assert!(
+            !table.is_empty(),
+            "README's Key/Action table moved or changed shape"
+        );
+
+        let bound: Vec<&str> = LIST
+            .iter()
+            .flat_map(binding_keys)
+            .chain(GISTS.iter().flat_map(binding_keys))
+            .collect();
+        // Keys README documents that belong to another screen or to the global set, neither of
+        // which the List and Gists tables carry.
+        let elsewhere = ["C", "T", ";", "Ctrl+p", "?", "j", "k", "h", "l", "1", "2"];
+
+        for row in table.iter().filter(|line| line.starts_with("| `")) {
+            let key_cell = row
+                .trim_start_matches("| ")
+                .split_once(" |")
+                .expect("a table row has a key cell and an action cell")
+                .0;
+            for key in key_cell.split('/').map(|k| k.trim().trim_matches('`')) {
+                if key.is_empty() || elsewhere.contains(&key) {
+                    continue;
+                }
+                assert!(
+                    bound.contains(&key),
+                    "README's key table promises `{key}`, which no List or Gists binding provides"
+                );
+            }
+        }
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -2340,6 +2340,7 @@ mod text;
 use text::{hscroll_max_among, hscroll_max_for_text, local_row_label};
 mod bg;
 mod dispatch;
+mod keymap;
 mod keys;
 mod list_cursor;
 pub(crate) use list_cursor::ListCursor;

--- a/src/tui/palette.rs
+++ b/src/tui/palette.rs
@@ -1,3 +1,4 @@
+use super::keymap::Category;
 use super::{keys::point_in, *};
 use crossterm::event::{KeyCode, KeyModifiers};
 
@@ -32,6 +33,8 @@ pub struct PaletteItem {
     pub label: String,
     pub exec: PaletteExec,
     pub enabled: bool,
+    /// What the action risks, which accents its key (see [`Category`]).
+    pub category: Category,
     /// Lowercased key+label string used for fuzzy filtering in command mode.
     pub search: String,
 }
@@ -140,22 +143,36 @@ impl AppState {
     }
 }
 
-fn palette_item(key: &str, label: &str, exec: PaletteExec, enabled: bool) -> PaletteItem {
+fn palette_item(
+    key: &str,
+    label: &str,
+    exec: PaletteExec,
+    enabled: bool,
+    category: Category,
+) -> PaletteItem {
     PaletteItem {
         key_hint: key.to_string(),
         label: label.to_string(),
         exec,
         enabled,
+        category,
         search: format!("{key} {label}").to_ascii_lowercase(),
     }
 }
 
-pub(super) fn key_item(key: &str, label: &str, code: KeyCode, enabled: bool) -> PaletteItem {
+pub(super) fn key_item(
+    key: &str,
+    label: &str,
+    code: KeyCode,
+    enabled: bool,
+    category: Category,
+) -> PaletteItem {
     palette_item(
         key,
         label,
         PaletteExec::Key(code, KeyModifiers::NONE),
         enabled,
+        category,
     )
 }
 
@@ -167,49 +184,79 @@ fn cross_items() -> Vec<PaletteItem> {
             "Go to Gists",
             PaletteExec::Cross(CrossAction::GoToGists),
             true,
+            Category::Nav,
         ),
         palette_item(
             "P",
             "Go to Pins",
             PaletteExec::Cross(CrossAction::GoToPins),
             true,
+            Category::Nav,
         ),
         palette_item(
             "?",
             "Go to Help",
             PaletteExec::Cross(CrossAction::OpenHelp),
             true,
+            Category::Nav,
         ),
         palette_item(
             "C",
             "Open settings",
             PaletteExec::Cross(CrossAction::OpenConfig),
             true,
+            Category::Nav,
         ),
         palette_item(
             "T",
             "Toggle theme",
             PaletteExec::Cross(CrossAction::ToggleTheme),
             true,
+            Category::Nav,
         ),
-        palette_item("q", "Quit", PaletteExec::Cross(CrossAction::Quit), true),
+        palette_item(
+            "q",
+            "Quit",
+            PaletteExec::Cross(CrossAction::Quit),
+            true,
+            Category::Nav,
+        ),
     ]
 }
 
+/// Whether the screen's own guard says `code` is available right now (issue #288). Screens
+/// whose keys are never gated — and the two with no table at all — answer `true`.
+fn guard_for(state: &AppState, screen: &Screen, code: KeyCode) -> bool {
+    use super::screens::{detail, diff, gists, list, pins, revisions};
+    match screen {
+        Screen::List => list::list_guard(state, code),
+        Screen::Pins(_) => pins::pins_guard(state, code),
+        Screen::Gists(_) => gists::gists_guard(state, code),
+        Screen::GistDetail(_) => detail::detail_guard(state, code),
+        Screen::Revisions(_) => revisions::revisions_guard(state, code),
+        Screen::Diff(_) => diff::diff_guard(state, code),
+        Screen::Preview(_) | Screen::Help(_) | Screen::Config(_) => true,
+        Screen::Confirm(_) | Screen::Palette(_) => true,
+    }
+}
+
+/// The screen's palette rows, in the keymap table's order. Command mode appends the
+/// screen-independent jumps.
 fn build_palette_items(state: &AppState, screen: &Screen, mode: PaletteMode) -> Vec<PaletteItem> {
-    let mut items = match screen {
-        Screen::List => super::screens::list::list_palette_items(state),
-        Screen::Pins(_) => super::screens::pins::pins_palette_items(state),
-        Screen::Gists(_) => super::screens::gists::gists_palette_items(state),
-        Screen::GistDetail(_) => super::screens::detail::detail_palette_items(state),
-        Screen::Revisions(_) => super::screens::revisions::revisions_palette_items(state),
-        Screen::Diff(_) => super::screens::diff::diff_palette_items(state),
-        Screen::Preview(_) => super::screens::preview::preview_palette_items(state),
-        Screen::Help(_) => super::screens::help::help_palette_items(),
-        Screen::Config(_) => super::screens::config::config_palette_items(),
-        Screen::Confirm(_) => super::screens::confirm::confirm_palette_items(state),
-        Screen::Palette(_) => super::screens::palette::palette_palette_items(state),
-    };
+    let mut items: Vec<PaletteItem> = super::keymap::for_screen(screen)
+        .iter()
+        .filter_map(|binding| binding.code.map(|code| (binding, code)))
+        .map(|(binding, code)| {
+            let enabled = !binding.guarded || guard_for(state, screen, code);
+            key_item(
+                binding.key_hint,
+                binding.label,
+                code,
+                enabled,
+                binding.category,
+            )
+        })
+        .collect();
     if mode == PaletteMode::Command {
         items.extend(cross_items());
     }

--- a/src/tui/render/mod.rs
+++ b/src/tui/render/mod.rs
@@ -1,3 +1,4 @@
+use super::keymap::{category_for_footer_key, Binding, Category};
 use super::view_model::PaneTitleVm;
 use super::{
     screens::{
@@ -778,30 +779,21 @@ pub(super) fn footer_height(text: &str, width: u16, title: &str, colored: bool) 
 /// from plain navigation at a glance: destructive (delete/remove/unpin) → Red, write/sync
 /// (download/upload/create/sync/…) → Green, everything else (navigation/view) → Cyan. Matched on
 /// whole label words so e.g. `pins` does not read as the `pin` action.
-pub(super) fn action_color(label: &str, theme: &Theme) -> Color {
-    const DESTRUCTIVE: [&str; 3] = ["delete", "remove", "unpin"];
-    const WRITE: [&str; 11] = [
-        "download", "upload", "create", "new", "sync", "push", "pull", "pin", "edit", "desc",
-        "star",
-    ];
-    let mut color = theme.accent;
-    for word in label.split_whitespace() {
-        let word = word.to_ascii_lowercase();
-        if DESTRUCTIVE.contains(&word.as_str()) {
-            return theme.del_color;
-        }
-        if WRITE.contains(&word.as_str()) {
-            color = theme.write_color;
-        }
+/// The accent a key gets from what its action risks. The category is read off the keymap table,
+/// which is why this no longer has to guess it from the label's wording (issue #369).
+pub(super) fn category_color(category: Category, theme: &Theme) -> Color {
+    match category {
+        Category::Destructive => theme.del_color,
+        Category::Write => theme.write_color,
+        Category::Nav | Category::Read => theme.accent,
     }
-    color
 }
 
 /// Style a footer command string: the leading key token of each `·`-separated item is accented by
-/// its action category (see [`action_color`]); the descriptive label keeps the terminal's default
-/// brightness so it stays legible, and only the separators are dimmed. Every input character is
-/// preserved verbatim so `wrap_line_count` sizing stays exact.
-pub(super) fn hint_line(text: &str, theme: &Theme) -> Line<'static> {
+/// its action category, looked up in `bindings` (see [`category_color`]); the descriptive label
+/// keeps the terminal's default brightness so it stays legible, and only the separators are
+/// dimmed. Every input character is preserved verbatim so `wrap_line_count` sizing stays exact.
+pub(super) fn hint_line(text: &str, bindings: &[Binding], theme: &Theme) -> Line<'static> {
     let dim = Style::default().fg(theme.dim);
     let mut spans: Vec<Span<'static>> = Vec::new();
     for (i, seg) in text.split('·').enumerate() {
@@ -819,13 +811,17 @@ pub(super) fn hint_line(text: &str, theme: &Theme) -> Line<'static> {
         match rest.find(char::is_whitespace) {
             Some(pos) => {
                 let (k, label) = rest.split_at(pos);
-                let key = Style::default().fg(action_color(label, theme));
+                let category = category_for_footer_key(bindings, k);
+                let key = Style::default().fg(category_color(category, theme));
                 spans.push(Span::styled(k.to_string(), key));
                 spans.push(Span::raw(label.to_string()));
             }
             None => spans.push(Span::styled(
                 rest.to_string(),
-                Style::default().fg(action_color("", theme)),
+                Style::default().fg(category_color(
+                    category_for_footer_key(bindings, rest),
+                    theme,
+                )),
             )),
         }
     }
@@ -857,8 +853,8 @@ pub(super) fn render_footer(
     title: &str,
     text: &str,
     colored: bool,
+    bindings: &[Binding],
     theme: &Theme,
-    _layout: &mut MouseLayout,
 ) {
     let inner = area.width.saturating_sub(2) as usize;
     let text = if colored {
@@ -867,7 +863,7 @@ pub(super) fn render_footer(
         text.to_string()
     };
     let para = if colored {
-        Paragraph::new(hint_line(&text, theme))
+        Paragraph::new(hint_line(&text, bindings, theme))
     } else {
         Paragraph::new(text)
     };
@@ -1348,13 +1344,21 @@ pub(super) fn palette_row_line(
     theme: &Theme,
     row_style: Style,
 ) -> Line<'static> {
-    palette_row_spans(&item.key_hint, &item.label, key_width, theme, row_style)
+    palette_row_spans(
+        &item.key_hint,
+        &item.label,
+        item.category,
+        key_width,
+        theme,
+        row_style,
+    )
 }
 
 /// Shared by palette paint (`PaletteVm` rows) and test helpers.
 pub(super) fn palette_row_spans(
     key_hint: &str,
     label: &str,
+    category: Category,
     key_width: usize,
     theme: &Theme,
     row_style: Style,
@@ -1362,7 +1366,7 @@ pub(super) fn palette_row_spans(
     Line::from(vec![
         Span::styled(
             format!("  {:<key_width$}  ", key_hint, key_width = key_width),
-            Style::default().fg(action_color(label, theme)),
+            Style::default().fg(category_color(category, theme)),
         ),
         Span::styled(label.to_string(), row_style),
     ])

--- a/src/tui/screens/config.rs
+++ b/src/tui/screens/config.rs
@@ -257,15 +257,6 @@ pub(crate) fn render_config_vm(
     );
 }
 
-pub(crate) fn config_palette_items() -> Vec<crate::tui::palette::PaletteItem> {
-    use crate::tui::palette::key_item;
-    vec![
-        key_item("Enter", "Toggle / increase value", KeyCode::Enter, true),
-        key_item("h/l", "Decrease / increase value", KeyCode::Char('l'), true),
-        key_item("Esc", "Close settings", KeyCode::Esc, true),
-    ]
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/tui/screens/confirm.rs
+++ b/src/tui/screens/confirm.rs
@@ -229,10 +229,6 @@ pub(crate) fn render_confirm_vm(
     }
 }
 
-pub(crate) fn confirm_palette_items(_state: &AppState) -> Vec<crate::tui::palette::PaletteItem> {
-    Vec::new()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/tui/screens/detail.rs
+++ b/src/tui/screens/detail.rs
@@ -690,8 +690,8 @@ pub(crate) fn render_gist_detail_vm(
         "",
         &detail.footer,
         detail.footer_colored,
+        crate::tui::keymap::for_screen(&state.screen),
         &state.theme,
-        layout,
     );
 
     let edit_modal = if let Some(input) = &detail.description_input {
@@ -950,71 +950,6 @@ pub(crate) fn detail_focus_tabs_line(
         spans.push(Span::styled(format!(" {label} "), style));
     }
     Line::from(spans)
-}
-
-pub(crate) fn detail_palette_items(state: &AppState) -> Vec<crate::tui::palette::PaletteItem> {
-    use crate::tui::palette::key_item;
-    let g = |code| detail_guard(state, code);
-    vec![
-        key_item(
-            "Enter",
-            "Preview selected file",
-            KeyCode::Enter,
-            g(KeyCode::Enter),
-        ),
-        key_item(
-            "o",
-            "Open in browser",
-            KeyCode::Char('o'),
-            g(KeyCode::Char('o')),
-        ),
-        key_item(
-            "y",
-            "Copy gist URL",
-            KeyCode::Char('y'),
-            g(KeyCode::Char('y')),
-        ),
-        key_item(
-            "H",
-            "Revision history",
-            KeyCode::Char('H'),
-            g(KeyCode::Char('H')),
-        ),
-        key_item(
-            "e",
-            "Edit description",
-            KeyCode::Char('e'),
-            g(KeyCode::Char('e')),
-        ),
-        key_item(
-            "c",
-            "Compact revisions",
-            KeyCode::Char('c'),
-            g(KeyCode::Char('c')),
-        ),
-        key_item(
-            "*",
-            "Star / unstar gist",
-            KeyCode::Char('*'),
-            g(KeyCode::Char('*')),
-        ),
-        key_item("F", "Fork gist", KeyCode::Char('F'), g(KeyCode::Char('F'))),
-        key_item(
-            "X",
-            "Delete gist",
-            KeyCode::Char('X'),
-            g(KeyCode::Char('X')),
-        ),
-        key_item("Tab", "Switch Files / Comments", KeyCode::Tab, true),
-        key_item(
-            "m",
-            "Load older comments",
-            KeyCode::Char('m'),
-            g(KeyCode::Char('m')),
-        ),
-        key_item("q", "Back to Gist manager", KeyCode::Char('q'), true),
-        key_item("?", "Help", KeyCode::Char('?'), true),
-    ]
 }
 
 #[cfg(test)]

--- a/src/tui/screens/diff.rs
+++ b/src/tui/screens/diff.rs
@@ -202,24 +202,12 @@ pub(crate) fn render_diff_vm(
         "",
         &diff.footer,
         true,
+        crate::tui::keymap::for_screen(&state.screen),
         &state.theme,
-        layout,
     );
     if chrome.mouse_enabled {
         layout.close_button = Some(crate::tui::render_close_button(frame, area, &state.theme));
     }
-}
-
-pub(crate) fn diff_palette_items(state: &AppState) -> Vec<crate::tui::palette::PaletteItem> {
-    use crate::tui::palette::key_item;
-    let g = |code| diff_guard(state, code);
-    vec![
-        key_item("d", "Download", KeyCode::Char('d'), g(KeyCode::Char('d'))),
-        key_item("u", "Upload", KeyCode::Char('u'), g(KeyCode::Char('u'))),
-        key_item("c", "Toggle full diff context", KeyCode::Char('c'), true),
-        key_item("w", "Toggle line wrap", KeyCode::Char('w'), true),
-        key_item("q", "Back", KeyCode::Char('q'), true),
-    ]
 }
 
 #[cfg(test)]

--- a/src/tui/screens/gists.rs
+++ b/src/tui/screens/gists.rs
@@ -14,7 +14,6 @@ use ratatui::{
 };
 
 pub(crate) const HELP_TOPIC: HelpTopic = HelpTopic::GistManager;
-const GISTS_HINTS: &str = "↑↓ move  ·  Enter detail  ·  * star  ·  o browser  ·  y copy URL  ·  H revisions  ·  s sort  ·  v visibility  ·  / filter  ·  Esc/q back";
 
 pub(crate) fn help_topic() -> HelpTopic {
     HELP_TOPIC
@@ -149,8 +148,8 @@ pub(crate) fn build_gists_vm(state: &AppState) -> GistsVm {
             false,
         )
     } else {
-        let (footer, colored) =
-            crate::tui::footer_with_status(state.status.as_deref(), GISTS_HINTS);
+        let hints = crate::tui::keymap::footer_hints(&state.screen);
+        let (footer, colored) = crate::tui::footer_with_status(state.status.as_deref(), &hints);
         (String::new(), footer, colored)
     };
 
@@ -273,55 +272,13 @@ pub(crate) fn render_gists_vm(
             &gists.footer_title,
             &gists.footer,
             gists.footer_colored,
+            crate::tui::keymap::for_screen(&state.screen),
             &state.theme,
-            layout,
         );
     }
     if chrome.mouse_enabled {
         layout.close_button = Some(crate::tui::render_close_button(frame, area, &state.theme));
     }
-}
-
-pub(crate) fn gists_palette_items(state: &AppState) -> Vec<crate::tui::palette::PaletteItem> {
-    use crate::tui::palette::key_item;
-    let g = |code| gists_guard(state, code);
-    vec![
-        key_item(
-            "Enter",
-            "Open gist detail",
-            KeyCode::Enter,
-            g(KeyCode::Enter),
-        ),
-        key_item(
-            "o",
-            "Open in browser",
-            KeyCode::Char('o'),
-            g(KeyCode::Char('o')),
-        ),
-        key_item(
-            "y",
-            "Copy gist URL",
-            KeyCode::Char('y'),
-            g(KeyCode::Char('y')),
-        ),
-        key_item(
-            "H",
-            "Revision history",
-            KeyCode::Char('H'),
-            g(KeyCode::Char('H')),
-        ),
-        key_item(
-            "*",
-            "Star / unstar gist",
-            KeyCode::Char('*'),
-            g(KeyCode::Char('*')),
-        ),
-        key_item("/", "Filter gists", KeyCode::Char('/'), true),
-        key_item("s", "Cycle sort", KeyCode::Char('s'), true),
-        key_item("v", "Cycle visibility", KeyCode::Char('v'), true),
-        key_item("q", "Back to list", KeyCode::Char('q'), true),
-        key_item("?", "Help", KeyCode::Char('?'), true),
-    ]
 }
 
 #[cfg(test)]

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -370,7 +370,8 @@ Mouse (on by default; disable with mouse = false in config or --no-mouse)
   Up/Down/Left/Right  scroll (also j / k / h / l; Left/Right only when wrap is off)
   PageUp/Dn  scroll by 10 lines (also Ctrl+b / Ctrl+f)
   w          toggle soft line wrapping (remembered for the session)
-  y          copy the gist URL · Y copy the file content to the clipboard
+  y          copy the gist URL to the clipboard
+  Y          copy the file content to the clipboard
   syntax     known file types are syntax-highlighted
   R          re-fetch the content
   Esc / q    back"
@@ -409,6 +410,7 @@ File-only: skip_dirs — ~/.config/gistui/config.toml (or $XDG_CONFIG_HOME)"
             "\
   Esc / q    close an overlay; from the list, press twice to quit the app
   ?          show this help
+  Tab        in this help, open the topic index (1-9 / g / 0 jump straight to a topic)
   C          open Settings (flat list of preferences; also Ctrl+p)
   ;          context menu (actions valid for the current screen + selection)
   Ctrl+p     command palette (all actions + cross-screen navigation; type to filter)

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -538,14 +538,6 @@ pub(crate) fn render_help_vm(
     }
 }
 
-pub(crate) fn help_palette_items() -> Vec<crate::tui::palette::PaletteItem> {
-    use crate::tui::palette::key_item;
-    vec![
-        key_item("Tab", "Browse topic index", KeyCode::Tab, true),
-        key_item("q", "Close Help", KeyCode::Char('q'), true),
-    ]
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/tui/screens/list.rs
+++ b/src/tui/screens/list.rs
@@ -13,7 +13,6 @@ use crate::tui::{
 use crossterm::event::KeyCode;
 
 pub(crate) const HELP_TOPIC: HelpTopic = HelpTopic::List;
-const LIST_HINTS: &str = "↑↓ move  ·  Tab panes  ·  Enter diff  ·  d download  ·  u upload  ·  n new gist  ·  p pin  ·  P pins  ·  g gists  ·  / filter  ·  Esc/q back";
 
 pub(crate) fn help_topic() -> HelpTopic {
     HELP_TOPIC
@@ -621,7 +620,7 @@ pub(crate) fn build_list_vm(state: &AppState) -> ListVm {
         }
     } else {
         ListFooterVm::Hints {
-            text: LIST_HINTS.to_string(),
+            text: crate::tui::keymap::footer_hints(&Screen::List),
         }
     };
 
@@ -742,105 +741,11 @@ pub(crate) fn render_list_vm(
                 "",
                 &footer_body,
                 footer_is_command,
+                crate::tui::keymap::for_screen(&state.screen),
                 &state.theme,
-                layout,
             );
         }
     }
-}
-
-pub(crate) fn list_palette_items(state: &AppState) -> Vec<crate::tui::palette::PaletteItem> {
-    use crate::tui::palette::key_item;
-    let g = |code| list_guard(state, code);
-    vec![
-        key_item(
-            "Enter",
-            "Diff local ↔ gist",
-            KeyCode::Enter,
-            g(KeyCode::Enter),
-        ),
-        key_item(
-            "Space",
-            "Preview gist content",
-            KeyCode::Char(' '),
-            g(KeyCode::Char(' ')),
-        ),
-        key_item(
-            "d",
-            "Download gist → cwd",
-            KeyCode::Char('d'),
-            g(KeyCode::Char('d')),
-        ),
-        key_item(
-            "u",
-            "Upload local → gist",
-            KeyCode::Char('u'),
-            g(KeyCode::Char('u')),
-        ),
-        key_item(
-            "n",
-            "Create gist from local",
-            KeyCode::Char('n'),
-            g(KeyCode::Char('n')),
-        ),
-        key_item(
-            "p",
-            "Pin / unpin pair",
-            KeyCode::Char('p'),
-            g(KeyCode::Char('p')),
-        ),
-        key_item("P", "Open Pins view", KeyCode::Char('P'), true),
-        key_item(
-            "g",
-            "Open Gist manager",
-            KeyCode::Char('g'),
-            g(KeyCode::Char('g')),
-        ),
-        key_item(
-            "S",
-            "Smart-sync pinned pair",
-            KeyCode::Char('S'),
-            g(KeyCode::Char('S')),
-        ),
-        key_item(
-            "X",
-            "Remove file from gist",
-            KeyCode::Char('X'),
-            g(KeyCode::Char('X')),
-        ),
-        key_item(
-            "e",
-            "Edit local file",
-            KeyCode::Char('e'),
-            g(KeyCode::Char('e')),
-        ),
-        key_item(
-            "y",
-            "Copy gist URL",
-            KeyCode::Char('y'),
-            g(KeyCode::Char('y')),
-        ),
-        key_item(
-            "H",
-            "Revision history",
-            KeyCode::Char('H'),
-            g(KeyCode::Char('H')),
-        ),
-        key_item(
-            "*",
-            "Star / unstar gist",
-            KeyCode::Char('*'),
-            g(KeyCode::Char('*')),
-        ),
-        key_item("r", "Toggle recursive scan", KeyCode::Char('r'), true),
-        key_item("/", "Filter focused pane", KeyCode::Char('/'), true),
-        key_item("Tab", "Switch pane", KeyCode::Tab, true),
-        key_item("a", "Flip ranking anchor", KeyCode::Char('a'), true),
-        key_item("t", "Toggle description / id", KeyCode::Char('t'), true),
-        key_item("v", "Cycle gist visibility", KeyCode::Char('v'), true),
-        key_item("s", "Cycle pane sort", KeyCode::Char('s'), true),
-        key_item("?", "Help", KeyCode::Char('?'), true),
-    ]
 }
 
 #[cfg(test)]

--- a/src/tui/screens/palette.rs
+++ b/src/tui/screens/palette.rs
@@ -1,7 +1,7 @@
 //! `Screen::Palette` — key handling, view-model, paint, and palette items colocated in one
 //! file (issue #287, Phase 2).
 
-use crate::tui::palette::{CrossAction, PaletteExec, PaletteItem, PaletteMode};
+use crate::tui::palette::{CrossAction, PaletteExec, PaletteMode};
 use crate::tui::view_model::{ChromeVm, PaletteVm};
 use crate::tui::EditResult;
 use crate::tui::{AppState, HelpTopic, KeyOutcome, MouseLayout, Screen};
@@ -22,10 +22,6 @@ pub(crate) fn help_topic() -> HelpTopic {
 
 pub(crate) fn wheel_step() -> usize {
     1
-}
-
-pub(crate) fn palette_palette_items(_state: &AppState) -> Vec<PaletteItem> {
-    Vec::new()
 }
 
 impl AppState {
@@ -160,6 +156,7 @@ pub(crate) fn build_palette_vm(state: &AppState) -> PaletteVm {
         .map(|item| crate::tui::view_model::PaletteRowVm {
             key_hint: item.key_hint.clone(),
             label: item.label.clone(),
+            category: item.category,
             enabled: item.enabled,
         })
         .collect();
@@ -257,6 +254,7 @@ pub(crate) fn render_palette_vm(
             lines.push(crate::tui::render::palette_row_spans(
                 &item.key_hint,
                 &item.label,
+                item.category,
                 palette.key_width,
                 &state.theme,
                 row_style,

--- a/src/tui/screens/pins.rs
+++ b/src/tui/screens/pins.rs
@@ -14,7 +14,6 @@ use ratatui::{
 };
 
 pub(crate) const HELP_TOPIC: HelpTopic = HelpTopic::Pins;
-const PINS_HINTS: &str = "↑↓ move  ·  Enter diff  ·  s sync  ·  u push  ·  d pull  ·  x unpin  ·  o sort  ·  / filter  ·  Esc/q back";
 const PINS_STATUS_LEGEND: &str =
     "✓ synced · ↑ local newer · ↓ remote newer · ✕ missing · ? unknown";
 
@@ -192,7 +191,8 @@ pub(crate) fn build_pins_vm(state: &AppState) -> PinsVm {
             false,
         )
     } else {
-        let (footer, colored) = crate::tui::footer_with_status(state.status.as_deref(), PINS_HINTS);
+        let hints = crate::tui::keymap::footer_hints(&state.screen);
+        let (footer, colored) = crate::tui::footer_with_status(state.status.as_deref(), &hints);
         (PINS_STATUS_LEGEND.to_string(), footer, colored)
     };
 
@@ -331,34 +331,13 @@ pub(crate) fn render_pins_vm(
             &pins.footer_title,
             &pins.footer,
             pins.footer_colored,
+            crate::tui::keymap::for_screen(&state.screen),
             &state.theme,
-            layout,
         );
     }
     if chrome.mouse_enabled {
         layout.close_button = Some(crate::tui::render_close_button(frame, area, &state.theme));
     }
-}
-
-pub(crate) fn pins_palette_items(state: &AppState) -> Vec<crate::tui::palette::PaletteItem> {
-    use crate::tui::palette::key_item;
-    let g = |code| pins_guard(state, code);
-    vec![
-        key_item(
-            "Enter",
-            "Diff pinned pair",
-            KeyCode::Enter,
-            g(KeyCode::Enter),
-        ),
-        key_item("s", "Smart-sync", KeyCode::Char('s'), g(KeyCode::Char('s'))),
-        key_item("u", "Force push", KeyCode::Char('u'), g(KeyCode::Char('u'))),
-        key_item("d", "Force pull", KeyCode::Char('d'), g(KeyCode::Char('d'))),
-        key_item("x", "Unpin pair", KeyCode::Char('x'), g(KeyCode::Char('x'))),
-        key_item("/", "Filter pins", KeyCode::Char('/'), true),
-        key_item("o", "Cycle sort", KeyCode::Char('o'), true),
-        key_item("q", "Back to list", KeyCode::Char('q'), true),
-        key_item("?", "Help", KeyCode::Char('?'), true),
-    ]
 }
 
 #[cfg(test)]

--- a/src/tui/screens/preview.rs
+++ b/src/tui/screens/preview.rs
@@ -171,23 +171,12 @@ pub(crate) fn render_preview_vm(
         "",
         &preview.footer,
         preview.footer_colored,
+        crate::tui::keymap::for_screen(&state.screen),
         &state.theme,
-        layout,
     );
     if chrome.mouse_enabled {
         layout.close_button = Some(crate::tui::render_close_button(frame, area, &state.theme));
     }
-}
-
-pub(crate) fn preview_palette_items(_state: &AppState) -> Vec<crate::tui::palette::PaletteItem> {
-    use crate::tui::palette::key_item;
-    vec![
-        key_item("R", "Refresh content", KeyCode::Char('R'), true),
-        key_item("w", "Toggle line wrap", KeyCode::Char('w'), true),
-        key_item("y", "Copy gist URL", KeyCode::Char('y'), true),
-        key_item("Y", "Copy file content", KeyCode::Char('Y'), true),
-        key_item("q", "Back", KeyCode::Char('q'), true),
-    ]
 }
 
 #[cfg(test)]

--- a/src/tui/screens/revisions.rs
+++ b/src/tui/screens/revisions.rs
@@ -435,49 +435,12 @@ pub(crate) fn render_revisions_vm(
         "",
         &revs.footer,
         revs.footer_colored,
+        crate::tui::keymap::for_screen(&state.screen),
         &state.theme,
-        layout,
     );
     if chrome.mouse_enabled {
         layout.close_button = Some(crate::tui::render_close_button(frame, area, &state.theme));
     }
-}
-
-pub(crate) fn revisions_palette_items(state: &AppState) -> Vec<crate::tui::palette::PaletteItem> {
-    use crate::tui::palette::key_item;
-    let g = |code| revisions_guard(state, code);
-    vec![
-        key_item(
-            "Enter",
-            "Diff parent → revision",
-            KeyCode::Enter,
-            g(KeyCode::Enter),
-        ),
-        key_item(
-            "D",
-            "Diff revision vs head",
-            KeyCode::Char('D'),
-            g(KeyCode::Char('D')),
-        ),
-        key_item(
-            "r",
-            "Restore revision",
-            KeyCode::Char('r'),
-            g(KeyCode::Char('r')),
-        ),
-        // The palette *is* gated through `revisions_guard` here, unlike the real handler's
-        // own `F` arm (which stays unconditional — see the comment on that case in
-        // `revisions_guard`): cycling the target file doesn't need the revision list loaded,
-        // so `revisions_guard`'s `F` case checks file count, not `has_entries` (issue #288).
-        key_item(
-            "F",
-            "Cycle target file",
-            KeyCode::Char('F'),
-            g(KeyCode::Char('F')),
-        ),
-        key_item("q", "Back", KeyCode::Char('q'), true),
-        key_item("?", "Help", KeyCode::Char('?'), true),
-    ]
 }
 
 #[cfg(test)]

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -448,8 +448,11 @@ fn about_metadata_is_available_for_help() {
 
 #[test]
 fn hint_line_colours_keys_by_action_category() {
+    // Detail is the screen that binds `X` to a destructive delete.
+    let bindings = keymap::for_screen(&Screen::List);
     let line = hint_line(
-        "Tab panes  ·  d download  ·  X delete  ·  Esc/q back",
+        "Tab panes  ·  d download  ·  P pins  ·  Esc/q back",
+        bindings,
         &Theme::DARK,
     );
     let key_fg = |k: &str| {
@@ -461,8 +464,8 @@ fn hint_line_colours_keys_by_action_category() {
             .fg
     };
     assert_eq!(key_fg("Tab"), Some(Color::Cyan)); // navigation
-    assert_eq!(key_fg("d"), Some(Color::Green)); // write/sync
-    assert_eq!(key_fg("X"), Some(Color::Red)); // destructive
+    assert_eq!(key_fg("d"), Some(Color::Green)); // write
+    assert_eq!(key_fg("P"), Some(Color::Cyan)); // opens a view, not the `pin` write action
     assert_eq!(key_fg("Esc/q"), Some(Color::Cyan)); // navigation
                                                     // Labels keep default brightness (no fg override) regardless of the key's category.
     let label = line
@@ -474,23 +477,43 @@ fn hint_line_colours_keys_by_action_category() {
 }
 
 #[test]
-fn action_color_matches_whole_words_only() {
-    // `pins` opens a view, not the `pin` write action, so it must not read as Green.
-    assert_eq!(action_color("pins", &Theme::DARK), Color::Cyan);
+fn category_color_maps_every_category() {
+    use crate::tui::keymap::Category;
+    assert_eq!(category_color(Category::Nav, &Theme::DARK), Color::Cyan);
+    assert_eq!(category_color(Category::Read, &Theme::DARK), Color::Cyan);
+    assert_eq!(category_color(Category::Write, &Theme::DARK), Color::Green);
     assert_eq!(
-        action_color("synced ↑ local-newer", &Theme::DARK),
-        Color::Cyan
+        category_color(Category::Destructive, &Theme::DARK),
+        Color::Red
     );
-    assert_eq!(action_color("remove file", &Theme::DARK), Color::Red);
-    assert_eq!(action_color("pin", &Theme::DARK), Color::Green);
-    assert_eq!(action_color("star", &Theme::DARK), Color::Green);
+}
+
+/// A key the screen's table does not claim — a status line, or `MINIMAL_HINT`'s `;` and
+/// `Ctrl+p` — reads as navigation rather than panicking or borrowing a neighbour's colour.
+#[test]
+fn hint_line_leaves_an_unclaimed_key_on_the_navigation_accent() {
+    let line = hint_line(
+        crate::tui::MINIMAL_HINT,
+        keymap::for_screen(&Screen::GistDetail(Box::default())),
+        &Theme::DARK,
+    );
+    let key_fg = |k: &str| {
+        line.spans
+            .iter()
+            .find(|s| s.content == k)
+            .unwrap_or_else(|| panic!("key span {k}"))
+            .style
+            .fg
+    };
+    assert_eq!(key_fg(";"), Some(Color::Cyan));
+    assert_eq!(key_fg("Ctrl+p"), Some(Color::Cyan));
 }
 
 #[test]
 fn hint_line_preserves_every_character() {
     // Sizing relies on wrap_line_count over the raw text, so styling must not add/drop chars.
     let text = "↑↓ move  ·  Enter diff · q back";
-    let joined: String = hint_line(text, &Theme::DARK)
+    let joined: String = hint_line(text, keymap::for_screen(&Screen::List), &Theme::DARK)
         .spans
         .iter()
         .map(|s| s.content.as_ref())
@@ -4227,6 +4250,7 @@ fn palette_row_line_aligns_long_keys() {
         label: "Diff local ↔ gist".to_string(),
         exec: crate::tui::palette::PaletteExec::Key(KeyCode::Enter, KeyModifiers::NONE),
         enabled: true,
+        category: crate::tui::keymap::Category::Read,
         search: String::new(),
     };
     let line = palette_row_line(

--- a/src/tui/view_model.rs
+++ b/src/tui/view_model.rs
@@ -76,6 +76,8 @@ pub struct PaletteVm {
 pub struct PaletteRowVm {
     pub key_hint: String,
     pub label: String,
+    /// What the action risks, resolved by the keymap table so paint only looks it up.
+    pub category: crate::tui::keymap::Category,
     pub enabled: bool,
 }
 
@@ -1153,6 +1155,7 @@ mod tests {
             mode: PaletteMode::Menu,
             items: vec![PaletteItem {
                 key_hint: "d".into(),
+                category: crate::tui::keymap::Category::Write,
                 label: "download".into(),
                 exec: PaletteExec::Key(KeyCode::Char('d'), crossterm::event::KeyModifiers::empty()),
                 enabled: true,


### PR DESCRIPTION
Collapses the four hand-written descriptions of every key into one table per screen, derives the three renderings that can be derived, and nets the two that stay prose.

The full spec is issue #369; this description covers what the implementation added on top of it.

## What changed

`keymap::for_screen` returns one table per screen. It **describes** — it does not dispatch and it does not gate. `handle_key_*` still executes keys, and #288's shared `*_guard` still answers "is this available right now". Three renderings read the table:

| Rendering | Before | After |
|---|---|---|
| Palette rows | eleven `*_palette_items` builders | one `build_palette_items` walking the table |
| Footer hints | `LIST_HINTS` / `GISTS_HINTS` / `PINS_HINTS` | `keymap::footer_hints`, ordered by `rank` |
| Action colour | `action_color` word-splitting the label | `Category` → `category_color` |

Help topics and `README.md` stay hand-written. The List help topic is fifty lines of sectioned prose with multi-line caveats, and About is 329 lines with no keys at all — generating those would flatten explanation to win a consistency check a test can do instead.

## The safety net

Two tests, one per drift direction:

- **#344's direction** — every key the table binds must appear in its help topic, or in General for the screen-wide keys documented once rather than repeated.
- **#346's direction** — every key `README.md`'s Key/Action table promises must actually be bound.

Both were verified to fail when drift is introduced, not just to pass today: planting an undocumented binding, and planting a `` `Q` `` in README's table, each fail the right test with the right message.

The help net caught a miss that predates this branch: `Tab` opens the topic index on the Help screen, was already a palette row on `main`, and was documented nowhere.

## Three deviations from the issue

- **`Binding.code` is `Option<KeyCode>`, not `keys: &[(KeyCode, KeyModifiers)]`.** Every binding in the codebase is `KeyModifiers::NONE` — `main`'s `key_item` hardcodes it — so a column that is always `NONE` would be speculative generality. `Option` instead carries a fact the table needs: pure navigation (`↑↓`, `Esc/q`) has no key for the palette to send, so `None` says so and `code.is_some()` replaces what would otherwise be a separate `in_palette` flag. Which keys reach `handle_key_*` remains that function's business; the table describes.
- **Two commits, not three.** The planned standalone "table with nothing consuming it yet" commit cannot exist here: an unread table is dead code under `cargo clippy -- -D warnings`, and an `#[allow(dead_code)]` to be removed one commit later is scaffolding. The table lands with its three consumers; the nets follow. Both commits build and pass `mise run check` on their own.
- **Preview's `y`/`Y` help line is split in two.** They shared one line behind a `·`. Reading keys out of descriptions to cope with that would let prose vouch for a binding — a topic that had lost its `a` line would still pass on an unrelated sentence starting with "a" (verified). One key per line keeps the net honest.

## User-visible changes

Footer strings are pinned verbatim in tests — reproducing them exactly is what makes this a refactor. Footer accents are unchanged.

Four palette rows change accent, all of them cases the old word-splitting got wrong: `Smart-sync pinned pair` and `Smart-sync` were unaccented despite writing, `Fork gist` and `Restore revision` likewise, and `Pin / unpin pair` read as destructive red purely because "unpin" appeared in its label.

`Category` draws its line at the user's data, not at persistence: changing a setting writes `config.toml` and is still `Nav`; `Write` means a gist, a local file, or the pin list moves; `Destructive` means something does not come back.

## Verification

`mise run check` green — 702 lib + 12 integration tests. `docs/agents/architecture.md` gains a **Keymap** section recording what derives from the table, why `rank` and `key` are separate columns, and where the `Category` line falls.

Closes #369
