### PR TITLE
refactor(tui): stage dispatch work in screen modules

### DIFF
--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -38,6 +38,10 @@ Fields stay `pub`. No `#[serde(default)]` on the struct.
 handle_key (pure) → KeyOutcome → run_loop / dispatch_outcome (IO)
 ```
 
+Before a fetch/action is spawned, its owning screen's `stage_*` function performs any
+branching state work and returns the values dispatch needs. `dispatch_outcome` then only
+routes that payload to `Jobs`; it does not restage labels, return paths, caches, or loading flags.
+
 - New key logic → `AppState::handle_key` (testable).
 - New IO → `dispatch` / `bg` helpers, not `handle_key`.
 - IO-bearing `KeyOutcome` variants carry payloads (issue #244): `@src/tui/mod.rs` (`KeyOutcome`), `@src/tui/dispatch.rs`.

--- a/src/tui/bg.rs
+++ b/src/tui/bg.rs
@@ -374,10 +374,9 @@ pub(super) fn spawn_pin_push(
     let gist_id = m.gist_id.clone();
     let filename = m.gist_filename.clone();
     // Upload Confirm is opened when UploadPreview completes (staged return is Pins).
-    let raw_url = state.gist_file_raw_url(&gist_id, &filename);
-    let file = crate::domain::GistFileRef::new(gist_id, filename, raw_url);
-    let (local_label, gist_label) =
-        diff_labels(Some(&local_path), &state.gist_file_for_diff(&file));
+    let file = crate::domain::GistFileRef::id_name(gist_id, filename);
+    let (file, local_label, gist_label) =
+        screens::confirm::stage_upload_preview(state, local_path.clone(), file, true);
     jobs.spawn_gist_fetch_action(
         state,
         "Loading diff…",
@@ -406,9 +405,9 @@ pub(super) fn spawn_pin_pull(
     let target = pin_local_abs(state, m);
     let gist_id = m.gist_id.clone();
     let filename = m.gist_filename.clone();
-    let raw_url = state.gist_file_raw_url(&gist_id, &filename);
-    let file = crate::domain::GistFileRef::new(gist_id, filename, raw_url);
-    let (local_label, gist_label) = diff_labels(Some(&target), &state.gist_file_for_diff(&file));
+    let file = crate::domain::GistFileRef::id_name(gist_id, filename);
+    let (file, local_label, gist_label) =
+        screens::diff::stage_download_gist(state, target.clone(), file);
     jobs.spawn_gist_fetch_action(state, "Downloading…", file, move |result, file, state| {
         screens::diff::on_download_selected(state, result, target, local_label, gist_label, file)
     });
@@ -425,9 +424,9 @@ pub(super) fn spawn_pin_diff(
     let filename = m.gist_filename.clone();
     // Stage pin identity so enter_diff copies it onto DiffState (is_pin_diff_context).
     state.staged_diff_gist = Some((gist_id.clone(), filename.clone()));
-    let raw_url = state.gist_file_raw_url(&gist_id, &filename);
-    let file = crate::domain::GistFileRef::new(gist_id, filename, raw_url);
-    let (local_label, gist_label) = diff_labels(Some(&local_abs), &state.gist_file_for_diff(&file));
+    let file = crate::domain::GistFileRef::id_name(gist_id, filename);
+    let (file, local_label, gist_label) =
+        screens::diff::stage_preview_diff(state, Some(local_abs.clone()), file, None);
     let target = local_abs.clone();
     jobs.spawn_gist_fetch_action(
         state,

--- a/src/tui/dispatch.rs
+++ b/src/tui/dispatch.rs
@@ -22,10 +22,12 @@ pub(super) fn dispatch_outcome(
             target,
             upload_orientation,
         } => {
-            // List-originated diff returns to List on Esc.
-            state.pending_return = Some(Screen::List);
-            let gist = state.gist_file_for_diff(&file);
-            let (local_label, gist_label) = diff_labels(local_path.as_deref(), &gist);
+            let (file, local_label, gist_label) = screens::diff::stage_preview_diff(
+                state,
+                local_path.clone(),
+                file,
+                Some(Screen::List),
+            );
 
             jobs.spawn_gist_fetch_action(
                 state,
@@ -53,8 +55,8 @@ pub(super) fn dispatch_outcome(
             }
         }
         KeyOutcome::DownloadGist { file, target } => {
-            let gist = state.gist_file_for_diff(&file);
-            let (local_label, gist_label) = diff_labels(Some(&target), &gist);
+            let (file, local_label, gist_label) =
+                screens::diff::stage_download_gist(state, target.clone(), file);
 
             jobs.spawn_gist_fetch_action(
                 state,
@@ -83,16 +85,9 @@ pub(super) fn dispatch_outcome(
             state.reset_comment_pagination();
         }
         KeyOutcome::FetchComments { gist_id } => {
-            if state
-                .detail()
-                .is_some_and(|d| d.comments.is_some() || d.comments_loading)
-            {
+            let Some(fetch_id) = screens::detail::stage_fetch_comments(state, gist_id) else {
                 return Ok(LoopFlow::Proceed);
-            }
-            if let Some(d) = state.detail_mut() {
-                d.comments_loading = true;
-            }
-            let fetch_id = gist_id.clone();
+            };
             jobs.spawn_action(
                 state,
                 "Loading comments…",
@@ -106,13 +101,10 @@ pub(super) fn dispatch_outcome(
             );
         }
         KeyOutcome::LoadOlderComments { gist_id, page } => {
-            if page == 0 || !state.can_load_older_comments() {
+            let Some(fetch_id) = screens::detail::stage_load_older_comments(state, gist_id, page)
+            else {
                 return Ok(LoopFlow::Proceed);
-            }
-            if let Some(d) = state.detail_mut() {
-                d.comments_loading_more = true;
-            }
-            let fetch_id = gist_id.clone();
+            };
             jobs.spawn_action(
                 state,
                 "Loading older comments…",
@@ -198,16 +190,12 @@ pub(super) fn dispatch_outcome(
             file,
             from_pin_diff,
         } => {
-            if !from_pin_diff {
-                state.pending_return = Some(Screen::List);
-            }
-            let gist_file = state.gist_file_for_diff(&file);
-            let (local_label, gist_label) = diff_labels(Some(&local_path), &gist_file);
-            // Prefer list-row raw_url when present (may be richer than the outcome's ref).
-            let mut file = file;
-            if file.raw_url.is_none() {
-                file.raw_url = gist_file.raw_url.clone();
-            }
+            let (file, local_label, gist_label) = screens::confirm::stage_upload_preview(
+                state,
+                local_path.clone(),
+                file,
+                from_pin_diff,
+            );
 
             jobs.spawn_gist_fetch_action(
                 state,
@@ -299,16 +287,10 @@ pub(super) fn dispatch_outcome(
                 },
             );
         }
-        KeyOutcome::PreviewContent { mut file } => {
-            let key = file.cache_key();
-            if let Some(content) = state.gist_content_cache.get(&key).cloned() {
-                let preview_title = state.preview_title(&file.gist_id, &file.filename);
-                state.enter_preview(preview_title, content, Some(key));
-            } else {
-                if file.raw_url.is_none() {
-                    file.raw_url = state.gist_file_raw_url(&file.gist_id, &file.filename);
-                }
-                let preview_title = state.preview_title(&file.gist_id, &file.filename);
+        KeyOutcome::PreviewContent { file } => {
+            if let Some((file, preview_title)) =
+                screens::preview::stage_preview_content(state, file)
+            {
                 jobs.spawn_gist_fetch_action(
                     state,
                     "Loading preview…",
@@ -319,16 +301,8 @@ pub(super) fn dispatch_outcome(
                 );
             }
         }
-        KeyOutcome::RefreshPreview { mut file } => {
-            // Keep the current return path when reloading.
-            if state.screen.is_preview() {
-                state.pending_return = state.nav_stack.last().cloned();
-            }
-            state.gist_content_cache.remove(&file.cache_key());
-            if file.raw_url.is_none() {
-                file.raw_url = state.gist_file_raw_url(&file.gist_id, &file.filename);
-            }
-            let preview_title = state.preview_title(&file.gist_id, &file.filename);
+        KeyOutcome::RefreshPreview { file } => {
+            let (file, preview_title) = screens::preview::stage_refresh_preview(state, file);
             jobs.spawn_gist_fetch_action(
                 state,
                 "Loading preview…",

--- a/src/tui/screens/confirm.rs
+++ b/src/tui/screens/confirm.rs
@@ -18,6 +18,24 @@ pub(crate) fn wheel_step() -> usize {
     3
 }
 
+/// Stage an upload preview before dispatch fetches the current gist content.
+pub(crate) fn stage_upload_preview(
+    state: &mut AppState,
+    local_path: PathBuf,
+    mut file: crate::domain::GistFileRef,
+    from_pin_diff: bool,
+) -> (crate::domain::GistFileRef, String, String) {
+    if !from_pin_diff {
+        state.pending_return = Some(Screen::List);
+    }
+    let gist_file = state.gist_file_for_diff(&file);
+    let (local_label, gist_label) = crate::tui::render::diff_labels(Some(&local_path), &gist_file);
+    if file.raw_url.is_none() {
+        file.raw_url = gist_file.raw_url;
+    }
+    (file, local_label, gist_label)
+}
+
 impl AppState {
     pub(crate) fn handle_key_confirm(&mut self, code: KeyCode) -> KeyOutcome {
         // While typing the create flow's description, arrows drive the text cursor (handled
@@ -359,6 +377,21 @@ mod tests {
     use crate::tui::*;
     use crossterm::event::KeyCode;
     use std::path::PathBuf;
+
+    #[test]
+    fn stage_upload_preview_sets_list_return_and_falls_back_to_list_raw_url() {
+        let mut state = state_with_gists();
+        state.gists[0].raw_url = Some("https://example.test/a.txt".into());
+        let file = gist_file_ref("g1", "a.txt");
+
+        let (file, local_label, gist_label) =
+            stage_upload_preview(&mut state, PathBuf::from("/tmp/a.txt"), file, false);
+
+        assert!(matches!(state.pending_return, Some(Screen::List)));
+        assert_eq!(file.raw_url.as_deref(), Some("https://example.test/a.txt"));
+        assert!(local_label.starts_with("local: a.txt"));
+        assert!(gist_label.starts_with("gist g1 / a.txt"));
+    }
 
     fn upload_pending(gist_id: &str, filename: &str) -> PendingAction {
         PendingAction::Upload {

--- a/src/tui/screens/detail.rs
+++ b/src/tui/screens/detail.rs
@@ -77,6 +77,31 @@ pub struct InitialComments {
     pub oldest_page: u32,
 }
 
+/// Stage the initial comments fetch, skipping work already represented by detail state.
+pub(crate) fn stage_fetch_comments(state: &mut AppState, gist_id: String) -> Option<String> {
+    if state
+        .detail()
+        .is_some_and(|d| d.comments.is_some() || d.comments_loading)
+    {
+        return None;
+    }
+    state.detail_mut().map(|d| d.comments_loading = true)?;
+    Some(gist_id)
+}
+
+/// Stage an older-comments fetch only when a prior page remains available.
+pub(crate) fn stage_load_older_comments(
+    state: &mut AppState,
+    gist_id: String,
+    page: u32,
+) -> Option<String> {
+    if page == 0 || !state.can_load_older_comments() {
+        return None;
+    }
+    state.detail_mut().map(|d| d.comments_loading_more = true)?;
+    Some(gist_id)
+}
+
 impl AppState {
     pub(crate) fn handle_key_detail(&mut self, code: KeyCode) -> KeyOutcome {
         self.status = None;
@@ -981,6 +1006,43 @@ mod tests {
     use crate::tui::test_support::{detail_mut, state_with_gists, state_with_two_gists};
     use crate::tui::*;
     use crossterm::event::KeyCode;
+
+    #[test]
+    fn stage_fetch_comments_skips_loaded_or_loading_and_marks_a_new_load() {
+        let mut state = state_with_gists();
+        detail_mut(&mut state).comments_loading = true;
+        assert!(stage_fetch_comments(&mut state, "g1".into()).is_none());
+
+        detail_mut(&mut state).comments_loading = false;
+        assert_eq!(
+            stage_fetch_comments(&mut state, "g1".into()).as_deref(),
+            Some("g1")
+        );
+        assert!(detail_ref(&state).comments_loading);
+
+        let detail = detail_mut(&mut state);
+        detail.comments_loading = false;
+        detail.comments = Some(vec![]);
+        assert!(stage_fetch_comments(&mut state, "g1".into()).is_none());
+    }
+
+    #[test]
+    fn stage_load_older_comments_skips_invalid_page_and_marks_valid_load() {
+        let mut state = state_with_gists();
+        let detail = detail_mut(&mut state);
+        detail.comments = Some(vec![]);
+        detail.comments_loaded_oldest_page = 2;
+
+        assert!(stage_load_older_comments(&mut state, "g1".into(), 0).is_none());
+        detail_mut(&mut state).comments_loaded_oldest_page = 1;
+        assert!(stage_load_older_comments(&mut state, "g1".into(), 1).is_none());
+        detail_mut(&mut state).comments_loaded_oldest_page = 2;
+        assert_eq!(
+            stage_load_older_comments(&mut state, "g1".into(), 1).as_deref(),
+            Some("g1")
+        );
+        assert!(detail_ref(&state).comments_loading_more);
+    }
 
     fn detail_ref(state: &AppState) -> &DetailState {
         state.detail().expect("expected Screen::GistDetail")

--- a/src/tui/screens/diff.rs
+++ b/src/tui/screens/diff.rs
@@ -2,7 +2,7 @@
 //! colocated in one file (issue #287, Phase 2; issue #383).
 
 use crate::tui::bg::{record_pin_sync, refresh_locals, LocalScanMode, LoopFlow};
-use crate::tui::render::preview_diff_text;
+use crate::tui::render::{diff_labels, preview_diff_text};
 use crate::tui::view_model::{ChromeVm, DiffVm};
 use crate::tui::{AppState, HelpTopic, KeyOutcome, PendingAction};
 use crossterm::event::KeyCode;
@@ -20,6 +20,41 @@ pub(crate) fn help_topic() -> HelpTopic {
 
 pub(crate) fn wheel_step() -> usize {
     3
+}
+
+/// Stage a gist-vs-local diff before dispatch starts its fetch.
+pub(crate) fn stage_preview_diff(
+    state: &mut AppState,
+    local_path: Option<PathBuf>,
+    file: crate::domain::GistFileRef,
+    pending_return: Option<crate::tui::Screen>,
+) -> (crate::domain::GistFileRef, String, String) {
+    if let Some(screen) = pending_return {
+        state.pending_return = Some(screen);
+    }
+    stage_gist_diff_fetch(state, local_path.as_deref(), file)
+}
+
+/// Stage labels for downloading a gist file before dispatch starts its fetch.
+pub(crate) fn stage_download_gist(
+    state: &mut AppState,
+    target: PathBuf,
+    file: crate::domain::GistFileRef,
+) -> (crate::domain::GistFileRef, String, String) {
+    stage_gist_diff_fetch(state, Some(&target), file)
+}
+
+fn stage_gist_diff_fetch(
+    state: &AppState,
+    local_path: Option<&std::path::Path>,
+    mut file: crate::domain::GistFileRef,
+) -> (crate::domain::GistFileRef, String, String) {
+    let gist = state.gist_file_for_diff(&file);
+    if file.raw_url.is_none() {
+        file.raw_url = gist.raw_url.clone();
+    }
+    let (local_label, gist_label) = diff_labels(local_path, &gist);
+    (file, local_label, gist_label)
 }
 
 /// Shared "would this key actually do something" predicate for `Screen::Diff`, mirrored by
@@ -390,10 +425,41 @@ fn set_diff_identical(state: &mut AppState, identical: bool) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tui::test_support::{gist_file_ref, set_diff_body, set_diff_scroll, set_pending};
+    use crate::tui::test_support::{
+        gist_file_ref, set_diff_body, set_diff_scroll, set_pending, state_with_gists,
+    };
     use crate::tui::*;
     use crossterm::event::KeyCode;
     use std::path::PathBuf;
+
+    #[test]
+    fn stage_preview_diff_sets_list_return_and_labels() {
+        let mut state = state_with_gists();
+        let file = gist_file_ref("g1", "a.txt");
+
+        let (_, local_label, gist_label) = stage_preview_diff(
+            &mut state,
+            Some(PathBuf::from("/tmp/a.txt")),
+            file,
+            Some(Screen::List),
+        );
+
+        assert!(matches!(state.pending_return, Some(Screen::List)));
+        assert!(local_label.starts_with("local: a.txt"));
+        assert!(gist_label.starts_with("gist g1 / a.txt"));
+    }
+
+    #[test]
+    fn stage_download_gist_builds_labels() {
+        let mut state = state_with_gists();
+        let file = gist_file_ref("g1", "a.txt");
+
+        let (_, local_label, gist_label) =
+            stage_download_gist(&mut state, PathBuf::from("/tmp/a.txt"), file);
+
+        assert!(local_label.starts_with("local: a.txt"));
+        assert!(gist_label.starts_with("gist g1 / a.txt"));
+    }
 
     #[test]
     fn diff_w_toggles_wrap_and_resets_hscroll() {

--- a/src/tui/screens/preview.rs
+++ b/src/tui/screens/preview.rs
@@ -22,6 +22,40 @@ pub(crate) fn wheel_step() -> usize {
     3
 }
 
+/// Stage a content preview. A cache hit enters Preview immediately; a miss returns fetch data.
+pub(crate) fn stage_preview_content(
+    state: &mut AppState,
+    mut file: crate::domain::GistFileRef,
+) -> Option<(crate::domain::GistFileRef, String)> {
+    let key = file.cache_key();
+    if let Some(content) = state.gist_content_cache.get(&key).cloned() {
+        let title = state.preview_title(&file.gist_id, &file.filename);
+        state.enter_preview(title, content, Some(key));
+        return None;
+    }
+    if file.raw_url.is_none() {
+        file.raw_url = state.gist_file_raw_url(&file.gist_id, &file.filename);
+    }
+    let title = state.preview_title(&file.gist_id, &file.filename);
+    Some((file, title))
+}
+
+/// Restage the return path and invalidate cached content before refetching a preview.
+pub(crate) fn stage_refresh_preview(
+    state: &mut AppState,
+    mut file: crate::domain::GistFileRef,
+) -> (crate::domain::GistFileRef, String) {
+    if state.screen.is_preview() {
+        state.pending_return = state.nav_stack.last().cloned();
+    }
+    state.gist_content_cache.remove(&file.cache_key());
+    if file.raw_url.is_none() {
+        file.raw_url = state.gist_file_raw_url(&file.gist_id, &file.filename);
+    }
+    let title = state.preview_title(&file.gist_id, &file.filename);
+    (file, title)
+}
+
 impl AppState {
     pub(crate) fn handle_key_preview(&mut self, code: KeyCode) -> KeyOutcome {
         // One-shot: any key dismisses a lingering status (e.g. a previous "fetch failed: …"); the
@@ -207,6 +241,49 @@ mod tests {
     use crate::tui::test_support::{gist_file_ref, state_with_gists};
     use crate::tui::*;
     use crossterm::event::KeyCode;
+
+    #[test]
+    fn stage_preview_content_cache_hit_enters_preview_without_spawn_payload() {
+        let mut state = state_with_gists();
+        let file = gist_file_ref("g1", "a.txt");
+        state
+            .gist_content_cache
+            .insert(file.cache_key(), "cached".into());
+
+        assert!(stage_preview_content(&mut state, file).is_none());
+
+        assert_eq!(state.preview().expect("preview").body.text, "cached");
+    }
+
+    #[test]
+    fn stage_preview_content_miss_falls_back_to_raw_url_and_returns_title() {
+        let mut state = state_with_gists();
+        state.gists[0].raw_url = Some("https://example.test/a.txt".into());
+
+        let (file, title) =
+            stage_preview_content(&mut state, gist_file_ref("g1", "a.txt")).expect("spawn");
+
+        assert_eq!(file.raw_url.as_deref(), Some("https://example.test/a.txt"));
+        assert!(title.contains("a.txt"));
+    }
+
+    #[test]
+    fn stage_refresh_preview_restages_return_drops_cache_and_returns_fetch_payload() {
+        let mut state = state_with_gists();
+        state.gists[0].raw_url = Some("https://example.test/a.txt".into());
+        let file = gist_file_ref("g1", "a.txt");
+        state
+            .gist_content_cache
+            .insert(file.cache_key(), "cached".into());
+        state.enter_preview("a.txt".into(), "cached".into(), Some(file.cache_key()));
+
+        let (file, title) = stage_refresh_preview(&mut state, file);
+
+        assert!(matches!(state.pending_return, Some(Screen::Gists(_))));
+        assert!(state.gist_content_cache.get(&file.cache_key()).is_none());
+        assert_eq!(file.raw_url.as_deref(), Some("https://example.test/a.txt"));
+        assert!(title.contains("a.txt"));
+    }
 
     #[test]
     fn preview_w_toggles_line_wrapping() {


### PR DESCRIPTION
## Summary
- move branching dispatch staging into owning screen modules
- reuse screen staging from pin fetch helpers
- cover staging branches with screen-local unit tests

## Verification
- mise run check

Closes #387