### PR TITLE
refactor(gh): one fetch entry per function, runner required

### DIFF
--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -113,6 +113,6 @@ Narrow-terminal reflow (issue #342), also in `@src/tui/render/mod.rs` — differ
 ## Safety seams (rich refs)
 
 - Download overwrite gate (issue #246): `@src/actions.rs` — `DownloadMode` / `OverwriteConfirmed`.
-- Injectable `gh` boundary (issue #245): `CommandRunner` + `actions::test_support::SeqRunner`; fixtures in `tests/fixtures/gh/`.
+- Injectable `gh` boundary (issue #245, #386): `foo(runner)` with `CommandRunner` first; adapters `SystemRunner` / `SeqRunner`. There is no second door. Fixtures in `tests/fixtures/gh/`.
 - Gold-style TUI pure logic: each `tui` module's own `#[cfg(test)] mod tests` (no network); shared `AppState` fixtures live in `@src/tui/test_support.rs`.
 - E2E frames: `@scripts/demo/` (real binary + fake `gh` + fake cwd).

--- a/src/gh/comments.rs
+++ b/src/gh/comments.rs
@@ -1,7 +1,7 @@
 //! Gist comment fetch/parse/pagination (issue #301).
 
 use super::{parse_gh_gists, GhCommentUser};
-use crate::actions::{run_command, CommandPlan, CommandRunner, SystemRunner};
+use crate::actions::{run_command, CommandPlan, CommandRunner};
 use crate::domain::GistComment;
 use anyhow::{Context, Result};
 use serde::Deserialize;
@@ -105,19 +105,11 @@ pub fn gist_comments_page_plan(gist_id: &str, page: u32, per_page: u32) -> Comma
     }
 }
 
-pub fn fetch_gist_comments_probe(gist_id: &str) -> Result<String> {
-    fetch_gist_comments_probe_with(&SystemRunner, gist_id)
-}
-
-pub fn fetch_gist_comments_probe_with(runner: &dyn CommandRunner, gist_id: &str) -> Result<String> {
+pub fn fetch_gist_comments_probe(runner: &dyn CommandRunner, gist_id: &str) -> Result<String> {
     run_command(runner, &gist_comments_probe_plan(gist_id))
 }
 
-pub fn fetch_gist_comments_page(gist_id: &str, page: u32, per_page: u32) -> Result<String> {
-    fetch_gist_comments_page_with(&SystemRunner, gist_id, page, per_page)
-}
-
-pub fn fetch_gist_comments_page_with(
+pub fn fetch_gist_comments_page(
     runner: &dyn CommandRunner,
     gist_id: &str,
     page: u32,

--- a/src/gh/forks.rs
+++ b/src/gh/forks.rs
@@ -1,7 +1,7 @@
 //! Gist fork counts, fork-flag detection, and fork_of resolution (issue #301).
 
 use super::{escape_graphql_string, parse_gh_gists, GhGist};
-use crate::actions::{run_command, CommandPlan, CommandRunner, SystemRunner};
+use crate::actions::{run_command, CommandPlan, CommandRunner};
 use crate::domain::GistFile;
 use anyhow::{Context, Result};
 use serde::Deserialize;
@@ -29,7 +29,7 @@ pub fn gist_forks_plan(gist_id: &str) -> CommandPlan {
     }
 }
 
-pub fn fetch_gist_fork_count_with(runner: &dyn CommandRunner, gist_id: &str) -> Result<u32> {
+pub fn fetch_gist_fork_count(runner: &dyn CommandRunner, gist_id: &str) -> Result<u32> {
     let raw = run_command(runner, &gist_forks_plan(gist_id))?;
     let forks: Vec<serde_json::Value> = serde_json::from_str(&raw).context("parse gist forks")?;
     Ok(forks.len() as u32)
@@ -39,7 +39,7 @@ pub fn fetch_gist_fork_count_with(runner: &dyn CommandRunner, gist_id: &str) -> 
 /// One page of the viewer's gists with their `isFork` flag. Accounts with >100 gists need
 /// pagination: `after` carries the previous page's `endCursor` (escaped, since it is opaque
 /// API text), and the response's `pageInfo` drives the loop in
-/// [`fetch_forked_gist_ids_graphql_with`].
+/// [`fetch_forked_gist_ids_graphql`].
 fn gist_fork_flags_graphql_query(after: Option<&str>) -> String {
     let connection = match after {
         Some(cursor) => format!(
@@ -74,7 +74,7 @@ pub fn gist_detail_plan(gist_id: &str) -> CommandPlan {
     }
 }
 
-pub fn fetch_forked_gist_ids_graphql_with(runner: &dyn CommandRunner) -> Result<HashSet<String>> {
+pub fn fetch_forked_gist_ids_graphql(runner: &dyn CommandRunner) -> Result<HashSet<String>> {
     let mut all = HashSet::new();
     let mut after: Option<String> = None;
     loop {
@@ -149,15 +149,12 @@ fn parse_fork_flags_page(raw: &str) -> Result<(HashSet<String>, Option<String>)>
 }
 
 /// Owned gist ids flagged as forks by a single GraphQL viewer page (the cursor is dropped).
-/// Pagination is handled by [`fetch_forked_gist_ids_graphql_with`].
+/// Pagination is handled by [`fetch_forked_gist_ids_graphql`].
 pub fn parse_forked_gist_ids_graphql(raw: &str) -> Result<HashSet<String>> {
     parse_fork_flags_page(raw).map(|(ids, _)| ids)
 }
 
-pub fn fetch_gist_fork_of_id_with(
-    runner: &dyn CommandRunner,
-    gist_id: &str,
-) -> Result<Option<String>> {
+pub fn fetch_gist_fork_of_id(runner: &dyn CommandRunner, gist_id: &str) -> Result<Option<String>> {
     let raw = run_command(runner, &gist_detail_plan(gist_id))?;
     let gist: GhGist = serde_json::from_str(&raw).context("parse gh gist detail JSON")?;
     Ok(gist.fork_of.map(|f| f.id))
@@ -166,23 +163,16 @@ pub fn fetch_gist_fork_of_id_with(
 /// Map owned gist id → upstream `fork_of` id. Uses GraphQL `isFork` (one call) then
 /// `GET /gists/{id}` only for the handful of owned forks (list JSON omits `fork_of`).
 pub fn collect_owned_fork_of_ids(
-    owned_ids: HashSet<String>,
-) -> Result<HashMap<String, Option<String>>, String> {
-    collect_owned_fork_of_ids_with(&SystemRunner, owned_ids)
-}
-
-/// Injectable variant of [`collect_owned_fork_of_ids`] (issue #245).
-pub fn collect_owned_fork_of_ids_with(
     runner: &dyn CommandRunner,
     owned_ids: HashSet<String>,
 ) -> Result<HashMap<String, Option<String>>, String> {
     // Surface a failure of the single fork-detection query — a transient error or expired
     // token would otherwise leave every owned fork undetected with no hint why the `forked`
     // filter is empty. Per-gist `fork_of` lookups stay best-effort (one bad gist is skipped).
-    let fork_ids = fetch_forked_gist_ids_graphql_with(runner).map_err(|e| e.to_string())?;
+    let fork_ids = fetch_forked_gist_ids_graphql(runner).map_err(|e| e.to_string())?;
     let mut out = HashMap::new();
     for id in fork_ids.intersection(&owned_ids) {
-        if let Ok(fork_of) = fetch_gist_fork_of_id_with(runner, id) {
+        if let Ok(fork_of) = fetch_gist_fork_of_id(runner, id) {
             out.insert(id.clone(), fork_of);
         }
     }
@@ -201,15 +191,6 @@ pub fn apply_fork_of_ids(gists: &mut [GistFile], fork_of: &HashMap<String, Optio
 /// Fill fork counts. List JSON usually omits `forks`, so each id is probed via
 /// `/gists/{id}/forks` when the parsed count is zero. Merges owned and starred list JSON.
 pub fn collect_gist_fork_counts(
-    owned_raw: Option<&str>,
-    starred_raw: Option<&str>,
-    gist_ids: impl IntoIterator<Item = String>,
-) -> HashMap<String, u32> {
-    collect_gist_fork_counts_with(&SystemRunner, owned_raw, starred_raw, gist_ids)
-}
-
-/// Injectable variant of [`collect_gist_fork_counts`] (issue #245).
-pub fn collect_gist_fork_counts_with(
     runner: &dyn CommandRunner,
     owned_raw: Option<&str>,
     starred_raw: Option<&str>,
@@ -227,7 +208,7 @@ pub fn collect_gist_fork_counts_with(
         if counts.get(&id).copied().unwrap_or(0) > 0 {
             continue;
         }
-        if let Ok(n) = fetch_gist_fork_count_with(runner, &id) {
+        if let Ok(n) = fetch_gist_fork_count(runner, &id) {
             if n > 0 {
                 counts.insert(id, n);
             }
@@ -340,7 +321,7 @@ mod tests {
                 stderr: String::new(),
             },
         ]);
-        let counts = collect_gist_fork_counts_with(
+        let counts = collect_gist_fork_counts(
             &runner,
             Some(list_raw),
             None,
@@ -387,7 +368,7 @@ mod tests {
             },
         ]);
         let owned = HashSet::from(["g1".into(), "g2".into(), "g3".into()]);
-        let map = collect_owned_fork_of_ids_with(&runner, owned).unwrap();
+        let map = collect_owned_fork_of_ids(&runner, owned).unwrap();
         assert_eq!(map.get("g1").cloned(), Some(Some("upstream1".into())));
         assert!(!map.contains_key("g2"));
         assert!(!map.contains_key("g3"));
@@ -406,8 +387,7 @@ mod tests {
             stdout: String::new(),
             stderr: "HTTP 401".into(),
         }]);
-        let err =
-            collect_owned_fork_of_ids_with(&runner, HashSet::from(["g1".into()])).unwrap_err();
+        let err = collect_owned_fork_of_ids(&runner, HashSet::from(["g1".into()])).unwrap_err();
         assert!(err.contains("401") || err.contains("HTTP"));
     }
 }

--- a/src/gh/gists.rs
+++ b/src/gh/gists.rs
@@ -1,7 +1,7 @@
 //! Gist listing, node-id mapping, and file-content fetch (issue #301).
 
 use super::{parse_gh_gists, raw_url_fetch_plan};
-use crate::actions::{run_command, CommandPlan, CommandRunner, SystemRunner};
+use crate::actions::{run_command, CommandPlan, CommandRunner};
 use crate::domain::GistFile;
 use anyhow::{Context, Result};
 use std::collections::HashMap;
@@ -115,27 +115,15 @@ pub fn merge_gist_node_id_maps(
     map
 }
 
-pub fn fetch_gist_list_json() -> Result<String> {
-    fetch_gist_list_json_with(&SystemRunner)
-}
-
-pub fn fetch_gist_list_json_with(runner: &dyn CommandRunner) -> Result<String> {
+pub fn fetch_gist_list_json(runner: &dyn CommandRunner) -> Result<String> {
     run_command(runner, &gist_list_plan())
 }
 
-pub fn fetch_gist_starred_list_json() -> Result<String> {
-    fetch_gist_starred_list_json_with(&SystemRunner)
-}
-
-pub fn fetch_gist_starred_list_json_with(runner: &dyn CommandRunner) -> Result<String> {
+pub fn fetch_gist_starred_list_json(runner: &dyn CommandRunner) -> Result<String> {
     run_command(runner, &gist_starred_list_plan())
 }
 
-pub fn fetch_current_user_login() -> Result<String> {
-    fetch_current_user_login_with(&SystemRunner)
-}
-
-pub fn fetch_current_user_login_with(runner: &dyn CommandRunner) -> Result<String> {
+pub fn fetch_current_user_login(runner: &dyn CommandRunner) -> Result<String> {
     let raw = run_command(runner, &current_user_plan())?;
     let login = raw.trim().trim_matches('"').to_string();
     if login.is_empty() {
@@ -151,14 +139,6 @@ pub fn parse_starred_gist_ids(raw: &str) -> Result<std::collections::HashSet<Str
 }
 
 pub fn fetch_gist_file_content(
-    gist_id: &str,
-    filename: &str,
-    raw_url: Option<&str>,
-) -> Result<String> {
-    fetch_gist_file_content_with(&SystemRunner, gist_id, filename, raw_url)
-}
-
-pub fn fetch_gist_file_content_with(
     runner: &dyn CommandRunner,
     gist_id: &str,
     filename: &str,
@@ -240,7 +220,7 @@ mod tests {
             },
         ]);
 
-        let content = fetch_gist_file_content_with(&runner, "id", "file.md", Some(url)).unwrap();
+        let content = fetch_gist_file_content(&runner, "id", "file.md", Some(url)).unwrap();
         assert_eq!(content, "big content");
         let calls = runner.calls();
         assert_eq!(calls[0], gist_view_plan("id", "file.md"));

--- a/src/gh/mod.rs
+++ b/src/gh/mod.rs
@@ -1,4 +1,4 @@
-use crate::actions::{CommandPlan, CommandRunner, SystemRunner};
+use crate::actions::{CommandPlan, CommandRunner};
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
 use std::collections::BTreeMap;
@@ -65,11 +65,7 @@ pub fn auth_status_plan() -> CommandPlan {
     }
 }
 
-pub fn check_gh_ready() -> Result<()> {
-    check_gh_ready_with(&SystemRunner)
-}
-
-pub fn check_gh_ready_with(runner: &dyn CommandRunner) -> Result<()> {
+pub fn check_gh_ready(runner: &dyn CommandRunner) -> Result<()> {
     if !runner.run(&gh_version_plan())?.success {
         bail!("gh is installed but did not run successfully");
     }
@@ -112,41 +108,36 @@ pub fn raw_url_fetch_plan(url: &str) -> CommandPlan {
 // existing `crate::gh::X` call sites don't need to know the submodule boundary exists.
 mod comments;
 pub use comments::{
-    comments_total_from_probe, fetch_gist_comments_page, fetch_gist_comments_page_with,
-    fetch_gist_comments_probe, fetch_gist_comments_probe_with, gist_comments_page_plan,
-    gist_comments_probe_plan, last_page, parse_gist_comment_counts, parse_gist_comments_json,
-    parse_link_rel, COMMENTS_PAGE_SIZE,
+    comments_total_from_probe, fetch_gist_comments_page, fetch_gist_comments_probe,
+    gist_comments_page_plan, gist_comments_probe_plan, last_page, parse_gist_comment_counts,
+    parse_gist_comments_json, parse_link_rel, COMMENTS_PAGE_SIZE,
 };
 
 mod forks;
 pub use forks::{
-    apply_fork_of_ids, collect_gist_fork_counts, collect_gist_fork_counts_with,
-    collect_owned_fork_of_ids, collect_owned_fork_of_ids_with, fetch_forked_gist_ids_graphql_with,
-    fetch_gist_fork_count_with, fetch_gist_fork_of_id_with, gist_detail_plan,
+    apply_fork_of_ids, collect_gist_fork_counts, collect_owned_fork_of_ids,
+    fetch_forked_gist_ids_graphql, fetch_gist_fork_count, fetch_gist_fork_of_id, gist_detail_plan,
     gist_fork_flags_graphql_plan, gist_forks_plan, parse_forked_gist_ids_graphql,
     parse_gist_fork_counts,
 };
 
 mod gists;
 pub use gists::{
-    current_user_plan, fetch_current_user_login, fetch_current_user_login_with,
-    fetch_gist_file_content, fetch_gist_file_content_with, fetch_gist_list_json,
-    fetch_gist_list_json_with, fetch_gist_starred_list_json, fetch_gist_starred_list_json_with,
-    gist_list_plan, gist_node_id_map, gist_starred_list_plan, gist_view_plan,
-    merge_gist_node_id_maps, parse_gist_list_json, parse_starred_gist_ids,
+    current_user_plan, fetch_current_user_login, fetch_gist_file_content, fetch_gist_list_json,
+    fetch_gist_starred_list_json, gist_list_plan, gist_node_id_map, gist_starred_list_plan,
+    gist_view_plan, merge_gist_node_id_maps, parse_gist_list_json, parse_starred_gist_ids,
 };
 
 mod revisions;
 pub use revisions::{
-    build_gist_revision_raw_url, fetch_gist_commits_json, fetch_gist_commits_json_with,
-    fetch_gist_revision_json_with, fetch_revision_file_text, fetch_revision_file_text_optional,
-    fetch_revision_file_text_optional_with, fetch_revision_file_text_with,
-    fetch_revision_file_with, gist_commits_plan, gist_revision_plan, parse_gist_commits_json,
-    revision_file_content, RevisionFileContent,
+    build_gist_revision_raw_url, fetch_gist_commits_json, fetch_gist_revision_json,
+    fetch_revision_file, fetch_revision_file_text, fetch_revision_file_text_optional,
+    gist_commits_plan, gist_revision_plan, parse_gist_commits_json, revision_file_content,
+    RevisionFileContent,
 };
 
 mod stars;
 pub use stars::{
-    build_stargazer_graphql_query, collect_gist_star_counts, collect_gist_star_counts_with,
-    gist_stargazer_graphql_plan, parse_stargazer_counts_graphql,
+    build_stargazer_graphql_query, collect_gist_star_counts, gist_stargazer_graphql_plan,
+    parse_stargazer_counts_graphql,
 };

--- a/src/gh/revisions.rs
+++ b/src/gh/revisions.rs
@@ -1,7 +1,7 @@
 //! Gist revision history and per-revision file fetch/parse (issue #301).
 
 use super::{raw_url_fetch_plan, GhCommentUser};
-use crate::actions::{run_command, CommandPlan, CommandRunner, SystemRunner};
+use crate::actions::{run_command, CommandPlan, CommandRunner};
 use crate::domain::{GistRevision, GistRevisionChangeStatus};
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
@@ -26,15 +26,11 @@ pub fn gist_revision_plan(gist_id: &str, version: &str) -> CommandPlan {
     }
 }
 
-pub fn fetch_gist_commits_json(gist_id: &str) -> Result<String> {
-    fetch_gist_commits_json_with(&SystemRunner, gist_id)
-}
-
-pub fn fetch_gist_commits_json_with(runner: &dyn CommandRunner, gist_id: &str) -> Result<String> {
+pub fn fetch_gist_commits_json(runner: &dyn CommandRunner, gist_id: &str) -> Result<String> {
     run_command(runner, &gist_commits_plan(gist_id))
 }
 
-pub fn fetch_gist_revision_json_with(
+pub fn fetch_gist_revision_json(
     runner: &dyn CommandRunner,
     gist_id: &str,
     version: &str,
@@ -88,7 +84,7 @@ fn fetch_revision_file_via_raw_url(
 /// Fetch one file at a gist revision SHA. Uses the revision API when it works; on HTTP
 /// failures or truncated payloads, falls back to the revision `raw_url` or the canonical
 /// `gist.githubusercontent.com/.../raw/{sha}/{file}` URL.
-pub fn fetch_revision_file_with(
+pub fn fetch_revision_file(
     runner: &dyn CommandRunner,
     gist_id: &str,
     version: &str,
@@ -96,7 +92,7 @@ pub fn fetch_revision_file_with(
     owner_login: &str,
 ) -> Result<RevisionFileContent> {
     let constructed = build_gist_revision_raw_url(owner_login, gist_id, version, filename);
-    match fetch_gist_revision_json_with(runner, gist_id, version) {
+    match fetch_gist_revision_json(runner, gist_id, version) {
         Ok(raw) => {
             let root: serde_json::Value =
                 serde_json::from_str(&raw).context("parse gh gist revision JSON")?;
@@ -123,22 +119,13 @@ pub fn fetch_revision_file_with(
 }
 
 pub fn fetch_revision_file_text(
-    gist_id: &str,
-    version: &str,
-    filename: &str,
-    owner_login: &str,
-) -> Result<String> {
-    fetch_revision_file_text_with(&SystemRunner, gist_id, version, filename, owner_login)
-}
-
-pub fn fetch_revision_file_text_with(
     runner: &dyn CommandRunner,
     gist_id: &str,
     version: &str,
     filename: &str,
     owner_login: &str,
 ) -> Result<String> {
-    match fetch_revision_file_with(runner, gist_id, version, filename, owner_login)? {
+    match fetch_revision_file(runner, gist_id, version, filename, owner_login)? {
         RevisionFileContent::Present(content) => Ok(content),
         RevisionFileContent::Truncated => {
             bail!("file too large for API preview (>1 MB)")
@@ -148,22 +135,13 @@ pub fn fetch_revision_file_text_with(
 }
 
 pub fn fetch_revision_file_text_optional(
-    gist_id: &str,
-    version: &str,
-    filename: &str,
-    owner_login: &str,
-) -> Result<String> {
-    fetch_revision_file_text_optional_with(&SystemRunner, gist_id, version, filename, owner_login)
-}
-
-pub fn fetch_revision_file_text_optional_with(
     runner: &dyn CommandRunner,
     gist_id: &str,
     version: &str,
     filename: &str,
     owner_login: &str,
 ) -> Result<String> {
-    match fetch_revision_file_with(runner, gist_id, version, filename, owner_login)? {
+    match fetch_revision_file(runner, gist_id, version, filename, owner_login)? {
         RevisionFileContent::Present(content) => Ok(content),
         RevisionFileContent::Truncated => bail!("file too large for API preview (>1 MB)"),
         RevisionFileContent::Absent => Ok(String::new()),
@@ -312,7 +290,7 @@ mod tests {
             },
         ]);
 
-        let content = fetch_revision_file_with(&runner, "g1", "sha1", "f.md", "karpathy").unwrap();
+        let content = fetch_revision_file(&runner, "g1", "sha1", "f.md", "karpathy").unwrap();
         assert_eq!(
             content,
             RevisionFileContent::Present("revision body".into())

--- a/src/gh/stars.rs
+++ b/src/gh/stars.rs
@@ -1,7 +1,7 @@
 //! Stargazer counts via a batched GraphQL query (issue #301).
 
 use super::escape_graphql_string;
-use crate::actions::{run_command, CommandPlan, CommandRunner, SystemRunner};
+use crate::actions::{run_command, CommandPlan, CommandRunner};
 use anyhow::{Context, Result};
 use std::collections::HashMap;
 
@@ -58,11 +58,7 @@ pub fn parse_stargazer_counts_graphql(raw: &str) -> Result<HashMap<String, u32>>
     Ok(out)
 }
 
-pub fn collect_gist_star_counts(node_ids: HashMap<String, String>) -> HashMap<String, u32> {
-    collect_gist_star_counts_with(&SystemRunner, node_ids)
-}
-
-pub fn collect_gist_star_counts_with(
+pub fn collect_gist_star_counts(
     runner: &dyn CommandRunner,
     node_ids: HashMap<String, String>,
 ) -> HashMap<String, u32> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ fn main() -> Result<()> {
         .map_err(|e| anyhow::anyhow!("could not enter {}: {e}", workdir.display()))?;
 
     if cli.check {
-        gistui::gh::check_gh_ready()?;
+        gistui::gh::check_gh_ready(&gistui::actions::SystemRunner)?;
         println!("gh is installed and authenticated");
         return Ok(());
     }

--- a/src/tui/bg.rs
+++ b/src/tui/bg.rs
@@ -3,6 +3,7 @@
 //! so call sites do not own parallel channel fields by hand (issue #243).
 
 use super::*;
+use crate::actions::SystemRunner;
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io;
 use std::path::PathBuf;
@@ -55,13 +56,25 @@ pub(super) fn fetch_revision_incremental_pair(
     owner_login: &str,
 ) -> std::result::Result<(String, String), String> {
     let new_content = ensure_fetched_text(
-        crate::gh::fetch_revision_file_text_optional(gist_id, child_version, filename, owner_login)
-            .map_err(|e| e.to_string())?,
+        crate::gh::fetch_revision_file_text_optional(
+            &SystemRunner,
+            gist_id,
+            child_version,
+            filename,
+            owner_login,
+        )
+        .map_err(|e| e.to_string())?,
     )?;
     let old_content = match parent_version {
         Some(parent) => ensure_fetched_text(
-            crate::gh::fetch_revision_file_text_optional(gist_id, parent, filename, owner_login)
-                .map_err(|e| e.to_string())?,
+            crate::gh::fetch_revision_file_text_optional(
+                &SystemRunner,
+                gist_id,
+                parent,
+                filename,
+                owner_login,
+            )
+            .map_err(|e| e.to_string())?,
         )?,
         None => String::new(),
     };
@@ -78,7 +91,7 @@ pub(super) fn fetch_revision_pair(
     _new_label: &str,
 ) -> std::result::Result<(String, String), String> {
     let old_content = ensure_fetched_text(
-        crate::gh::fetch_revision_file_text(gist_id, version, filename, owner_login)
+        crate::gh::fetch_revision_file_text(&SystemRunner, gist_id, version, filename, owner_login)
             .map_err(|e| e.to_string())?,
     )?;
     let new_content = fetch_gist_content(gist_id, filename, raw_url)?;
@@ -90,7 +103,7 @@ pub(super) fn fetch_gist_content(
     filename: &str,
     raw_url: Option<&str>,
 ) -> std::result::Result<String, String> {
-    let content = crate::gh::fetch_gist_file_content(gist_id, filename, raw_url)
+    let content = crate::gh::fetch_gist_file_content(&SystemRunner, gist_id, filename, raw_url)
         .map_err(|e| e.to_string())?;
     crate::domain::ensure_text_size(content.len() as u64)?;
     Ok(content)
@@ -175,15 +188,16 @@ pub(super) fn spawn_update_check(
 pub(super) fn spawn_gist_fetch() -> std::sync::mpsc::Receiver<GistFetchResult> {
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
-        let result = if crate::gh::check_gh_ready().is_ok() {
+        let result = if crate::gh::check_gh_ready(&SystemRunner).is_ok() {
             // Owned list, starred list, and current-user login are independent network
             // legs — run them concurrently so large accounts don't pay three sequential
             // round-trips on cold start (issue #223). Soft-fail each leg independently
             // (`.ok()`), matching the previous sequential behaviour.
             let (owned, starred_raw, user_login) = std::thread::scope(|s| {
-                let owned_h = s.spawn(|| crate::gh::fetch_gist_list_json().ok());
-                let starred_h = s.spawn(|| crate::gh::fetch_gist_starred_list_json().ok());
-                let user_h = s.spawn(|| crate::gh::fetch_current_user_login().ok());
+                let owned_h = s.spawn(|| crate::gh::fetch_gist_list_json(&SystemRunner).ok());
+                let starred_h =
+                    s.spawn(|| crate::gh::fetch_gist_starred_list_json(&SystemRunner).ok());
+                let user_h = s.spawn(|| crate::gh::fetch_current_user_login(&SystemRunner).ok());
                 (
                     owned_h.join().unwrap_or(None),
                     starred_h.join().unwrap_or(None),
@@ -237,6 +251,7 @@ pub(super) fn spawn_fork_count_fetch(
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
         let counts = crate::gh::collect_gist_fork_counts(
+            &SystemRunner,
             owned_raw.as_deref(),
             starred_raw.as_deref(),
             gist_ids,
@@ -251,7 +266,7 @@ pub(super) fn spawn_star_count_fetch(
 ) -> std::sync::mpsc::Receiver<std::collections::HashMap<String, u32>> {
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
-        let counts = crate::gh::collect_gist_star_counts(node_ids);
+        let counts = crate::gh::collect_gist_star_counts(&SystemRunner, node_ids);
         let _ = tx.send(counts);
     });
     rx
@@ -262,7 +277,7 @@ pub(super) fn spawn_fork_metadata_fetch(
 ) -> std::sync::mpsc::Receiver<ForkMetaResult> {
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
-        let fork_of = crate::gh::collect_owned_fork_of_ids(owned_ids);
+        let fork_of = crate::gh::collect_owned_fork_of_ids(&SystemRunner, owned_ids);
         let _ = tx.send(fork_of);
     });
     rx
@@ -301,7 +316,8 @@ type ActionRx = Option<std::sync::mpsc::Receiver<(u64, ActionApply)>>;
 /// Initial newest-first comment load: probe the total, then fetch the newest page.
 /// Thin IO boundary (network) — not unit-tested.
 pub(super) fn load_initial_comments(gist_id: &str) -> Result<crate::tui::InitialComments, String> {
-    let probe = crate::gh::fetch_gist_comments_probe(gist_id).map_err(|e| e.to_string())?;
+    let probe =
+        crate::gh::fetch_gist_comments_probe(&SystemRunner, gist_id).map_err(|e| e.to_string())?;
     let total = crate::gh::comments_total_from_probe(&probe);
     if total == 0 {
         return Ok(crate::tui::InitialComments {
@@ -311,9 +327,13 @@ pub(super) fn load_initial_comments(gist_id: &str) -> Result<crate::tui::Initial
         });
     }
     let oldest_page = crate::gh::last_page(total, crate::gh::COMMENTS_PAGE_SIZE);
-    let raw =
-        crate::gh::fetch_gist_comments_page(gist_id, oldest_page, crate::gh::COMMENTS_PAGE_SIZE)
-            .map_err(|e| e.to_string())?;
+    let raw = crate::gh::fetch_gist_comments_page(
+        &SystemRunner,
+        gist_id,
+        oldest_page,
+        crate::gh::COMMENTS_PAGE_SIZE,
+    )
+    .map_err(|e| e.to_string())?;
     let comments = crate::gh::parse_gist_comments_json(&raw).map_err(|e| e.to_string())?;
     Ok(crate::tui::InitialComments {
         comments,

--- a/src/tui/dispatch.rs
+++ b/src/tui/dispatch.rs
@@ -4,6 +4,7 @@
 
 use super::bg::*;
 use super::*;
+use crate::actions::SystemRunner;
 use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io;
 
@@ -117,6 +118,7 @@ pub(super) fn dispatch_outcome(
                 "Loading older comments…",
                 move || {
                     let result = crate::gh::fetch_gist_comments_page(
+                        &SystemRunner,
                         &fetch_id,
                         page,
                         crate::gh::COMMENTS_PAGE_SIZE,

--- a/src/tui/screens/revisions.rs
+++ b/src/tui/screens/revisions.rs
@@ -1,6 +1,7 @@
 //! `Screen::Revisions` — key handling, view-model, paint, palette items, and apply handlers
 //! colocated in one file (issue #287, Phase 2; issue #383).
 
+use crate::actions::SystemRunner;
 use crate::tui::bg::{revision_version_label, Jobs, LoopFlow};
 use crate::tui::keys::{point_in, NavAction, PAGE_SCROLL};
 use crate::tui::render::list_pane::render_list_pane;
@@ -481,7 +482,7 @@ pub(crate) fn request_revisions(jobs: &mut Jobs, state: &mut AppState, gist_id: 
         state,
         "Loading revisions…",
         move || {
-            let result = crate::gh::fetch_gist_commits_json(&gist_id)
+            let result = crate::gh::fetch_gist_commits_json(&SystemRunner, &gist_id)
                 .map_err(|e| e.to_string())
                 .and_then(|raw| {
                     crate::gh::parse_gist_commits_json(&raw).map_err(|e| e.to_string())

--- a/tests/gh_integration.rs
+++ b/tests/gh_integration.rs
@@ -12,10 +12,9 @@ use std::path::PathBuf;
 use gistui::actions::{run_command, upload_command, CommandOutput, CommandPlan, CommandRunner};
 use gistui::domain::GistFile;
 use gistui::gh::{
-    auth_status_plan, check_gh_ready_with, fetch_gist_comments_page_with,
-    fetch_gist_file_content_with, fetch_gist_list_json_with, gh_version_plan,
-    gist_comments_page_plan, gist_list_plan, gist_view_plan, parse_gist_comments_json,
-    parse_gist_list_json,
+    auth_status_plan, check_gh_ready, fetch_gist_comments_page, fetch_gist_file_content,
+    fetch_gist_list_json, gh_version_plan, gist_comments_page_plan, gist_list_plan, gist_view_plan,
+    parse_gist_comments_json, parse_gist_list_json,
 };
 
 /// A scripted runner: returns queued outputs in order and records every plan it
@@ -68,7 +67,7 @@ const GIST_COMMENTS_JSON: &str = include_str!("fixtures/gh/gist-comments.json");
 fn fetch_and_parse_gist_list_via_fake_runner() {
     let runner = FakeRunner::new(vec![FakeRunner::ok(GIST_LIST_JSON)]);
 
-    let raw = fetch_gist_list_json_with(&runner).unwrap();
+    let raw = fetch_gist_list_json(&runner).unwrap();
     let files = parse_gist_list_json(&raw).unwrap();
 
     assert_eq!(files.len(), 3);
@@ -79,7 +78,7 @@ fn fetch_and_parse_gist_list_via_fake_runner() {
 fn fetch_gist_list_surfaces_stderr_on_failure() {
     let runner = FakeRunner::new(vec![FakeRunner::fail("HTTP 401: Bad credentials")]);
 
-    let err = fetch_gist_list_json_with(&runner).unwrap_err();
+    let err = fetch_gist_list_json(&runner).unwrap_err();
     assert!(err.to_string().contains("Bad credentials"));
 }
 
@@ -87,7 +86,7 @@ fn fetch_gist_list_surfaces_stderr_on_failure() {
 fn fetch_gist_file_content_returns_stdout_and_plans_view() {
     let runner = FakeRunner::new(vec![FakeRunner::ok("hello = true\n")]);
 
-    let content = fetch_gist_file_content_with(&runner, "abc123", "config.toml", None).unwrap();
+    let content = fetch_gist_file_content(&runner, "abc123", "config.toml", None).unwrap();
 
     assert_eq!(content, "hello = true\n");
     assert_eq!(
@@ -100,7 +99,7 @@ fn fetch_gist_file_content_returns_stdout_and_plans_view() {
 fn fetch_gist_file_content_surfaces_stderr_on_failure() {
     let runner = FakeRunner::new(vec![FakeRunner::fail("could not find gist")]);
 
-    let err = fetch_gist_file_content_with(&runner, "missing", "x", None).unwrap_err();
+    let err = fetch_gist_file_content(&runner, "missing", "x", None).unwrap_err();
     assert!(err.to_string().contains("could not find gist"));
 }
 
@@ -108,7 +107,7 @@ fn fetch_gist_file_content_surfaces_stderr_on_failure() {
 fn check_gh_ready_passes_when_version_and_auth_succeed() {
     let runner = FakeRunner::new(vec![FakeRunner::ok(""), FakeRunner::ok("")]);
 
-    assert!(check_gh_ready_with(&runner).is_ok());
+    assert!(check_gh_ready(&runner).is_ok());
 
     let calls = runner.calls.borrow();
     assert_eq!(calls[0], gh_version_plan());
@@ -119,7 +118,7 @@ fn check_gh_ready_passes_when_version_and_auth_succeed() {
 fn check_gh_ready_fails_when_gh_missing() {
     let runner = FakeRunner::new(vec![FakeRunner::fail("command not found")]);
 
-    let err = check_gh_ready_with(&runner).unwrap_err();
+    let err = check_gh_ready(&runner).unwrap_err();
     assert!(err.to_string().contains("did not run successfully"));
     // Auth is never probed once the version check fails.
     assert_eq!(runner.calls.borrow().len(), 1);
@@ -129,7 +128,7 @@ fn check_gh_ready_fails_when_gh_missing() {
 fn check_gh_ready_fails_when_unauthenticated() {
     let runner = FakeRunner::new(vec![FakeRunner::ok(""), FakeRunner::fail("not logged in")]);
 
-    let err = check_gh_ready_with(&runner).unwrap_err();
+    let err = check_gh_ready(&runner).unwrap_err();
     assert!(err.to_string().contains("gh auth login"));
 }
 
@@ -171,7 +170,7 @@ fn run_command_surfaces_stderr_on_failure() {
 fn fetch_and_parse_gist_comments_via_fake_runner() {
     let runner = FakeRunner::new(vec![FakeRunner::ok(GIST_COMMENTS_JSON)]);
 
-    let raw = fetch_gist_comments_page_with(&runner, "abc123", 1, 30).unwrap();
+    let raw = fetch_gist_comments_page(&runner, "abc123", 1, 30).unwrap();
     let comments = parse_gist_comments_json(&raw).unwrap();
 
     assert_eq!(comments.len(), 3);
@@ -191,7 +190,7 @@ fn fetch_and_parse_gist_comments_via_fake_runner() {
 fn fetch_gist_comments_surfaces_stderr_on_failure() {
     let runner = FakeRunner::new(vec![FakeRunner::fail("HTTP 404: Not Found")]);
 
-    let err = fetch_gist_comments_page_with(&runner, "missing", 1, 30).unwrap_err();
+    let err = fetch_gist_comments_page(&runner, "missing", 1, 30).unwrap_err();
     assert!(err.to_string().contains("Not Found"));
 }
 


### PR DESCRIPTION
Closes #386

Delete the 13 `SystemRunner` convenience wrappers and drop the `_with` suffix so every `src/gh` fetch/collect is `foo(runner, …)` with `CommandRunner` first. Production call sites pass `&SystemRunner`. There is no second door.

- The five `_with`-only entries are renamed too (`fetch_gist_revision_json`, `fetch_revision_file`, `fetch_gist_fork_count`, `fetch_forked_gist_ids_graphql`, `fetch_gist_fork_of_id`)
- `src/gh` no longer constructs `SystemRunner`
- Tests keep `SeqRunner` / FakeRunner on the same names
- Architecture safety-seam note updated (continues #245; no new ADR)

Out of scope (as specified): `actions::execute_command` and other write helpers, threading a runner through `Jobs`, `dispatch.rs` staging.