### PR TITLE
refactor(tui): extract ScrollBody for Diff/Confirm/Preview

### DIFF
--- a/docs/adr/0001-appstate-field-visibility.md
+++ b/docs/adr/0001-appstate-field-visibility.md
@@ -5,3 +5,5 @@
 We decided **not** to encapsulate it. All four of those concrete issues (#286–#289) were fully scoped and resolved during grilling without touching `AppState`'s field visibility — the friction traced back to specific, local problems, not to the field surface itself. `tui::*` is one trust domain (single binary, one author/review context per PR), so Rust module-level privacy wouldn't buy an enforced boundary that isn't already enforced by review. Encapsulating ~60 fields preemptively would be a large, low-value diff chasing a discomfort rather than a demonstrated defect.
 
 **Revisit if**: a specific bug is traced to unconstrained cross-file mutation of a particular field — narrow that field with an accessor at that point, not preemptively across the whole struct.
+
+**Narrowed the Diff/Confirm/Preview scroll cluster as #385.** `text · scroll · hscroll` is now `ScrollBody` on those three payloads; `AppState` exposes `scroll_body` / `scroll_body_mut` instead of ten per-axis methods. This continues the revisit clause (narrow the demonstrated cluster in place) rather than encapsulating the rest of `AppState`.

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -27,6 +27,7 @@ Fields stay `pub`. No `#[serde(default)]` on the struct.
 - **`Screen` is `Clone`, not `Copy`** — payload variants own screen-local UI (`@src/tui/mod.rs`, issue #242).
 - **`List` stays a unit tag** — dual-pane selection / filters / sorts are session-global on `AppState` (user story 19).
 - Other variants (`Diff`, `Confirm`, `Preview`, `Help`, `Config`, `Revisions`, `Pins`, `Gists`, `GistDetail`, `Palette`, …) carry payloads (body/scroll/return/origin as needed).
+- **Diff/Confirm/Preview body+scroll** is `ScrollBody` (`@src/tui/scroll.rs`, issue #385), reached only via `scroll_body` / `scroll_body_mut`. The ten `diff_body_text` / `scroll_diff_*` methods are gone. `apply_navigation` handles `scroll_body_mut` before the `Screen` match (Pins/Gists still return earlier). Help and Detail comments have no `ScrollBody`.
 - **`nav_stack`** (issue #271) holds return targets; Esc pops. Prefer stack ops over parallel “return” root fields for new navigation.
 - Staged root fields (`diff_return` / `preview_return` / `staged_diff_gist` and similar) are consumed on enter only when still present.
 - **`back_to_list()` is a hard reset** (clears `nav_stack`) — reserve it for paths whose only possible origin is `Screen::List` itself. Confirm-execute paths with more than one possible origin (e.g. `ExecuteDelete`, `ExecuteCompactGist` in `dispatch.rs`) use `leave()`/`cancel_confirm()` instead, to return to whichever screen actually launched them; pop an extra time if the popped screen is now stale (e.g. `GistDetail` for a gist just deleted).
@@ -40,6 +41,7 @@ handle_key (pure) → KeyOutcome → run_loop / dispatch_outcome (IO)
 - New key logic → `AppState::handle_key` (testable).
 - New IO → `dispatch` / `bg` helpers, not `handle_key`.
 - IO-bearing `KeyOutcome` variants carry payloads (issue #244): `@src/tui/mod.rs` (`KeyOutcome`), `@src/tui/dispatch.rs`.
+- Diff/Confirm/Preview scroll keys go through `scroll_body_mut` (issue #385), not per-axis `AppState` methods.
 
 ## Keymap (`@src/tui/keymap.rs`)
 

--- a/src/tui/bg.rs
+++ b/src/tui/bg.rs
@@ -501,7 +501,7 @@ pub(super) fn copy_gist_url_id(state: &mut AppState, gist_id: &str) {
 /// Copies the full previewed file content (the text shown on `Screen::Preview`) to the
 /// system clipboard.
 pub(super) fn copy_preview_content(state: &mut AppState) {
-    let Some(text) = state.preview().map(|p| p.text.clone()) else {
+    let Some(text) = state.preview().map(|p| p.body.text.clone()) else {
         state.set_status("no content to copy");
         return;
     };

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -197,6 +197,19 @@ impl AppState {
         if matches!(self.screen, Screen::Gists(_)) {
             return self.apply_navigation_gists(action);
         }
+        // Diff/Confirm/Preview share ScrollBody; a fourth payload that embeds one gets
+        // these keys for free. Help and Detail comments must not match.
+        if let Some(body) = self.scroll_body_mut() {
+            match action {
+                NavAction::Down => body.down(),
+                NavAction::Up => body.up(),
+                NavAction::PageDown => body.page_down(PAGE_SCROLL),
+                NavAction::PageUp => body.page_up(PAGE_SCROLL),
+                NavAction::Right => body.right(),
+                NavAction::Left => body.left(),
+            }
+            return true;
+        }
         match &mut self.screen {
             Screen::Palette(_) => {
                 let len = self.palette_visible_items().len();
@@ -220,21 +233,14 @@ impl AppState {
             Screen::Revisions(_) => self.apply_navigation_revisions(action),
             Screen::List => self.apply_navigation_list(action),
             Screen::Config(_) => self.apply_navigation_config(action),
-            // Diff, Preview and Confirm all scroll the same diff/preview buffer identically.
-            Screen::Diff(_) | Screen::Preview(_) | Screen::Confirm(_) => {
-                match action {
-                    NavAction::Down => self.scroll_diff_down(),
-                    NavAction::Up => self.scroll_diff_up(),
-                    NavAction::PageDown => self.scroll_diff_page_down(PAGE_SCROLL),
-                    NavAction::PageUp => self.scroll_diff_page_up(PAGE_SCROLL),
-                    NavAction::Right => self.scroll_diff_right(),
-                    NavAction::Left => self.scroll_diff_left(),
-                }
-                true
-            }
-            // Exhaustiveness only — Pins/Gists return above before this match.
-            Screen::Pins(_) | Screen::Gists(_) => {
-                unreachable!("Pins/Gists navigation is handled before the match")
+            // Exhaustiveness only — Pins/Gists return above; Diff/Confirm/Preview use
+            // scroll_body_mut before this match.
+            Screen::Pins(_)
+            | Screen::Gists(_)
+            | Screen::Diff(_)
+            | Screen::Preview(_)
+            | Screen::Confirm(_) => {
+                unreachable!("Pins/Gists and ScrollBody screens are handled before the match")
             }
         }
     }
@@ -796,7 +802,7 @@ mod tests {
 
     #[test]
     fn scroll_down_moves_content_three_lines() {
-        // Set up a Diff screen with enough lines that diff_scroll can reach 3.
+        // Set up a Diff screen with enough lines that wheel-down can reach 3.
         let mut state = state_with_selection();
         state.enter_diff(
             "line1\nline2\nline3\nline4\nline5".into(),
@@ -805,9 +811,9 @@ mod tests {
             std::path::PathBuf::from("/tmp/cwd/x"),
         );
         assert!(state.screen.is_diff());
-        assert_eq!(state.diff_scroll(), 0);
+        assert_eq!(state.scroll_body().expect("Diff ScrollBody").scroll, 0);
         state.handle_mouse(MouseInput::ScrollDown, &MouseLayout::default());
-        assert_eq!(state.diff_scroll(), 3);
+        assert_eq!(state.scroll_body().expect("Diff ScrollBody").scroll, 3);
     }
 
     #[test]
@@ -821,7 +827,7 @@ mod tests {
         );
         set_diff_scroll(&mut state, 3);
         state.handle_mouse(MouseInput::ScrollUp, &MouseLayout::default());
-        assert_eq!(state.diff_scroll(), 0);
+        assert_eq!(state.scroll_body().expect("Diff ScrollBody").scroll, 0);
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -2340,6 +2340,7 @@ mod keymap;
 mod keys;
 mod list_cursor;
 pub(crate) use list_cursor::ListCursor;
+mod scroll;
 mod list_ranking;
 mod pin_sync;
 pub use pin_sync::PinSyncCacheEntry;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -761,10 +761,7 @@ pub struct PinsState {
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct PreviewState {
     pub title: String,
-    /// Body text shown in the preview pane.
-    pub text: String,
-    pub scroll: u16,
-    pub hscroll: u16,
+    pub body: ScrollBody,
     /// `(gist_id, filename)` for refresh / copy-url context.
     pub gist_key: Option<(String, String)>,
 }
@@ -774,9 +771,7 @@ pub struct PreviewState {
 /// state cannot linger on the root (including while parked under Confirm).
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct DiffState {
-    pub text: String,
-    pub scroll: u16,
-    pub hscroll: u16,
+    pub body: ScrollBody,
     /// Remote file body (download source content).
     pub remote_content: String,
     /// Local path paired in the diff (empty for revision-only comparisons).
@@ -796,18 +791,14 @@ pub struct DiffState {
 pub struct ConfirmState {
     pub action: PendingAction,
     /// Background body (unified diff or explanatory message).
-    pub text: String,
-    pub scroll: u16,
-    pub hscroll: u16,
+    pub body: ScrollBody,
 }
 
 impl Default for ConfirmState {
     fn default() -> Self {
         Self {
             action: PendingAction::Download,
-            text: String::new(),
-            scroll: 0,
-            hscroll: 0,
+            body: ScrollBody::default(),
         }
     }
 }
@@ -1132,9 +1123,10 @@ impl AppState {
         self.status = None;
         self.enter(Screen::Preview(Box::new(PreviewState {
             title,
-            text,
-            scroll: 0,
-            hscroll: 0,
+            body: ScrollBody {
+                text,
+                ..ScrollBody::default()
+            },
             gist_key,
         })));
     }
@@ -1155,36 +1147,22 @@ impl AppState {
         self.confirm().map(|c| &c.action)
     }
 
-    /// Background body text for Diff or Confirm (not Preview).
-    pub fn diff_body_text(&self) -> &str {
+    /// Live Diff / Confirm / Preview body. Does not walk `nav_stack` or palette origin.
+    fn scroll_body(&self) -> Option<&ScrollBody> {
         match &self.screen {
-            Screen::Diff(d) => d.text.as_str(),
-            Screen::Confirm(c) => c.text.as_str(),
-            _ => "",
-        }
-    }
-
-    pub fn diff_body_text_mut(&mut self) -> Option<&mut String> {
-        match &mut self.screen {
-            Screen::Diff(d) => Some(&mut d.text),
-            Screen::Confirm(c) => Some(&mut c.text),
+            Screen::Diff(d) => Some(&d.body),
+            Screen::Confirm(c) => Some(&c.body),
+            Screen::Preview(p) => Some(&p.body),
             _ => None,
         }
     }
 
-    pub fn diff_scroll(&self) -> u16 {
-        match &self.screen {
-            Screen::Diff(d) => d.scroll,
-            Screen::Confirm(c) => c.scroll,
-            _ => 0,
-        }
-    }
-
-    pub fn diff_hscroll(&self) -> u16 {
-        match &self.screen {
-            Screen::Diff(d) => d.hscroll,
-            Screen::Confirm(c) => c.hscroll,
-            _ => 0,
+    fn scroll_body_mut(&mut self) -> Option<&mut ScrollBody> {
+        match &mut self.screen {
+            Screen::Diff(d) => Some(&mut d.body),
+            Screen::Confirm(c) => Some(&mut c.body),
+            Screen::Preview(p) => Some(&mut p.body),
+            _ => None,
         }
     }
 
@@ -1194,9 +1172,10 @@ impl AppState {
         self.status = None;
         self.enter(Screen::Confirm(Box::new(ConfirmState {
             action,
-            text,
-            scroll: 0,
-            hscroll: 0,
+            body: ScrollBody {
+                text,
+                ..ScrollBody::default()
+            },
         })));
     }
 
@@ -1206,17 +1185,12 @@ impl AppState {
             return;
         };
         self.status = None;
-        let (text, scroll, hscroll) = (d.text.clone(), d.scroll, d.hscroll);
+        let body = d.body.clone();
         // Park full Diff (pairing + identity) so cancel/download IO still have it; not a
         // `pending_return` case (synchronous — `d` came straight off `self.screen`), so push it
         // directly rather than going through `enter()`.
         self.nav_stack.push(Screen::Diff(d));
-        self.screen = Screen::Confirm(Box::new(ConfirmState {
-            action,
-            text,
-            scroll,
-            hscroll,
-        }));
+        self.screen = Screen::Confirm(Box::new(ConfirmState { action, body }));
     }
 
     /// Leave Confirm for a Download cancel: restore the parked Diff payload.
@@ -1226,9 +1200,7 @@ impl AppState {
         };
         self.leave();
         if let Screen::Diff(ref mut d) = self.screen {
-            d.text = c.text;
-            d.scroll = c.scroll;
-            d.hscroll = c.hscroll;
+            d.body = c.body;
         }
     }
 
@@ -1292,8 +1264,8 @@ impl AppState {
             &local_content,
             self.ignore_trailing_newline,
         );
-        if let Some(body) = self.diff_body_text_mut() {
-            *body = diff;
+        if let Some(body) = self.scroll_body_mut() {
+            body.text = diff;
         }
     }
 
@@ -1989,9 +1961,10 @@ impl AppState {
         };
         self.status = None;
         self.enter(Screen::Diff(Box::new(DiffState {
-            text: diff_text,
-            scroll: 0,
-            hscroll: 0,
+            body: ScrollBody {
+                text: diff_text,
+                ..ScrollBody::default()
+            },
             remote_content: remote,
             local_path: local,
             download_target: target,
@@ -2047,100 +2020,6 @@ impl AppState {
 
     pub fn set_status(&mut self, message: impl Into<String>) {
         self.status = Some(message.into());
-    }
-
-    pub fn scroll_diff_down(&mut self) {
-        let max = self.diff_vscroll_max();
-        if let Some(p) = self.preview_mut() {
-            if p.scroll < max {
-                p.scroll += 1;
-            }
-            return;
-        }
-        match &mut self.screen {
-            Screen::Diff(d) if d.scroll < max => d.scroll += 1,
-            Screen::Confirm(c) if c.scroll < max => c.scroll += 1,
-            _ => {}
-        }
-    }
-
-    /// Bottom clamp for the diff/preview vertical scroll: the last addressable line index.
-    fn diff_vscroll_max(&self) -> u16 {
-        let text = self
-            .preview()
-            .map(|p| p.text.as_str())
-            .unwrap_or_else(|| self.diff_body_text());
-        text.lines()
-            .count()
-            .saturating_sub(1)
-            .min(u16::MAX as usize) as u16
-    }
-
-    pub fn scroll_diff_up(&mut self) {
-        if let Some(p) = self.preview_mut() {
-            p.scroll = p.scroll.saturating_sub(1);
-            return;
-        }
-        match &mut self.screen {
-            Screen::Diff(d) => d.scroll = d.scroll.saturating_sub(1),
-            Screen::Confirm(c) => c.scroll = c.scroll.saturating_sub(1),
-            _ => {}
-        }
-    }
-
-    /// Page the diff/preview down by `lines`, clamped to the same bottom as `scroll_diff_down`.
-    pub fn scroll_diff_page_down(&mut self, lines: u16) {
-        let max = self.diff_vscroll_max();
-        if let Some(p) = self.preview_mut() {
-            p.scroll = p.scroll.saturating_add(lines).min(max);
-            return;
-        }
-        match &mut self.screen {
-            Screen::Diff(d) => d.scroll = d.scroll.saturating_add(lines).min(max),
-            Screen::Confirm(c) => c.scroll = c.scroll.saturating_add(lines).min(max),
-            _ => {}
-        }
-    }
-
-    /// Page the diff/preview up by `lines`, saturating at the top.
-    pub fn scroll_diff_page_up(&mut self, lines: u16) {
-        if let Some(p) = self.preview_mut() {
-            p.scroll = p.scroll.saturating_sub(lines);
-            return;
-        }
-        match &mut self.screen {
-            Screen::Diff(d) => d.scroll = d.scroll.saturating_sub(lines),
-            Screen::Confirm(c) => c.scroll = c.scroll.saturating_sub(lines),
-            _ => {}
-        }
-    }
-
-    pub fn scroll_diff_right(&mut self) {
-        if let Some(p) = self.preview_mut() {
-            let max = hscroll_max_among(p.text.lines());
-            if p.hscroll < max {
-                p.hscroll += 1;
-            }
-            return;
-        }
-        let max = hscroll_max_among(self.diff_body_text().lines());
-        match &mut self.screen {
-            Screen::Diff(d) if d.hscroll < max => d.hscroll += 1,
-            Screen::Confirm(c) if c.hscroll < max => c.hscroll += 1,
-            _ => {}
-        }
-    }
-
-    pub fn scroll_diff_left(&mut self) {
-        if let Some(p) = self.preview_mut() {
-            p.hscroll = p.hscroll.saturating_sub(1);
-            return;
-        }
-        match &mut self.screen {
-            Screen::Diff(d) => d.hscroll = d.hscroll.saturating_sub(1),
-            Screen::Confirm(c) => c.hscroll = c.hscroll.saturating_sub(1),
-            _ => {}
-        }
     }
 
     /// Context radius to render the diff with: `None` shows the full file, `Some(n)`
@@ -2333,7 +2212,7 @@ mod gist_mutation;
 mod screens;
 pub use screens::detail::InitialComments;
 mod text;
-use text::{hscroll_max_among, hscroll_max_for_text, local_row_label};
+use text::{hscroll_max_for_text, local_row_label};
 mod bg;
 mod dispatch;
 mod keymap;
@@ -2341,6 +2220,7 @@ mod keys;
 mod list_cursor;
 pub(crate) use list_cursor::ListCursor;
 mod scroll;
+pub(crate) use scroll::ScrollBody;
 mod list_ranking;
 mod pin_sync;
 pub use pin_sync::PinSyncCacheEntry;

--- a/src/tui/screens/confirm.rs
+++ b/src/tui/screens/confirm.rs
@@ -389,7 +389,11 @@ mod tests {
             state.upload.watching,
             "still watching — editor hasn't closed yet"
         );
-        assert!(state.diff_body_text().contains("new"));
+        assert!(state
+            .scroll_body()
+            .expect("Confirm ScrollBody")
+            .text
+            .contains("new"));
     }
 
     #[test]
@@ -518,9 +522,9 @@ mod tests {
         set_pending(&mut state, PendingAction::Download);
         set_diff_body(&mut state, "l1\nl2\nl3");
         assert_eq!(state.handle_key(KeyCode::Down), KeyOutcome::None);
-        assert_eq!(state.diff_scroll(), 1);
+        assert_eq!(state.scroll_body().expect("Confirm ScrollBody").scroll, 1);
         state.handle_key(KeyCode::Up);
-        assert_eq!(state.diff_scroll(), 0);
+        assert_eq!(state.scroll_body().expect("Confirm ScrollBody").scroll, 0);
     }
 
     #[test]

--- a/src/tui/screens/diff.rs
+++ b/src/tui/screens/diff.rs
@@ -56,8 +56,8 @@ impl AppState {
             // count changes, so reset the vertical scroll. The choice is persisted.
             KeyCode::Char('c') => {
                 self.diff_show_full = !self.diff_show_full;
-                if let Some(d) = self.diff_mut() {
-                    d.scroll = 0;
+                if let Some(body) = self.scroll_body_mut() {
+                    body.scroll = 0;
                 }
                 return KeyOutcome::PersistDiffContext;
             }
@@ -65,8 +65,8 @@ impl AppState {
             // horizontal offset so wrapped lines start at column 0.
             KeyCode::Char('w') => {
                 self.diff_wrap = !self.diff_wrap;
-                if let Some(d) = self.diff_mut() {
-                    d.hscroll = 0;
+                if let Some(body) = self.scroll_body_mut() {
+                    body.hscroll = 0;
                 }
             }
             _ => {}
@@ -157,7 +157,10 @@ pub(crate) fn diff_footer(state: &AppState) -> String {
 
 /// Diff pane facts — also used as Confirm overwrite background (non-compact).
 pub(crate) fn build_diff_vm(state: &AppState) -> DiffVm {
-    let text = state.diff_body_text();
+    let (text, scroll, hscroll) = match state.scroll_body() {
+        Some(b) => (b.text.as_str(), b.scroll, b.hscroll),
+        None => ("", 0, 0),
+    };
     let body = match state.effective_diff_context() {
         Some(radius) => crate::diff::collapse_context(text, radius),
         None => text.to_string(),
@@ -174,8 +177,8 @@ pub(crate) fn build_diff_vm(state: &AppState) -> DiffVm {
         body,
         footer: diff_footer(state),
         wrap: state.diff_wrap,
-        scroll: state.diff_scroll(),
-        hscroll: state.diff_hscroll(),
+        scroll,
+        hscroll,
         syntax_highlight: state.syntax_highlight,
         ext,
     }
@@ -392,29 +395,16 @@ mod tests {
     use crossterm::event::KeyCode;
     use std::path::PathBuf;
 
-    fn set_diff_hscroll(state: &mut AppState, hscroll: u16) {
-        match &mut state.screen {
-            Screen::Diff(d) => d.hscroll = hscroll,
-            Screen::Confirm(c) => c.hscroll = hscroll,
-            _ => {
-                state.screen = Screen::Diff(Box::new(DiffState {
-                    hscroll,
-                    ..DiffState::default()
-                }));
-            }
-        }
-    }
-
     #[test]
     fn diff_w_toggles_wrap_and_resets_hscroll() {
         let mut state = initial_state();
         state.screen = Screen::Diff(Box::default());
-        set_diff_hscroll(&mut state, 5);
+        state.scroll_body_mut().expect("Diff ScrollBody").hscroll = 5;
         assert!(!state.diff_wrap);
         state.handle_key(KeyCode::Char('w'));
         assert!(state.diff_wrap);
         // Horizontal offset is meaningless once wrapping, so it resets.
-        assert_eq!(state.diff_hscroll(), 0);
+        assert_eq!(state.scroll_body().expect("Diff ScrollBody").hscroll, 0);
         state.handle_key(KeyCode::Char('w'));
         assert!(!state.diff_wrap);
     }
@@ -438,7 +428,7 @@ mod tests {
         set_diff_body(&mut state, "a\nb\nc");
         set_diff_scroll(&mut state, 1);
         state.handle_key(KeyCode::PageUp);
-        assert_eq!(state.diff_scroll(), 0);
+        assert_eq!(state.scroll_body().expect("Diff ScrollBody").scroll, 0);
     }
 
     #[test]
@@ -453,7 +443,7 @@ mod tests {
         let outcome = state.handle_key(KeyCode::Char('c'));
         assert_eq!(outcome, KeyOutcome::PersistDiffContext);
         assert!(state.diff_show_full);
-        assert_eq!(state.diff_scroll(), 0);
+        assert_eq!(state.scroll_body().expect("Diff ScrollBody").scroll, 0);
         assert_eq!(state.effective_diff_context(), None);
 
         // Pressing it again returns to the configured radius.
@@ -498,7 +488,7 @@ mod tests {
         assert_eq!(state.preview_remote(), "remote body");
         assert_eq!(state.preview_local(), PathBuf::from("/tmp/x"));
         assert_eq!(state.download_target(), PathBuf::from("/tmp/cwd/x"));
-        assert_eq!(state.diff_scroll(), 0);
+        assert_eq!(state.scroll_body().expect("Diff ScrollBody").scroll, 0);
     }
 
     #[test]
@@ -510,38 +500,27 @@ mod tests {
             PathBuf::from("/tmp/x"),
             PathBuf::from("/tmp/x"),
         );
-        assert_eq!(state.diff_scroll(), 0);
-        state.handle_key(KeyCode::Up); // stays at 0
-        assert_eq!(state.diff_scroll(), 0);
+        assert_eq!(state.scroll_body().expect("Diff ScrollBody").scroll, 0);
         state.handle_key(KeyCode::Down);
-        assert_eq!(state.diff_scroll(), 1);
-        state.handle_key(KeyCode::Down);
-        assert_eq!(state.diff_scroll(), 2);
-        state.handle_key(KeyCode::Down); // capped at lines-1 = 2
-        assert_eq!(state.diff_scroll(), 2);
+        assert_eq!(state.scroll_body().expect("Diff ScrollBody").scroll, 1);
         state.handle_key(KeyCode::Up);
-        assert_eq!(state.diff_scroll(), 1);
+        assert_eq!(state.scroll_body().expect("Diff ScrollBody").scroll, 0);
     }
 
     #[test]
     fn diff_hscroll_respects_bounds() {
         let mut state = initial_state();
-        // Longest line is "abcd" (4 chars) -> max offset 3.
         state.enter_diff(
             "abcd\nab".into(),
             "r".into(),
             PathBuf::from("/tmp/x"),
             PathBuf::from("/tmp/x"),
         );
-        assert_eq!(state.diff_hscroll(), 0);
-        state.handle_key(KeyCode::Left); // stays at 0
-        assert_eq!(state.diff_hscroll(), 0);
-        for _ in 0..10 {
-            state.handle_key(KeyCode::Right);
-        }
-        assert_eq!(state.diff_hscroll(), 3);
+        assert_eq!(state.scroll_body().expect("Diff ScrollBody").hscroll, 0);
+        state.handle_key(KeyCode::Right);
+        assert_eq!(state.scroll_body().expect("Diff ScrollBody").hscroll, 1);
         state.handle_key(KeyCode::Left);
-        assert_eq!(state.diff_hscroll(), 2);
+        assert_eq!(state.scroll_body().expect("Diff ScrollBody").hscroll, 0);
     }
 
     #[test]

--- a/src/tui/screens/list.rs
+++ b/src/tui/screens/list.rs
@@ -854,7 +854,7 @@ mod tests {
         state.back_to_list();
         assert_eq!(state.screen, Screen::List);
         assert!(!state.diff_previewed());
-        assert!(state.diff_body_text().is_empty());
+        assert!(state.scroll_body().is_none());
         assert!(state.preview_remote().is_empty());
         assert_eq!(state.preview_local(), PathBuf::new());
         assert_eq!(state.download_target(), PathBuf::new());

--- a/src/tui/screens/preview.rs
+++ b/src/tui/screens/preview.rs
@@ -77,12 +77,12 @@ pub(crate) fn build_preview_vm(state: &AppState) -> PreviewVm {
         .and_then(|(_, filename)| crate::tui::view_model::file_ext(filename));
     PreviewVm {
         title: p.title,
-        body: p.text,
+        body: p.body.text,
         footer,
         footer_colored,
         wrap: state.preview_wrap,
-        scroll: p.scroll,
-        hscroll: p.hscroll,
+        scroll: p.body.scroll,
+        hscroll: p.body.hscroll,
         syntax_highlight: state.syntax_highlight,
         ext,
     }
@@ -208,10 +208,6 @@ mod tests {
     use crate::tui::*;
     use crossterm::event::KeyCode;
 
-    fn preview_ref(state: &AppState) -> &PreviewState {
-        state.preview().expect("expected Screen::Preview")
-    }
-
     #[test]
     fn preview_w_toggles_line_wrapping() {
         let mut state = initial_state();
@@ -237,28 +233,23 @@ mod tests {
         let mut state = initial_state();
         state.enter_preview("t".into(), "l1\nl2\nl3".into(), None);
         state.handle_key(KeyCode::Down);
-        assert_eq!(preview_ref(&state).scroll, 1);
+        assert_eq!(state.scroll_body().expect("Preview ScrollBody").scroll, 1);
         state.handle_key(KeyCode::Up);
-        assert_eq!(preview_ref(&state).scroll, 0);
+        assert_eq!(state.scroll_body().expect("Preview ScrollBody").scroll, 0);
     }
 
     #[test]
-    fn page_keys_jump_by_ten_clamped_to_bounds() {
+    fn page_keys_jump_by_ten() {
         let mut state = initial_state();
-        // 30 lines → bottom is line 29 (count - 1).
-        let text = (0..30)
+        let text = (0..12)
             .map(|i| format!("l{i}"))
             .collect::<Vec<_>>()
             .join("\n");
         state.enter_preview("t".into(), text, None);
         state.handle_key(KeyCode::PageDown);
-        assert_eq!(preview_ref(&state).scroll, 10);
-        // A second page-down would reach 20; a third clamps at the 29-line bottom, not 30.
-        state.handle_key(KeyCode::PageDown);
-        state.handle_key(KeyCode::PageDown);
-        assert_eq!(preview_ref(&state).scroll, 29);
+        assert_eq!(state.scroll_body().expect("Preview ScrollBody").scroll, 10);
         state.handle_key(KeyCode::PageUp);
-        assert_eq!(preview_ref(&state).scroll, 19);
+        assert_eq!(state.scroll_body().expect("Preview ScrollBody").scroll, 0);
     }
 
     #[test]
@@ -380,7 +371,7 @@ mod tests {
             Some(&"body".to_string())
         );
         let preview = state.preview().expect("expected Screen::Preview");
-        assert_eq!(preview.text, "body");
+        assert_eq!(preview.body.text, "body");
     }
 
     #[test]

--- a/src/tui/scroll.rs
+++ b/src/tui/scroll.rs
@@ -1,0 +1,139 @@
+//! Shared body text + scroll offsets for Diff, Confirm, and Preview.
+//!
+//! Vertical max is the last addressable line (`lines - 1`; empty → 0). Horizontal
+//! max is [`hscroll_max_among`]. Wrap is not this type's job — callers zero
+//! `hscroll` themselves when wrapping.
+
+use super::text::hscroll_max_among;
+
+/// Scrollable text body: content plus vertical and horizontal offsets.
+#[allow(dead_code)] // Wired into Diff/Confirm/Preview in the following commit.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ScrollBody {
+    pub text: String,
+    pub scroll: u16,
+    pub hscroll: u16,
+}
+
+#[allow(dead_code)] // Wired into Diff/Confirm/Preview in the following commit.
+impl ScrollBody {
+    /// Last addressable line index (empty body → 0).
+    fn vscroll_max(&self) -> u16 {
+        self.text
+            .lines()
+            .count()
+            .saturating_sub(1)
+            .min(u16::MAX as usize) as u16
+    }
+
+    /// Move down one line, clamped at [`Self::vscroll_max`].
+    pub fn down(&mut self) {
+        let max = self.vscroll_max();
+        if self.scroll < max {
+            self.scroll += 1;
+        }
+    }
+
+    /// Move up one line, saturating at 0.
+    pub fn up(&mut self) {
+        self.scroll = self.scroll.saturating_sub(1);
+    }
+
+    /// Page down by `lines`, clamped at [`Self::vscroll_max`].
+    pub fn page_down(&mut self, lines: u16) {
+        let max = self.vscroll_max();
+        self.scroll = self.scroll.saturating_add(lines).min(max);
+    }
+
+    /// Page up by `lines`, saturating at 0.
+    pub fn page_up(&mut self, lines: u16) {
+        self.scroll = self.scroll.saturating_sub(lines);
+    }
+
+    /// Move right one character, clamped at the longest line.
+    pub fn right(&mut self) {
+        let max = hscroll_max_among(self.text.lines());
+        if self.hscroll < max {
+            self.hscroll += 1;
+        }
+    }
+
+    /// Move left one character, saturating at 0.
+    pub fn left(&mut self) {
+        self.hscroll = self.hscroll.saturating_sub(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_body_down_and_right_stay_at_zero() {
+        let mut body = ScrollBody::default();
+        body.down();
+        body.right();
+        assert_eq!(body.scroll, 0);
+        assert_eq!(body.hscroll, 0);
+    }
+
+    #[test]
+    fn vertical_cap_is_last_line_index() {
+        let mut body = ScrollBody {
+            text: "l1\nl2\nl3".into(),
+            ..ScrollBody::default()
+        };
+        body.down();
+        body.down();
+        body.down();
+        assert_eq!(body.scroll, 2);
+    }
+
+    #[test]
+    fn up_saturates_at_zero() {
+        let mut body = ScrollBody {
+            text: "l1\nl2\nl3".into(),
+            scroll: 1,
+            ..ScrollBody::default()
+        };
+        body.up();
+        body.up();
+        assert_eq!(body.scroll, 0);
+    }
+
+    #[test]
+    fn page_down_and_page_up_clamp() {
+        let mut body = ScrollBody {
+            text: "l1\nl2\nl3".into(),
+            ..ScrollBody::default()
+        };
+        body.page_down(10);
+        assert_eq!(body.scroll, 2);
+        body.page_up(10);
+        assert_eq!(body.scroll, 0);
+    }
+
+    #[test]
+    fn horizontal_cap_is_longest_line() {
+        let mut body = ScrollBody {
+            text: "abcd\nab".into(),
+            ..ScrollBody::default()
+        };
+        for _ in 0..10 {
+            body.right();
+        }
+        assert_eq!(body.hscroll, 3);
+    }
+
+    #[test]
+    fn left_saturates_at_zero() {
+        let mut body = ScrollBody {
+            text: "abcd\nab".into(),
+            hscroll: 1,
+            ..ScrollBody::default()
+        };
+        body.left();
+        body.left();
+        assert_eq!(body.hscroll, 0);
+    }
+}

--- a/src/tui/scroll.rs
+++ b/src/tui/scroll.rs
@@ -7,7 +7,6 @@
 use super::text::hscroll_max_among;
 
 /// Scrollable text body: content plus vertical and horizontal offsets.
-#[allow(dead_code)] // Wired into Diff/Confirm/Preview in the following commit.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ScrollBody {
     pub text: String,
@@ -15,7 +14,6 @@ pub struct ScrollBody {
     pub hscroll: u16,
 }
 
-#[allow(dead_code)] // Wired into Diff/Confirm/Preview in the following commit.
 impl ScrollBody {
     /// Last addressable line index (empty body → 0).
     fn vscroll_max(&self) -> u16 {

--- a/src/tui/test_support.rs
+++ b/src/tui/test_support.rs
@@ -71,28 +71,36 @@ pub(super) fn set_pending(state: &mut AppState, action: PendingAction) {
 
 pub(super) fn set_diff_body(state: &mut AppState, text: impl Into<String>) {
     let text = text.into();
-    if let Some(t) = state.diff_body_text_mut() {
-        *t = text;
-        return;
+    if matches!(state.screen, Screen::Diff(_) | Screen::Confirm(_)) {
+        if let Some(body) = state.scroll_body_mut() {
+            body.text = text;
+            return;
+        }
     }
     // Ensure a Diff payload exists for tests that set body before navigating.
     state.screen = Screen::Diff(Box::new(DiffState {
-        text,
+        body: ScrollBody {
+            text,
+            ..ScrollBody::default()
+        },
         ..DiffState::default()
     }));
 }
 
 pub(super) fn set_diff_scroll(state: &mut AppState, scroll: u16) {
-    match &mut state.screen {
-        Screen::Diff(d) => d.scroll = scroll,
-        Screen::Confirm(c) => c.scroll = scroll,
-        _ => {
-            state.screen = Screen::Diff(Box::new(DiffState {
-                scroll,
-                ..DiffState::default()
-            }));
+    if matches!(state.screen, Screen::Diff(_) | Screen::Confirm(_)) {
+        if let Some(body) = state.scroll_body_mut() {
+            body.scroll = scroll;
+            return;
         }
     }
+    state.screen = Screen::Diff(Box::new(DiffState {
+        body: ScrollBody {
+            scroll,
+            ..ScrollBody::default()
+        },
+        ..DiffState::default()
+    }));
 }
 
 pub(super) fn state_with_gists() -> AppState {


### PR DESCRIPTION
Closes #385

Extract the `text · scroll · hscroll` cluster on Diff/Confirm/Preview into `ScrollBody`. `AppState` now exposes `scroll_body` / `scroll_body_mut` (live screen only, including Preview) instead of ten per-axis methods. Navigation keys hit the body before the `Screen` match.

- Clamp lives in `src/tui/scroll.rs` and is unit-tested there with literals
- Screen/keys tests only assert `handle_key` / wheel reaches `ScrollBody`
- `enter_confirm_from_diff` / `cancel_confirm_to_diff` copy `body`
- ADR-0001 records this as narrowing the demonstrated cluster, not reversing the decision

Out of scope (as specified): Help and GistDetail comment scroll, teaching `ScrollBody` about wrap, `dispatch.rs` staging, folding `handle_key` into `screens::lookup`, `render/mod.rs` split.