### PR TITLE
refactor(tui): one exhaustive lookup for per-screen facts

### DIFF
--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -13,6 +13,7 @@ Index: [`AGENTS.md`](../../AGENTS.md). Source of truth for types lives in the mo
 
 ## Screen state machine
 
+- **`screens::lookup`** (`@src/tui/screens/mod.rs`, issue #377) is the exhaustive match for the data-like per-screen columns: help topic, wheel step, key guard, VM builder. `handle_key` / `apply_navigation` / `click_select` stay matches — they need `&mut AppState` (issue #274). `render_screen_vm` matches `ScreenVm`, not `Screen`. `keymap::for_screen` stays in `keymap.rs` (bindings live there; putting them on the lookup would cycle `screens` ↔ `keymap`). No `ScreenModule` trait: the screen files already are the adapters.
 - **`Screen` is `Clone`, not `Copy`** — payload variants own screen-local UI (`@src/tui/mod.rs`, issue #242).
 - **`List` stays a unit tag** — dual-pane selection / filters / sorts are session-global on `AppState` (user story 19).
 - Other variants (`Diff`, `Confirm`, `Preview`, `Help`, `Config`, `Revisions`, `Pins`, `Gists`, `GistDetail`, `Palette`, …) carry payloads (body/scroll/return/origin as needed).

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -260,19 +260,7 @@ impl AppState {
     /// content panes (Diff, Preview, Confirm, GistDetail) scroll three lines for faster
     /// panning. Help body also scrolls three; the Help topic index is a list (one row).
     fn wheel_step(&self) -> usize {
-        match &self.screen {
-            Screen::List => super::screens::list::wheel_step(),
-            Screen::Diff(_) => super::screens::diff::wheel_step(),
-            Screen::Confirm(_) => super::screens::confirm::wheel_step(),
-            Screen::Preview(_) => super::screens::preview::wheel_step(),
-            Screen::Help(h) => super::screens::help::wheel_step(h),
-            Screen::Pins(_) => super::screens::pins::wheel_step(),
-            Screen::Gists(_) => super::screens::gists::wheel_step(),
-            Screen::GistDetail(_) => super::screens::detail::wheel_step(self),
-            Screen::Revisions(_) => super::screens::revisions::wheel_step(),
-            Screen::Config(_) => super::screens::config::wheel_step(),
-            Screen::Palette(_) => super::screens::palette::wheel_step(),
-        }
+        (super::screens::lookup(&self.screen).wheel_step)(self)
     }
 
     /// Select the clicked list row on the current screen, focusing its pane/list. Returns

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -245,19 +245,7 @@ impl HelpTopic {
     /// The topic to open when `?` is pressed on a given screen. Non-key-dense screens
     /// fall back to the List topic.
     pub fn for_screen(screen: &Screen) -> HelpTopic {
-        match screen {
-            Screen::List => screens::list::help_topic(),
-            Screen::Diff(_) => screens::diff::help_topic(),
-            Screen::Confirm(_) => screens::confirm::help_topic(),
-            Screen::Preview(_) => screens::preview::help_topic(),
-            Screen::Help(_) => screens::help::help_topic(),
-            Screen::Pins(_) => screens::pins::help_topic(),
-            Screen::Gists(_) => screens::gists::help_topic(),
-            Screen::GistDetail(_) => screens::detail::help_topic(),
-            Screen::Revisions(_) => screens::revisions::help_topic(),
-            Screen::Palette(_) => screens::palette::help_topic(),
-            Screen::Config(_) => screens::config::help_topic(),
-        }
+        screens::lookup(screen).help_topic
     }
 }
 

--- a/src/tui/palette.rs
+++ b/src/tui/palette.rs
@@ -227,17 +227,7 @@ fn cross_items() -> Vec<PaletteItem> {
 /// Whether the screen's own guard says `code` is available right now (issue #288). Screens
 /// whose keys are never gated — and the two with no table at all — answer `true`.
 fn guard_for(state: &AppState, screen: &Screen, code: KeyCode) -> bool {
-    use super::screens::{detail, diff, gists, list, pins, revisions};
-    match screen {
-        Screen::List => list::list_guard(state, code),
-        Screen::Pins(_) => pins::pins_guard(state, code),
-        Screen::Gists(_) => gists::gists_guard(state, code),
-        Screen::GistDetail(_) => detail::detail_guard(state, code),
-        Screen::Revisions(_) => revisions::revisions_guard(state, code),
-        Screen::Diff(_) => diff::diff_guard(state, code),
-        Screen::Preview(_) | Screen::Help(_) | Screen::Config(_) => true,
-        Screen::Confirm(_) | Screen::Palette(_) => true,
-    }
+    (super::screens::lookup(screen).guard)(state, code)
 }
 
 /// The screen's palette rows, in the keymap table's order. Command mode appends the

--- a/src/tui/screens/mod.rs
+++ b/src/tui/screens/mod.rs
@@ -1,8 +1,16 @@
-//! Per-screen colocation (issue #287, Phase 2): each `Screen` variant's `handle_key_*`,
-//! `build_*_vm`, `render_*_vm`, and `*_palette_items` bodies live in one file here, migrated
-//! one screen at a time. The six per-screen registries (`handle_key` dispatch,
-//! `build_view_model`, `render_screen_vm`, `build_palette_items`, `HelpTopic::for_screen`,
-//! `wheel_step`) keep their exhaustive-match shape; each arm becomes a one-line call into a screen module.
+//! Per-screen colocation (issue #287): each `Screen` variant's `handle_key_*`,
+//! `build_*_vm`, and `render_*_vm` live in one file here.
+//!
+//! [`lookup`] is the exhaustive match for the data-like per-screen columns
+//! (issue #377): help topic, wheel step, key guard, VM builder. `handle_key`,
+//! `apply_navigation`, and `click_select` stay matches — they need `&mut AppState`
+//! (issue #274). `render_screen_vm` matches [`ScreenVm`], not [`Screen`].
+//! `keymap::for_screen` stays in `keymap.rs` (bindings are that table; putting
+//! them here would cycle `screens` ↔ `keymap`).
+
+use super::view_model::ScreenVm;
+use super::{AppState, HelpTopic, Screen};
+use crossterm::event::KeyCode;
 
 pub(crate) mod config;
 pub(crate) mod confirm;
@@ -15,3 +23,137 @@ pub(crate) mod palette;
 pub(crate) mod pins;
 pub(crate) mod preview;
 pub(crate) mod revisions;
+
+/// Per-screen facts selected by [`lookup`]. Columns are `fn` pointers so the
+/// screen files stay the adapters — this type does not add a parallel set of
+/// dummy types.
+pub(crate) struct ScreenLookup {
+    pub help_topic: HelpTopic,
+    pub wheel_step: fn(&AppState) -> usize,
+    pub guard: fn(&AppState, KeyCode) -> bool,
+    pub build_vm: fn(&AppState) -> ScreenVm,
+}
+
+fn ungated(_: &AppState, _: KeyCode) -> bool {
+    true
+}
+
+/// Exhaustive map from `Screen` to the four lookup columns. A new variant that
+/// forgets this match fails to compile; that is the protection the old seven
+/// matches duplicated.
+pub(crate) fn lookup(screen: &Screen) -> ScreenLookup {
+    match screen {
+        Screen::List => ScreenLookup {
+            help_topic: list::help_topic(),
+            wheel_step: |_: &AppState| list::wheel_step(),
+            guard: list::list_guard,
+            build_vm: |state| ScreenVm::List(list::build_list_vm(state)),
+        },
+        Screen::Pins(_) => ScreenLookup {
+            help_topic: pins::help_topic(),
+            wheel_step: |_: &AppState| pins::wheel_step(),
+            guard: pins::pins_guard,
+            build_vm: |state| ScreenVm::Pins(pins::build_pins_vm(state)),
+        },
+        Screen::Gists(_) => ScreenLookup {
+            help_topic: gists::help_topic(),
+            wheel_step: |_: &AppState| gists::wheel_step(),
+            guard: gists::gists_guard,
+            build_vm: |state| ScreenVm::Gists(gists::build_gists_vm(state)),
+        },
+        Screen::GistDetail(_) => ScreenLookup {
+            help_topic: detail::help_topic(),
+            wheel_step: detail::wheel_step,
+            guard: detail::detail_guard,
+            build_vm: |state| ScreenVm::GistDetail(detail::build_gist_detail_vm(state)),
+        },
+        Screen::Revisions(_) => ScreenLookup {
+            help_topic: revisions::help_topic(),
+            wheel_step: |_: &AppState| revisions::wheel_step(),
+            guard: revisions::revisions_guard,
+            build_vm: |state| ScreenVm::Revisions(revisions::build_revisions_vm(state)),
+        },
+        Screen::Diff(_) => ScreenLookup {
+            help_topic: diff::help_topic(),
+            wheel_step: |_: &AppState| diff::wheel_step(),
+            guard: diff::diff_guard,
+            build_vm: |state| ScreenVm::Diff(diff::build_diff_vm(state)),
+        },
+        Screen::Preview(_) => ScreenLookup {
+            help_topic: preview::help_topic(),
+            wheel_step: |_: &AppState| preview::wheel_step(),
+            guard: ungated,
+            build_vm: |state| ScreenVm::Preview(preview::build_preview_vm(state)),
+        },
+        Screen::Help(_) => ScreenLookup {
+            help_topic: help::help_topic(),
+            wheel_step: |state| state.help().map(help::wheel_step).unwrap_or(1),
+            guard: ungated,
+            build_vm: |state| ScreenVm::Help(help::build_help_vm(state)),
+        },
+        Screen::Config(_) => ScreenLookup {
+            help_topic: config::help_topic(),
+            wheel_step: |_: &AppState| config::wheel_step(),
+            guard: ungated,
+            build_vm: |state| ScreenVm::Config(config::build_config_vm(state)),
+        },
+        Screen::Confirm(_) => ScreenLookup {
+            help_topic: confirm::help_topic(),
+            wheel_step: |_: &AppState| confirm::wheel_step(),
+            guard: ungated,
+            build_vm: |state| ScreenVm::Confirm(confirm::build_confirm_vm(state)),
+        },
+        Screen::Palette(_) => ScreenLookup {
+            help_topic: palette::help_topic(),
+            wheel_step: |_: &AppState| palette::wheel_step(),
+            guard: ungated,
+            build_vm: |state| ScreenVm::Palette(palette::build_palette_vm(state)),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lookup_answers_for_every_variant() {
+        let cases: &[(&str, Screen, HelpTopic)] = &[
+            ("List", Screen::List, list::HELP_TOPIC),
+            ("Pins", Screen::Pins(Box::default()), pins::HELP_TOPIC),
+            ("Gists", Screen::Gists(Box::default()), gists::HELP_TOPIC),
+            (
+                "GistDetail",
+                Screen::GistDetail(Box::default()),
+                detail::HELP_TOPIC,
+            ),
+            (
+                "Revisions",
+                Screen::Revisions(Box::default()),
+                revisions::HELP_TOPIC,
+            ),
+            ("Diff", Screen::Diff(Box::default()), diff::HELP_TOPIC),
+            (
+                "Preview",
+                Screen::Preview(Box::default()),
+                preview::HELP_TOPIC,
+            ),
+            ("Help", Screen::Help(Box::default()), help::HELP_TOPIC),
+            ("Config", Screen::Config(Box::default()), config::HELP_TOPIC),
+            (
+                "Confirm",
+                Screen::Confirm(Box::default()),
+                confirm::HELP_TOPIC,
+            ),
+            (
+                "Palette",
+                Screen::Palette(Box::default()),
+                palette::HELP_TOPIC,
+            ),
+        ];
+        for (name, screen, topic) in cases {
+            let found = lookup(screen);
+            assert_eq!(found.help_topic, *topic, "{name} help topic");
+        }
+    }
+}

--- a/src/tui/view_model.rs
+++ b/src/tui/view_model.rs
@@ -7,14 +7,7 @@ use super::render::{
     gist_info_line, gist_row_label, is_json_file, spinner_glyph, unix_now, CREATE_DESC_PREFIX,
     CREATE_DESC_SUFFIX,
 };
-use super::screens::{
-    config::build_config_vm as build_config, confirm::build_confirm_vm as build_confirm,
-    detail::build_gist_detail_vm as build_detail, diff::build_diff_vm as build_diff,
-    gists::build_gists_vm as build_gists, help::build_help_vm as build_help,
-    list::build_list_vm as build_list, palette::build_palette_vm as build_palette,
-    pins::build_pins_vm as build_pins, preview::build_preview_vm as build_preview,
-    revisions::build_revisions_vm as build_revisions,
-};
+use super::screens::lookup;
 use super::{
     AppState, DetailFocus, FocusPane, GistView, PaletteMode, PendingAction, Screen, TextInput,
 };
@@ -382,21 +375,10 @@ pub(crate) fn build_chrome(state: &AppState) -> ChromeVm {
 
 /// Pure: map app state (+ pin sync cache) into a view model. No FS / network / mutation.
 pub fn build_view_model(state: &AppState) -> ViewModel {
-    let chrome = build_chrome(state);
-    let screen = match &state.screen {
-        Screen::List => ScreenVm::List(build_list(state)),
-        Screen::Gists(_) => ScreenVm::Gists(build_gists(state)),
-        Screen::GistDetail(_) => ScreenVm::GistDetail(build_detail(state)),
-        Screen::Revisions(_) => ScreenVm::Revisions(build_revisions(state)),
-        Screen::Config(_) => ScreenVm::Config(build_config(state)),
-        Screen::Diff(_) => ScreenVm::Diff(build_diff(state)),
-        Screen::Preview(_) => ScreenVm::Preview(build_preview(state)),
-        Screen::Pins(_) => ScreenVm::Pins(build_pins(state)),
-        Screen::Confirm(_) => ScreenVm::Confirm(build_confirm(state)),
-        Screen::Help(_) => ScreenVm::Help(build_help(state)),
-        Screen::Palette(_) => ScreenVm::Palette(build_palette(state)),
-    };
-    ViewModel { chrome, screen }
+    ViewModel {
+        chrome: build_chrome(state),
+        screen: (lookup(&state.screen).build_vm)(state),
+    }
 }
 
 /// ViewModel for the screen a palette is covering, by its origin's tag. `state`'s accessors
@@ -407,16 +389,8 @@ pub fn build_view_model(state: &AppState) -> ViewModel {
 /// (unreachable — the palette can't be opened while itself active).
 pub(crate) fn build_background_screen_vm(state: &AppState, origin: &Screen) -> Option<ScreenVm> {
     match origin {
-        Screen::List => Some(ScreenVm::List(build_list(state))),
-        Screen::Gists(_) => Some(ScreenVm::Gists(build_gists(state))),
-        Screen::GistDetail(_) => Some(ScreenVm::GistDetail(build_detail(state))),
-        Screen::Revisions(_) => Some(ScreenVm::Revisions(build_revisions(state))),
-        Screen::Config(_) => Some(ScreenVm::Config(build_config(state))),
-        Screen::Diff(_) => Some(ScreenVm::Diff(build_diff(state))),
-        Screen::Preview(_) => Some(ScreenVm::Preview(build_preview(state))),
-        Screen::Pins(_) => Some(ScreenVm::Pins(build_pins(state))),
-        Screen::Help(_) => Some(ScreenVm::Help(build_help(state))),
         Screen::Confirm(_) | Screen::Palette(_) => None,
+        other => Some((lookup(other).build_vm)(state)),
     }
 }
 


### PR DESCRIPTION
After #369, palette rows no longer match on `Screen`. Four data-like columns still each had their own exhaustive match. `screens::lookup` is that match, once.

The full spec is issue #377; this description covers what the implementation added on top of it.

## What changed

`ScreenLookup` is a struct of columns (help topic, wheel step, key guard, VM builder), selected by one exhaustive `match` in `screens::lookup`. Callers are one-liners:

- `HelpTopic::for_screen`
- `AppState::wheel_step`
- `guard_for`
- `build_view_model` / `build_background_screen_vm` (Confirm/Palette background still `None`)

## Deviations from the 2026-08-19 review

The review asked for `trait ScreenModule` and 11 dummy adapters. That fails the deletion test: each adapter would only forward to functions that already live in `screens/*.rs`. A struct of `fn` pointers selected by one match keeps the compile-fail-on-new-variant protection without a parallel type hierarchy.

Left as matches, with reasons in the issue: `handle_key` / `apply_navigation` / `click_select` (`&mut AppState`, #274), `render_screen_vm` (`ScreenVm`, not `Screen`), `keymap::for_screen` (would cycle `screens` ↔ `keymap`).

## User-visible changes

None. Internal refactor (`skip-changelog`).

## Verification

`mise run check` green — 709 lib + 12 integration.

Two-axis review against #377: Spec had no findings. Standards had no hard violations. Two judgements were left: shared `one`/`three` wheel helpers would stop calling each screen's `wheel_step()` (that function stays the source of truth); asserting `guard` by function-pointer identity is not meaningful in Rust (`unpredictable_function_pointer_comparisons`). The new test pins `help_topic` wiring against each screen's `HELP_TOPIC` constant.

Closes #377