### PR TITLE
refactor(tui): deepen async screen transitions

### DIFF
--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -29,7 +29,12 @@ Fields stay `pub`. No `#[serde(default)]` on the struct.
 - Other variants (`Diff`, `Confirm`, `Preview`, `Help`, `Config`, `Revisions`, `Pins`, `Gists`, `GistDetail`, `Palette`, …) carry payloads (body/scroll/return/origin as needed).
 - **Diff/Confirm/Preview body+scroll** is `ScrollBody` (`@src/tui/scroll.rs`, issue #385), reached only via `scroll_body` / `scroll_body_mut`. The ten `diff_body_text` / `scroll_diff_*` methods are gone. Their `screens::lookup` rows share `scroll_navigation`; Help and Detail comments have no `ScrollBody`.
 - **`nav_stack`** (issue #271) holds return targets; Esc pops. Prefer stack ops over parallel “return” root fields for new navigation.
-- Staged root fields (`diff_return` / `preview_return` / `staged_diff_gist` and similar) are consumed on enter only when still present.
+- **Async screen entry is a moved value, not root staging.** `DeferredEntry` snapshots the
+  return screen at intent time and moves through `KeyOutcome` and the job apply closure.
+  Success consumes it through `open_deferred`; failure, cancellation, and generation
+  supersession drop it without touching navigation. Preview refresh captures the current
+  parent through `defer_replacement`, so refresh replaces Preview instead of stacking it.
+  Diff Gist identity is built directly into `DiffState`; do not add another staging field.
 - **`back_to_list()` is a hard reset** (clears `nav_stack`) — reserve it for paths whose only possible origin is `Screen::List` itself. Confirm-execute paths with more than one possible origin (e.g. `ExecuteDelete`, `ExecuteCompactGist` in `dispatch.rs`) use `leave()`/`cancel_confirm()` instead, to return to whichever screen actually launched them; pop an extra time if the popped screen is now stale (e.g. `GistDetail` for a gist just deleted).
 
 ## Key path (pure intent → impure dispatch)

--- a/src/tui/bg.rs
+++ b/src/tui/bg.rs
@@ -351,32 +351,21 @@ pub(super) fn pin_local_abs(state: &AppState, m: &crate::domain::PinnedMapping) 
     }
 }
 
-/// Stage the current Pins payload as `pending_return` so the pin diff/confirm entered once this
-/// (async) flow's background fetch lands restores list state, not wherever the user has since
-/// navigated to.
-pub(super) fn park_pins_on_diff_return(state: &mut AppState) {
-    let pins = match &state.screen {
-        Screen::Pins(p) => p.as_ref().clone(),
-        _ => state.pins().cloned().unwrap_or_default(),
-    };
-    state.pending_return = Some(Screen::Pins(Box::new(pins)));
-}
-
 /// Spawn the push (upload local → gist) flow for a pin: lands in the existing
 /// upload `Screen::Confirm` diff.
 pub(super) fn spawn_pin_push(
     state: &mut AppState,
     jobs: &mut Jobs,
     m: &crate::domain::PinnedMapping,
+    entry: crate::tui::DeferredEntry,
 ) {
-    park_pins_on_diff_return(state);
     let local_path = pin_local_abs(state, m);
     let gist_id = m.gist_id.clone();
     let filename = m.gist_filename.clone();
-    // Upload Confirm is opened when UploadPreview completes (staged return is Pins).
+    // Upload Confirm returns to the screen captured by `entry`.
     let file = crate::domain::GistFileRef::id_name(gist_id, filename);
     let (file, local_label, gist_label) =
-        screens::confirm::stage_upload_preview(state, local_path.clone(), file, true);
+        screens::confirm::stage_upload_preview(state, local_path.clone(), file);
     jobs.spawn_gist_fetch_action(
         state,
         "Loading diff…",
@@ -384,6 +373,7 @@ pub(super) fn spawn_pin_push(
         move |result, file, state| {
             screens::confirm::on_upload_preview(
                 state,
+                entry,
                 result,
                 file,
                 local_path,
@@ -400,8 +390,8 @@ pub(super) fn spawn_pin_pull(
     state: &mut AppState,
     jobs: &mut Jobs,
     m: &crate::domain::PinnedMapping,
+    entry: crate::tui::DeferredEntry,
 ) {
-    park_pins_on_diff_return(state);
     let target = pin_local_abs(state, m);
     let gist_id = m.gist_id.clone();
     let filename = m.gist_filename.clone();
@@ -409,7 +399,15 @@ pub(super) fn spawn_pin_pull(
     let (file, local_label, gist_label) =
         screens::diff::stage_download_gist(state, target.clone(), file);
     jobs.spawn_gist_fetch_action(state, "Downloading…", file, move |result, file, state| {
-        screens::diff::on_download_selected(state, result, target, local_label, gist_label, file)
+        screens::diff::on_download_selected(
+            state,
+            entry,
+            result,
+            target,
+            local_label,
+            gist_label,
+            file,
+        )
     });
 }
 
@@ -418,15 +416,15 @@ pub(super) fn spawn_pin_diff(
     state: &mut AppState,
     jobs: &mut Jobs,
     m: &crate::domain::PinnedMapping,
+    entry: crate::tui::DeferredEntry,
 ) {
     let local_abs = pin_local_abs(state, m);
     let gist_id = m.gist_id.clone();
     let filename = m.gist_filename.clone();
-    // Stage pin identity so enter_diff copies it onto DiffState (is_pin_diff_context).
-    state.staged_diff_gist = Some((gist_id.clone(), filename.clone()));
     let file = crate::domain::GistFileRef::id_name(gist_id, filename);
+    let gist_file = file.clone();
     let (file, local_label, gist_label) =
-        screens::diff::stage_preview_diff(state, Some(local_abs.clone()), file, None);
+        screens::diff::stage_preview_diff(state, Some(local_abs.clone()), file);
     let target = local_abs.clone();
     jobs.spawn_gist_fetch_action(
         state,
@@ -437,12 +435,14 @@ pub(super) fn spawn_pin_diff(
             // historical download orientation (old = local, new = gist).
             screens::diff::on_preview_diff(
                 state,
+                entry,
                 result,
                 Some(local_abs),
                 local_label,
                 gist_label,
                 target,
                 false,
+                Some(gist_file),
             )
         },
     );
@@ -838,8 +838,6 @@ pub(super) fn download(state: &mut AppState, mode: crate::actions::DownloadMode)
                     Some(crate::domain::SyncDirection::Download),
                 );
             }
-            // Diff pairing identity lives on the payload; leaving drops it.
-            state.staged_diff_gist = None;
             // Skip past the download overwrite gate's Confirm (if any) and its parked Diff to
             // land on whatever was behind them.
             if state.screen.is_confirm() {

--- a/src/tui/dispatch.rs
+++ b/src/tui/dispatch.rs
@@ -17,17 +17,14 @@ pub(super) fn dispatch_outcome(
     match outcome {
         KeyOutcome::Quit => return Ok(LoopFlow::Quit),
         KeyOutcome::PreviewDiff {
+            entry,
             local_path,
             file,
             target,
             upload_orientation,
         } => {
-            let (file, local_label, gist_label) = screens::diff::stage_preview_diff(
-                state,
-                local_path.clone(),
-                file,
-                Some(Screen::List),
-            );
+            let (file, local_label, gist_label) =
+                screens::diff::stage_preview_diff(state, local_path.clone(), file);
 
             jobs.spawn_gist_fetch_action(
                 state,
@@ -36,12 +33,14 @@ pub(super) fn dispatch_outcome(
                 move |result, _file, state| {
                     screens::diff::on_preview_diff(
                         state,
+                        entry,
                         result,
                         local_path,
                         local_label,
                         gist_label,
                         target,
                         upload_orientation,
+                        None,
                     )
                 },
             );
@@ -54,7 +53,11 @@ pub(super) fn dispatch_outcome(
                 download(state, crate::actions::DownloadMode::CreateNew);
             }
         }
-        KeyOutcome::DownloadGist { file, target } => {
+        KeyOutcome::DownloadGist {
+            entry,
+            file,
+            target,
+        } => {
             let (file, local_label, gist_label) =
                 screens::diff::stage_download_gist(state, target.clone(), file);
 
@@ -65,6 +68,7 @@ pub(super) fn dispatch_outcome(
                 move |result, file, state| {
                     screens::diff::on_download_selected(
                         state,
+                        entry,
                         result,
                         target,
                         local_label,
@@ -126,7 +130,11 @@ pub(super) fn dispatch_outcome(
                 },
             );
         }
-        KeyOutcome::CompactGist { gist_id, label } => {
+        KeyOutcome::CompactGist {
+            entry,
+            gist_id,
+            label,
+        } => {
             jobs.spawn_action(
                 state,
                 "Checking revisions…",
@@ -142,7 +150,7 @@ pub(super) fn dispatch_outcome(
                     (result, gist_id, label)
                 },
                 move |(result, gist_id, label), state| {
-                    screens::confirm::on_compact_analyze(state, result, gist_id, label)
+                    screens::confirm::on_compact_analyze(state, entry, result, gist_id, label)
                 },
             );
         }
@@ -161,9 +169,6 @@ pub(super) fn dispatch_outcome(
             gist_id,
             filename,
         } => {
-            if !state.is_pin_diff_context() {
-                state.pending_return = Some(Screen::List);
-            }
             let action = PendingAction::Upload {
                 gist_id,
                 filename: filename.clone(),
@@ -186,16 +191,12 @@ pub(super) fn dispatch_outcome(
             }
         }
         KeyOutcome::UploadPreview {
+            entry,
             local_path,
             file,
-            from_pin_diff,
         } => {
-            let (file, local_label, gist_label) = screens::confirm::stage_upload_preview(
-                state,
-                local_path.clone(),
-                file,
-                from_pin_diff,
-            );
+            let (file, local_label, gist_label) =
+                screens::confirm::stage_upload_preview(state, local_path.clone(), file);
 
             jobs.spawn_gist_fetch_action(
                 state,
@@ -204,6 +205,7 @@ pub(super) fn dispatch_outcome(
                 move |result, file, state| {
                     screens::confirm::on_upload_preview(
                         state,
+                        entry,
                         result,
                         file,
                         local_path,
@@ -249,7 +251,6 @@ pub(super) fn dispatch_outcome(
                 crate::actions::upload_add_command(&temp_file_path, &file.gist_id)
             };
 
-            state.staged_diff_gist = None;
             state.leave();
             jobs.spawn_action(
                 state,
@@ -287,7 +288,7 @@ pub(super) fn dispatch_outcome(
                 },
             );
         }
-        KeyOutcome::PreviewContent { file } => {
+        KeyOutcome::PreviewContent { entry, file } => {
             if let Some((file, preview_title)) =
                 screens::preview::stage_preview_content(state, file)
             {
@@ -296,19 +297,25 @@ pub(super) fn dispatch_outcome(
                     "Loading preview…",
                     file,
                     move |result, file, state| {
-                        screens::preview::on_preview_content(state, result, file, preview_title)
+                        screens::preview::on_preview_content(
+                            state,
+                            entry,
+                            result,
+                            file,
+                            preview_title,
+                        )
                     },
                 );
             }
         }
-        KeyOutcome::RefreshPreview { file } => {
+        KeyOutcome::RefreshPreview { entry, file } => {
             let (file, preview_title) = screens::preview::stage_refresh_preview(state, file);
             jobs.spawn_gist_fetch_action(
                 state,
                 "Loading preview…",
                 file,
                 move |result, file, state| {
-                    screens::preview::on_preview_content(state, result, file, preview_title)
+                    screens::preview::on_preview_content(state, entry, result, file, preview_title)
                 },
             );
         }
@@ -403,6 +410,7 @@ pub(super) fn dispatch_outcome(
         }
         KeyOutcome::UnpinAtPin { index } => unpin_at_pin_index(state, index),
         KeyOutcome::SyncSelectedPair {
+            entry,
             local_path,
             gist_id,
             filename,
@@ -419,29 +427,28 @@ pub(super) fn dispatch_outcome(
             };
             let m = state.pinned[idx].clone();
             let status = state.compute_pin_sync_status(idx);
-            apply_sync_status(state, jobs, &m, status);
+            apply_sync_status(state, jobs, &m, status, entry);
         }
-        KeyOutcome::SyncPinPush { index } => {
+        KeyOutcome::SyncPinPush { entry, index } => {
             if let Some(m) = state.pinned.get(index).cloned() {
-                spawn_pin_push(state, jobs, &m);
+                spawn_pin_push(state, jobs, &m, entry);
             }
         }
-        KeyOutcome::SyncPinPull { index } => {
+        KeyOutcome::SyncPinPull { entry, index } => {
             if let Some(m) = state.pinned.get(index).cloned() {
-                spawn_pin_pull(state, jobs, &m);
+                spawn_pin_pull(state, jobs, &m, entry);
             }
         }
-        KeyOutcome::SyncPinAuto { index } => {
+        KeyOutcome::SyncPinAuto { entry, index } => {
             let Some(m) = state.pinned.get(index).cloned() else {
                 return Ok(LoopFlow::Proceed);
             };
             let status = state.compute_pin_sync_status(index);
-            apply_sync_status(state, jobs, &m, status);
+            apply_sync_status(state, jobs, &m, status, entry);
         }
-        KeyOutcome::PreviewPinDiff { index } => {
+        KeyOutcome::PreviewPinDiff { entry, index } => {
             if let Some(m) = state.pinned.get(index).cloned() {
-                park_pins_on_diff_return(state);
-                spawn_pin_diff(state, jobs, &m);
+                spawn_pin_diff(state, jobs, &m, entry);
             }
         }
         KeyOutcome::PersistDiffContext => persist_diff_context(state),
@@ -454,6 +461,7 @@ pub(super) fn dispatch_outcome(
             screens::revisions::request_revisions(jobs, state, gist_id);
         }
         KeyOutcome::RevisionDiffIncremental {
+            entry,
             gist_id,
             filename,
             child_version,
@@ -475,11 +483,12 @@ pub(super) fn dispatch_outcome(
                     )
                 },
                 move |result, state| {
-                    screens::diff::on_revision_diff(state, result, old_label, new_label)
+                    screens::diff::on_revision_diff(state, entry, result, old_label, new_label)
                 },
             );
         }
         KeyOutcome::RevisionDiff {
+            entry,
             gist_id,
             filename,
             version,
@@ -504,11 +513,12 @@ pub(super) fn dispatch_outcome(
                     (result, old_label, new_label)
                 },
                 move |(result, old_label, new_label), state| {
-                    screens::diff::on_revision_diff(state, result, old_label, new_label)
+                    screens::diff::on_revision_diff(state, entry, result, old_label, new_label)
                 },
             );
         }
         KeyOutcome::RestoreRevisionPreview {
+            entry,
             gist_id,
             filename,
             version,
@@ -532,6 +542,7 @@ pub(super) fn dispatch_outcome(
                 move |(result, gist_id, filename, version), state| {
                     screens::confirm::on_restore_revision_ready(
                         state,
+                        entry,
                         result,
                         gist_id,
                         filename,
@@ -634,10 +645,11 @@ fn apply_sync_status(
     jobs: &mut Jobs,
     m: &crate::domain::PinnedMapping,
     status: crate::domain::SyncStatus,
+    entry: DeferredEntry,
 ) {
     match status {
-        crate::domain::SyncStatus::Push => spawn_pin_push(state, jobs, m),
-        crate::domain::SyncStatus::Pull => spawn_pin_pull(state, jobs, m),
+        crate::domain::SyncStatus::Push => spawn_pin_push(state, jobs, m, entry),
+        crate::domain::SyncStatus::Pull => spawn_pin_pull(state, jobs, m, entry),
         crate::domain::SyncStatus::InSync => state.set_status("already in sync"),
         crate::domain::SyncStatus::Missing => {
             state.set_status("local file is missing — use d to pull it back")

--- a/src/tui/gist_mutation.rs
+++ b/src/tui/gist_mutation.rs
@@ -45,7 +45,6 @@ pub(crate) fn on_upload_replace(
         }
         // Return to wherever this upload was initiated from (List, or Pins
         // for a pin push) instead of always snapping to List.
-        state.staged_diff_gist = None;
         state.leave();
         format!("Uploaded {} to gist {}", file.filename, file.gist_id)
     })

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -461,12 +461,13 @@ impl GistTypeFilter {
 /// Pure key/mouse intent returned by [`AppState::handle_key`]. IO-bearing variants carry
 /// the snapshot needed to execute so dispatch does not re-resolve selection (issue #244).
 /// Not `Copy` — payloads own small strings/paths.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum KeyOutcome {
     None,
     Quit,
     /// List-originated local↔gist diff.
     PreviewDiff {
+        entry: DeferredEntry,
         local_path: Option<PathBuf>,
         file: GistFileRef,
         target: PathBuf,
@@ -486,6 +487,7 @@ pub enum KeyOutcome {
     },
     /// Download/fetch a selected gist file (may land on Diff/Confirm).
     DownloadGist {
+        entry: DeferredEntry,
         file: GistFileRef,
         target: PathBuf,
     },
@@ -505,15 +507,15 @@ pub enum KeyOutcome {
         filename: String,
     },
     UploadPreview {
+        entry: DeferredEntry,
         local_path: PathBuf,
         file: GistFileRef,
-        /// When true, keep pin-originated `diff_return`; when false, reset to List.
-        from_pin_diff: bool,
     },
     /// Confirm-owned upload execute.
     Upload,
     Create(bool),
     PreviewContent {
+        entry: DeferredEntry,
         file: GistFileRef,
     },
     OpenBrowser {
@@ -536,6 +538,7 @@ pub enum KeyOutcome {
         page: u32,
     },
     CompactGist {
+        entry: DeferredEntry,
         gist_id: String,
         label: String,
     },
@@ -549,26 +552,32 @@ pub enum KeyOutcome {
         url: String,
     },
     RefreshPreview {
+        entry: DeferredEntry,
         file: GistFileRef,
     },
     UnpinAtPin {
         index: usize,
     },
     SyncPinAuto {
+        entry: DeferredEntry,
         index: usize,
     },
     SyncPinPush {
+        entry: DeferredEntry,
         index: usize,
     },
     SyncPinPull {
+        entry: DeferredEntry,
         index: usize,
     },
     SyncSelectedPair {
+        entry: DeferredEntry,
         local_path: PathBuf,
         gist_id: String,
         filename: String,
     },
     PreviewPinDiff {
+        entry: DeferredEntry,
         index: usize,
     },
     PersistDiffContext,
@@ -582,6 +591,7 @@ pub enum KeyOutcome {
         gist_id: String,
     },
     RevisionDiffIncremental {
+        entry: DeferredEntry,
         gist_id: String,
         filename: String,
         child_version: String,
@@ -591,6 +601,7 @@ pub enum KeyOutcome {
         owner_login: String,
     },
     RevisionDiff {
+        entry: DeferredEntry,
         gist_id: String,
         filename: String,
         version: String,
@@ -600,6 +611,7 @@ pub enum KeyOutcome {
         owner_login: String,
     },
     RestoreRevisionPreview {
+        entry: DeferredEntry,
         gist_id: String,
         filename: String,
         version: String,
@@ -616,6 +628,18 @@ pub enum KeyOutcome {
     ForkGist {
         gist_id: String,
     },
+}
+
+/// One-shot return path for a screen opened by background work.
+///
+/// Moving this value through the job closure keeps the transition's origin attached to the
+/// work that captured it. Dropping a failed, cancelled, or superseded job leaves navigation
+/// untouched.
+#[must_use]
+#[derive(Debug, PartialEq, Eq)]
+pub struct DeferredEntry {
+    return_to: Screen,
+    replaces_current: bool,
 }
 
 /// A clickable list pane recorded by `render` for the current frame.
@@ -988,18 +1012,10 @@ pub struct AppState {
     /// other key clears it. Prevents an accidental single-key exit.
     pub quit_armed: bool,
     pub upload: UploadState,
-    /// Staged pin/pull gist identity for the next [`Self::enter_diff`] (consumed into
-    /// [`DiffState`]). Live identity while Diff/Confirm is open lives on the payload.
-    pub staged_diff_gist: Option<(String, String)>,
     /// Navigation history (issue #271): every [`Self::enter`] pushes the screen being left;
     /// every [`Self::leave`] pops back to it. Flat — a screen's own return path never lives on
     /// its payload.
     pub nav_stack: Vec<Screen>,
-    /// Staged return target for a screen entered asynchronously (issue #271): set at the
-    /// triggering keypress (before the background fetch that will eventually call
-    /// [`Self::enter`] completes), since `self.screen` may have changed by the time that
-    /// happens. [`Self::enter`] consumes it in place of the live screen when present.
-    pub pending_return: Option<Screen>,
     /// Monotonic tick advanced once per event-loop iteration (~150ms); drives the in-progress
     /// spinner animation. Wraps freely — only its value modulo the frame count is observed.
     pub spinner_frame: usize,
@@ -1150,15 +1166,41 @@ impl AppState {
         preview, preview_mut, is_preview, PreviewState, preview_state, preview_state_mut
     }
 
-    /// Navigate to `new_screen`, remembering how to get back (issue #271). The screen being
-    /// left is pushed onto [`Self::nav_stack`] — or, if a [`Self::pending_return`] was staged
-    /// (an async entry: the triggering keypress ran before `self.screen` necessarily still
-    /// matched what the user meant), that staged screen is pushed instead and the live one is
-    /// discarded.
+    /// Navigate to `new_screen`, remembering how to get back (issue #271).
     pub fn enter(&mut self, new_screen: Screen) {
         let live = std::mem::replace(&mut self.screen, new_screen);
-        let prev = self.pending_return.take().unwrap_or(live);
-        self.nav_stack.push(prev);
+        self.nav_stack.push(live);
+    }
+
+    /// Capture the current screen as the return path for background work.
+    pub(crate) fn defer_entry(&self) -> DeferredEntry {
+        DeferredEntry {
+            return_to: self.screen.clone(),
+            replaces_current: false,
+        }
+    }
+
+    /// Capture the current screen's parent so an async refresh replaces, rather than stacks,
+    /// the live screen.
+    pub(crate) fn defer_replacement(&self) -> Option<DeferredEntry> {
+        self.nav_stack
+            .last()
+            .cloned()
+            .map(|return_to| DeferredEntry {
+                return_to,
+                replaces_current: true,
+            })
+    }
+
+    /// Complete a deferred transition atomically. The live screen at completion is discarded;
+    /// Back returns to the screen captured when the work started.
+    pub(crate) fn open_deferred(&mut self, entry: DeferredEntry, new_screen: Screen) {
+        self.status = None;
+        self.screen = new_screen;
+        if entry.replaces_current {
+            self.nav_stack.pop();
+        }
+        self.nav_stack.push(entry.return_to);
     }
 
     /// Leave the current screen, restoring whatever [`Self::enter`] pushed for it. Falls back
@@ -1221,8 +1263,7 @@ impl AppState {
         }
     }
 
-    /// Open Confirm with background `text`. Cancel path is whatever [`Self::enter`] captures —
-    /// the staged [`Self::pending_return`] if this follows an async fetch, else the live screen.
+    /// Open Confirm with background `text`.
     pub fn enter_confirm(&mut self, action: PendingAction, text: String) {
         self.status = None;
         self.enter(Screen::Confirm(Box::new(ConfirmState {
@@ -1242,8 +1283,7 @@ impl AppState {
         self.status = None;
         let body = d.body.clone();
         // Park full Diff (pairing + identity) so cancel/download IO still have it; not a
-        // `pending_return` case (synchronous — `d` came straight off `self.screen`), so push it
-        // directly rather than going through `enter()`.
+        // This synchronous path parks Diff directly rather than going through `enter()`.
         self.nav_stack.push(Screen::Diff(d));
         self.screen = Screen::Confirm(Box::new(ConfirmState { action, body }));
     }
@@ -1905,9 +1945,9 @@ impl AppState {
                 .any(|g| g.gist_id == gist_id && g.filename == local_filename);
             return if has_same_name {
                 KeyOutcome::UploadPreview {
+                    entry: self.defer_entry(),
                     local_path,
                     file: GistFileRef::new(gist_id, local_filename, raw_url),
-                    from_pin_diff: true,
                 }
             } else {
                 KeyOutcome::UploadAdd {
@@ -1939,9 +1979,9 @@ impl AppState {
             .any(|g| g.gist_id == gist_id && g.filename == local_filename);
         if has_same_name {
             KeyOutcome::UploadPreview {
+                entry: self.defer_entry(),
                 local_path,
                 file: GistFileRef::new(gist_id, local_filename, raw_url),
-                from_pin_diff: false,
             }
         } else {
             KeyOutcome::UploadAdd {
@@ -2013,10 +2053,6 @@ impl AppState {
         local: PathBuf,
         target: PathBuf,
     ) {
-        let (gist_id, gist_filename) = match self.staged_diff_gist.take() {
-            Some((id, name)) => (Some(id), Some(name)),
-            None => (None, None),
-        };
         self.status = None;
         self.enter(Screen::Diff(Box::new(DiffState {
             body: ScrollBody {
@@ -2027,8 +2063,8 @@ impl AppState {
             local_path: local,
             download_target: target,
             identical: false,
-            gist_id,
-            gist_filename,
+            gist_id: None,
+            gist_filename: None,
         })));
     }
 
@@ -2068,9 +2104,6 @@ impl AppState {
 
     pub fn back_to_list(&mut self) {
         self.screen = Screen::List;
-        // Diff pairing identity lives on the payload; leaving drops it.
-        self.staged_diff_gist = None;
-        self.pending_return = None;
         // A hard reset, not a `leave()` — nothing on the stack corresponds to List, so discard
         // it rather than let stale entries resurface on some later, unrelated `leave()`.
         self.nav_stack.clear();
@@ -2157,9 +2190,7 @@ pub fn initial_state() -> AppState {
         bg_task_generation: 0,
         quit_armed: false,
         upload: UploadState::default(),
-        staged_diff_gist: None,
         nav_stack: Vec::new(),
-        pending_return: None,
         spinner_frame: 0,
         gist_comment_counts: std::collections::HashMap::new(),
         gist_fork_counts: std::collections::HashMap::new(),
@@ -2529,6 +2560,46 @@ mod tests {
         // Exactly at the boundary: still counts as a double-click (inclusive `<=`).
         let r = super::classify_click(Some((5, 5)), super::DOUBLE_CLICK_MS, 5, 5);
         assert_eq!(r, MouseInput::DoubleClick { col: 5, row: 5 });
+    }
+
+    #[test]
+    fn deferred_entry_returns_to_the_screen_captured_before_work_started() {
+        let mut state = initial_state();
+        state.screen = Screen::Gists(Box::default());
+        let entry = state.defer_entry();
+        state.screen = Screen::Help(Box::default());
+
+        state.open_deferred(entry, Screen::Preview(Box::default()));
+        state.leave();
+
+        assert!(state.screen.is_gists());
+        assert!(state.nav_stack.is_empty());
+    }
+
+    #[test]
+    fn dropping_deferred_entry_does_not_touch_navigation() {
+        let mut state = initial_state();
+        state.screen = Screen::Gists(Box::default());
+        let entry = state.defer_entry();
+
+        drop(entry);
+
+        assert!(state.screen.is_gists());
+        assert!(state.nav_stack.is_empty());
+    }
+
+    #[test]
+    fn deferred_replacement_keeps_the_current_screens_parent() {
+        let mut state = initial_state();
+        state.screen = Screen::Gists(Box::default());
+        state.enter(Screen::Preview(Box::default()));
+        let entry = state.defer_replacement().unwrap();
+
+        state.open_deferred(entry, Screen::Preview(Box::default()));
+        state.leave();
+
+        assert!(state.screen.is_gists());
+        assert!(state.nav_stack.is_empty());
     }
 
     #[test]

--- a/src/tui/screens/confirm.rs
+++ b/src/tui/screens/confirm.rs
@@ -23,11 +23,7 @@ pub(crate) fn stage_upload_preview(
     state: &mut AppState,
     local_path: PathBuf,
     mut file: crate::domain::GistFileRef,
-    from_pin_diff: bool,
 ) -> (crate::domain::GistFileRef, String, String) {
-    if !from_pin_diff {
-        state.pending_return = Some(Screen::List);
-    }
     let gist_file = state.gist_file_for_diff(&file);
     let (local_label, gist_label) = crate::tui::render::diff_labels(Some(&local_path), &gist_file);
     if file.raw_url.is_none() {
@@ -254,6 +250,7 @@ pub(crate) fn render_confirm_vm(
 /// local-vs-gist diff.
 pub(crate) fn on_upload_preview(
     state: &mut AppState,
+    entry: crate::tui::DeferredEntry,
     result: std::result::Result<String, String>,
     file: crate::domain::GistFileRef,
     local_path: PathBuf,
@@ -262,7 +259,6 @@ pub(crate) fn on_upload_preview(
 ) -> LoopFlow {
     match result {
         Ok(remote) => {
-            // Keep staged pin/list return; enter_confirm consumes it.
             let action = PendingAction::Upload {
                 gist_id: file.gist_id,
                 filename: file.filename,
@@ -273,7 +269,13 @@ pub(crate) fn on_upload_preview(
                     // init_upload_state writes via update_upload_diff only when
                     // Confirm is already open; open Confirm first with empty
                     // body, then rebuild the upload diff into the payload.
-                    state.enter_confirm(action, String::new());
+                    state.open_deferred(
+                        entry,
+                        Screen::Confirm(Box::new(crate::tui::ConfirmState {
+                            action,
+                            body: crate::tui::ScrollBody::default(),
+                        })),
+                    );
                     state.update_upload_diff();
                 }
                 Err(error) => {
@@ -294,6 +296,7 @@ pub(crate) fn on_upload_preview(
 /// the Confirm warning before compacting.
 pub(crate) fn on_compact_analyze(
     state: &mut AppState,
+    entry: crate::tui::DeferredEntry,
     result: std::result::Result<usize, String>,
     gist_id: String,
     label: String,
@@ -303,18 +306,22 @@ pub(crate) fn on_compact_analyze(
             "\"{label}\" already has a single revision — nothing to compact"
         )),
         Ok(count) => {
-            // `pending_return` was staged at the 'c' keypress (keys.rs); `enter`
-            // (inside `enter_confirm`) consumes it as the Confirm cancel path.
-            state.enter_confirm(
-                PendingAction::CompactGist {
+            state.open_deferred(
+                entry,
+                Screen::Confirm(Box::new(crate::tui::ConfirmState {
+                    action: PendingAction::CompactGist {
                     gist_id: gist_id.clone(),
                     label: label.clone(),
                     count,
-                },
-                format!(
-                    "Compact gist {gist_id} (\"{label}\").\n\nIt has {count} revisions. Compacting clones it to a temp dir, squashes the history to a single commit, and force-pushes — the {} older revisions are gone for good.",
-                    count - 1
-                ),
+                    },
+                    body: crate::tui::ScrollBody {
+                        text: format!(
+                            "Compact gist {gist_id} (\"{label}\").\n\nIt has {count} revisions. Compacting clones it to a temp dir, squashes the history to a single commit, and force-pushes — the {} older revisions are gone for good.",
+                            count - 1
+                        ),
+                        ..crate::tui::ScrollBody::default()
+                    },
+                })),
             );
         }
         Err(error) => state.set_status(format!("revision check failed: {error}")),
@@ -327,6 +334,7 @@ pub(crate) fn on_compact_analyze(
 /// content matches current (nothing to restore).
 pub(crate) fn on_restore_revision_ready(
     state: &mut AppState,
+    entry: crate::tui::DeferredEntry,
     result: std::result::Result<(String, String), String>,
     gist_id: String,
     filename: String,
@@ -348,17 +356,21 @@ pub(crate) fn on_restore_revision_ready(
                 &current_content,
                 state.ignore_trailing_newline,
             );
-            // `enter_confirm` (via `enter`) parks the live Revisions screen so
-            // cancel restores cursor/entries.
-            state.enter_confirm(
-                PendingAction::RestoreRevision {
-                    gist_id,
-                    filename,
-                    version,
-                    version_label,
-                    content: revision_content,
-                },
-                diff,
+            state.open_deferred(
+                entry,
+                Screen::Confirm(Box::new(crate::tui::ConfirmState {
+                    action: PendingAction::RestoreRevision {
+                        gist_id,
+                        filename,
+                        version,
+                        version_label,
+                        content: revision_content,
+                    },
+                    body: crate::tui::ScrollBody {
+                        text: diff,
+                        ..crate::tui::ScrollBody::default()
+                    },
+                })),
             );
         }
         Err(error) => state.set_status(error),
@@ -379,15 +391,14 @@ mod tests {
     use std::path::PathBuf;
 
     #[test]
-    fn stage_upload_preview_sets_list_return_and_falls_back_to_list_raw_url() {
+    fn stage_upload_preview_falls_back_to_list_raw_url() {
         let mut state = state_with_gists();
         state.gists[0].raw_url = Some("https://example.test/a.txt".into());
         let file = gist_file_ref("g1", "a.txt");
 
         let (file, local_label, gist_label) =
-            stage_upload_preview(&mut state, PathBuf::from("/tmp/a.txt"), file, false);
+            stage_upload_preview(&mut state, PathBuf::from("/tmp/a.txt"), file);
 
-        assert!(matches!(state.pending_return, Some(Screen::List)));
         assert_eq!(file.raw_url.as_deref(), Some("https://example.test/a.txt"));
         assert!(local_label.starts_with("local: a.txt"));
         assert!(gist_label.starts_with("gist g1 / a.txt"));
@@ -877,6 +888,7 @@ mod tests {
 
         on_upload_preview(
             &mut state,
+            initial_state().defer_entry(),
             Err("boom".into()),
             gist_file_ref("g1", "a.txt"),
             PathBuf::from("a.txt"),
@@ -896,6 +908,7 @@ mod tests {
 
         on_upload_preview(
             &mut state,
+            initial_state().defer_entry(),
             Ok("remote body".into()),
             gist_file_ref("g1", "a.txt"),
             local_path.clone(),
@@ -915,7 +928,8 @@ mod tests {
     fn on_compact_analyze_single_revision_sets_status() {
         let mut state = initial_state();
 
-        on_compact_analyze(&mut state, Ok(1), "g1".into(), "demo".into());
+        let entry = state.defer_entry();
+        on_compact_analyze(&mut state, entry, Ok(1), "g1".into(), "demo".into());
 
         assert_eq!(
             state.status.as_deref(),
@@ -927,7 +941,8 @@ mod tests {
     fn on_compact_analyze_multi_revision_enters_confirm() {
         let mut state = initial_state();
 
-        on_compact_analyze(&mut state, Ok(4), "g1".into(), "demo".into());
+        let entry = state.defer_entry();
+        on_compact_analyze(&mut state, entry, Ok(4), "g1".into(), "demo".into());
 
         assert!(matches!(
             state.pending_action(),
@@ -940,7 +955,14 @@ mod tests {
     fn on_compact_analyze_err_sets_status() {
         let mut state = initial_state();
 
-        on_compact_analyze(&mut state, Err("boom".into()), "g1".into(), "demo".into());
+        let entry = state.defer_entry();
+        on_compact_analyze(
+            &mut state,
+            entry,
+            Err("boom".into()),
+            "g1".into(),
+            "demo".into(),
+        );
 
         assert_eq!(state.status.as_deref(), Some("revision check failed: boom"));
     }
@@ -951,6 +973,7 @@ mod tests {
 
         let flow = on_restore_revision_ready(
             &mut state,
+            initial_state().defer_entry(),
             Ok(("same".into(), "same".into())),
             "g1".into(),
             "a.txt".into(),
@@ -971,6 +994,7 @@ mod tests {
 
         let flow = on_restore_revision_ready(
             &mut state,
+            initial_state().defer_entry(),
             Ok(("old".into(), "new".into())),
             "g1".into(),
             "a.txt".into(),
@@ -992,6 +1016,7 @@ mod tests {
 
         on_restore_revision_ready(
             &mut state,
+            initial_state().defer_entry(),
             Err("boom".into()),
             "g1".into(),
             "a.txt".into(),

--- a/src/tui/screens/detail.rs
+++ b/src/tui/screens/detail.rs
@@ -8,7 +8,7 @@ use crate::tui::text::comment_lines_count;
 use crate::tui::view_model::{
     ChromeVm, CommentLineVm, CommentsAffordance, CommentsPaneVm, GistDetailVm,
 };
-use crate::tui::{AppState, DetailFocus, HelpTopic, KeyOutcome, MouseLayout, PaneHit, Screen};
+use crate::tui::{AppState, DetailFocus, HelpTopic, KeyOutcome, MouseLayout, PaneHit};
 
 pub(crate) const HELP_TOPIC: HelpTopic = HelpTopic::GistDetail;
 
@@ -166,7 +166,6 @@ impl AppState {
                 let Some(id) = self.detail().and_then(|d| d.gist_id.clone()) else {
                     return KeyOutcome::None;
                 };
-                self.pending_return = Some(self.park_gist_detail_screen());
                 let label = self
                     .group_by_id(&id)
                     .map(|g| {
@@ -177,7 +176,11 @@ impl AppState {
                         }
                     })
                     .unwrap_or_else(|| id.clone());
-                return KeyOutcome::CompactGist { gist_id: id, label };
+                return KeyOutcome::CompactGist {
+                    entry: self.defer_entry(),
+                    gist_id: id,
+                    label,
+                };
             }
             // Not gated through `detail_guard`: `star_toggle_intent`/`fork_intent` already have
             // their own complete messages for the disabled cases ("select a gist first",
@@ -235,8 +238,8 @@ impl AppState {
                 if let Some(gist_id) = self.detail().and_then(|d| d.gist_id.clone()) {
                     let cursor = self.detail().map(|d| d.file_cursor).unwrap_or(0);
                     if let Some(filename) = self.gist_filenames(&gist_id).into_iter().nth(cursor) {
-                        self.pending_return = Some(self.park_gist_detail_screen());
                         return KeyOutcome::PreviewContent {
+                            entry: self.defer_entry(),
                             file: crate::domain::GistFileRef::id_name(gist_id, filename),
                         };
                     }
@@ -280,22 +283,13 @@ impl AppState {
                 if self.block_if_non_previewable_gist_file(&gist_id, &filename) {
                     return KeyOutcome::None;
                 }
-                self.pending_return = Some(self.park_gist_detail_screen());
                 return KeyOutcome::PreviewContent {
+                    entry: self.defer_entry(),
                     file: crate::domain::GistFileRef::id_name(gist_id, filename),
                 };
             }
         }
         KeyOutcome::None
-    }
-
-    /// Snapshot the live GistDetail payload as a `Screen`, to stage into
-    /// [`AppState::pending_return`] before an async fetch (preview/revisions/compact) that will
-    /// eventually call [`AppState::enter`] once its result lands. Every caller is itself part of
-    /// GistDetail's own key handling, so `self.screen` is always `Screen::GistDetail` here.
-    fn park_gist_detail_screen(&self) -> Screen {
-        debug_assert!(self.screen.is_gist_detail());
-        self.screen.clone()
     }
 
     /// Arrow / hjkl / page-key navigation for `Screen::GistDetail`: moves within the focused
@@ -1140,10 +1134,10 @@ mod tests {
                 ..
             } if f.gist_id == "g1" && f.filename == "f9.txt"
         ));
-        assert!(state
-            .pending_return
-            .as_ref()
-            .is_some_and(Screen::is_gist_detail));
+        let KeyOutcome::PreviewContent { entry, .. } = outcome else {
+            unreachable!();
+        };
+        assert!(entry.return_to.is_gist_detail());
     }
 
     #[test]
@@ -1175,10 +1169,10 @@ mod tests {
         detail_mut(&mut state).gist_id = Some("g1".into());
         let outcome = state.handle_key(KeyCode::Char('c'));
         assert!(matches!(outcome, KeyOutcome::CompactGist { .. }));
-        assert!(state
-            .pending_return
-            .as_ref()
-            .is_some_and(Screen::is_gist_detail));
+        let KeyOutcome::CompactGist { entry, .. } = outcome else {
+            unreachable!();
+        };
+        assert!(entry.return_to.is_gist_detail());
     }
 
     #[test]
@@ -1194,10 +1188,10 @@ mod tests {
                 ..
             } if f.gist_id == "g1" && f.filename == "a.txt"
         ));
-        assert!(state
-            .pending_return
-            .as_ref()
-            .is_some_and(Screen::is_gist_detail));
+        let KeyOutcome::PreviewContent { entry, .. } = outcome else {
+            unreachable!();
+        };
+        assert!(entry.return_to.is_gist_detail());
     }
 
     #[test]

--- a/src/tui/screens/diff.rs
+++ b/src/tui/screens/diff.rs
@@ -27,11 +27,7 @@ pub(crate) fn stage_preview_diff(
     state: &mut AppState,
     local_path: Option<PathBuf>,
     file: crate::domain::GistFileRef,
-    pending_return: Option<crate::tui::Screen>,
 ) -> (crate::domain::GistFileRef, String, String) {
-    if let Some(screen) = pending_return {
-        state.pending_return = Some(screen);
-    }
     stage_gist_diff_fetch(state, local_path.as_deref(), file)
 }
 
@@ -74,7 +70,6 @@ impl AppState {
             KeyCode::Char('q') | KeyCode::Esc => {
                 // Diff pairing identity lives on the payload; leaving drops it (not a full
                 // `back_to_list()` — that would also discard the rest of `nav_stack`).
-                self.staged_diff_gist = None;
                 self.leave();
             }
             // Identical files have nothing to sync, so download/upload are not offered.
@@ -257,12 +252,14 @@ pub(crate) fn render_diff_vm(
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn on_preview_diff(
     state: &mut AppState,
+    entry: crate::tui::DeferredEntry,
     result: std::result::Result<String, String>,
     local_path: Option<PathBuf>,
     local_label: String,
     gist_label: String,
     target: PathBuf,
     upload_orientation: bool,
+    gist_file: Option<crate::domain::GistFileRef>,
 ) -> LoopFlow {
     match result {
         Ok(remote) => {
@@ -286,8 +283,21 @@ pub(crate) fn on_preview_diff(
                         &remote,
                         state.ignore_trailing_newline,
                     );
-                    state.enter_diff(diff, remote, local_path.unwrap_or_default(), target);
-                    set_diff_identical(state, identical);
+                    state.open_deferred(
+                        entry,
+                        crate::tui::Screen::Diff(Box::new(crate::tui::DiffState {
+                            body: crate::tui::ScrollBody {
+                                text: diff,
+                                ..crate::tui::ScrollBody::default()
+                            },
+                            remote_content: remote,
+                            local_path: local_path.unwrap_or_default(),
+                            download_target: target,
+                            identical,
+                            gist_id: gist_file.as_ref().map(|file| file.gist_id.clone()),
+                            gist_filename: gist_file.map(|file| file.filename),
+                        })),
+                    );
                     // A pin diff that turns out identical confirms the cached
                     // last_seen_hash is (still) accurate — refresh it for free
                     // using the content we already fetched, so the Pins list's
@@ -321,6 +331,7 @@ pub(crate) fn on_preview_diff(
 /// `DownloadSelected` outcome: diff against an existing local file, or write a new one.
 pub(crate) fn on_download_selected(
     state: &mut AppState,
+    entry: crate::tui::DeferredEntry,
     result: std::result::Result<String, String>,
     target: PathBuf,
     local_label: String,
@@ -344,10 +355,21 @@ pub(crate) fn on_download_selected(
                             &remote,
                             state.ignore_trailing_newline,
                         );
-                        state.staged_diff_gist =
-                            Some((file.gist_id.clone(), file.filename.clone()));
-                        state.enter_diff(diff, remote, target.clone(), target);
-                        set_diff_identical(state, identical);
+                        state.open_deferred(
+                            entry,
+                            crate::tui::Screen::Diff(Box::new(crate::tui::DiffState {
+                                body: crate::tui::ScrollBody {
+                                    text: diff,
+                                    ..crate::tui::ScrollBody::default()
+                                },
+                                remote_content: remote,
+                                local_path: target.clone(),
+                                download_target: target,
+                                identical,
+                                gist_id: Some(file.gist_id),
+                                gist_filename: Some(file.filename),
+                            })),
+                        );
                     }
                     Err(error) => state.set_status(error),
                 }
@@ -388,6 +410,7 @@ pub(crate) fn on_download_selected(
 /// `RevisionDiff` outcome: diff two historical revisions of the same file.
 pub(crate) fn on_revision_diff(
     state: &mut AppState,
+    entry: crate::tui::DeferredEntry,
     result: std::result::Result<(String, String), String>,
     old_label: String,
     new_label: String,
@@ -404,22 +427,22 @@ pub(crate) fn on_revision_diff(
             let identical = old_content == new_content;
             // `enter_diff` (via `enter`) parks the live Revisions screen so Esc
             // restores list cursor/entries.
-            state.enter_diff(diff, String::new(), PathBuf::new(), PathBuf::new());
-            set_diff_identical(state, identical);
+            state.open_deferred(
+                entry,
+                crate::tui::Screen::Diff(Box::new(crate::tui::DiffState {
+                    body: crate::tui::ScrollBody {
+                        text: diff,
+                        ..crate::tui::ScrollBody::default()
+                    },
+                    identical,
+                    ..crate::tui::DiffState::default()
+                })),
+            );
         }
         Err(error) => state.set_status(error),
     }
 
     LoopFlow::Proceed
-}
-
-/// Set `state`'s diff-payload `identical` flag, if a diff payload is currently open. Shared by
-/// the three action outcomes that build a diff and check content identity byte-for-byte:
-/// [`on_preview_diff`], [`on_download_selected`], [`on_revision_diff`].
-fn set_diff_identical(state: &mut AppState, identical: bool) {
-    if let Some(d) = state.diff_mut() {
-        d.identical = identical;
-    }
 }
 
 #[cfg(test)]
@@ -433,18 +456,13 @@ mod tests {
     use std::path::PathBuf;
 
     #[test]
-    fn stage_preview_diff_sets_list_return_and_labels() {
+    fn stage_preview_diff_builds_labels() {
         let mut state = state_with_gists();
         let file = gist_file_ref("g1", "a.txt");
 
-        let (_, local_label, gist_label) = stage_preview_diff(
-            &mut state,
-            Some(PathBuf::from("/tmp/a.txt")),
-            file,
-            Some(Screen::List),
-        );
+        let (_, local_label, gist_label) =
+            stage_preview_diff(&mut state, Some(PathBuf::from("/tmp/a.txt")), file);
 
-        assert!(matches!(state.pending_return, Some(Screen::List)));
         assert!(local_label.starts_with("local: a.txt"));
         assert!(gist_label.starts_with("gist g1 / a.txt"));
     }
@@ -689,12 +707,14 @@ mod tests {
 
         on_preview_diff(
             &mut state,
+            initial_state().defer_entry(),
             Err("boom".into()),
             None,
             "local".into(),
             "gist".into(),
             PathBuf::from("target"),
             false,
+            None,
         );
 
         assert_eq!(state.status.as_deref(), Some("fetch failed: boom"));
@@ -706,12 +726,14 @@ mod tests {
 
         on_preview_diff(
             &mut state,
+            initial_state().defer_entry(),
             Ok("remote body".into()),
             None,
             "local".into(),
             "gist".into(),
             PathBuf::from("target"),
             false,
+            None,
         );
 
         let diff = state.diff().expect("expected Screen::Diff");
@@ -725,6 +747,7 @@ mod tests {
 
         on_download_selected(
             &mut state,
+            initial_state().defer_entry(),
             Err("boom".into()),
             PathBuf::from("target"),
             "local".into(),
@@ -744,6 +767,7 @@ mod tests {
 
         on_download_selected(
             &mut state,
+            initial_state().defer_entry(),
             Ok("remote body".into()),
             target.clone(),
             "local".into(),
@@ -753,10 +777,8 @@ mod tests {
 
         let diff = state.diff().expect("expected Screen::Diff");
         assert_eq!(diff.remote_content, "remote body");
-        // `enter_diff` takes `staged_diff_gist` and moves it onto the `DiffState` itself.
         assert_eq!(diff.gist_id.as_deref(), Some("g1"));
         assert_eq!(diff.gist_filename.as_deref(), Some("a.txt"));
-        assert!(state.staged_diff_gist.is_none());
     }
 
     #[test]
@@ -765,6 +787,7 @@ mod tests {
 
         on_revision_diff(
             &mut state,
+            initial_state().defer_entry(),
             Ok(("old body".into(), "new body".into())),
             "old".into(),
             "new".into(),
@@ -778,7 +801,13 @@ mod tests {
     fn on_revision_diff_err_sets_status() {
         let mut state = initial_state();
 
-        on_revision_diff(&mut state, Err("boom".into()), "old".into(), "new".into());
+        on_revision_diff(
+            &mut state,
+            initial_state().defer_entry(),
+            Err("boom".into()),
+            "old".into(),
+            "new".into(),
+        );
 
         assert_eq!(state.status.as_deref(), Some("boom"));
     }

--- a/src/tui/screens/gists.rs
+++ b/src/tui/screens/gists.rs
@@ -325,8 +325,7 @@ mod tests {
     #[test]
     fn compact_confirm_y_executes_and_n_returns_to_gist_manager() {
         let mut state = state_with_two_gists();
-        // CompactAnalyze parks the restore target before Confirm opens (staged pending_return).
-        state.pending_return = Some(Screen::Gists(Box::default()));
+        state.screen = Screen::Gists(Box::default());
         set_pending(
             &mut state,
             PendingAction::CompactGist {
@@ -341,7 +340,7 @@ mod tests {
         );
 
         // Re-open confirm for the cancel path (y does not leave Confirm until IO runs).
-        state.pending_return = Some(Screen::Gists(Box::default()));
+        state.screen = Screen::Gists(Box::default());
         set_pending(
             &mut state,
             PendingAction::CompactGist {

--- a/src/tui/screens/list.rs
+++ b/src/tui/screens/list.rs
@@ -249,6 +249,7 @@ impl AppState {
                     return KeyOutcome::None;
                 };
                 return KeyOutcome::SyncSelectedPair {
+                    entry: self.defer_entry(),
                     local_path: local.path.clone(),
                     gist_id: gist.file.gist_id.clone(),
                     filename: gist.file.filename.clone(),
@@ -281,8 +282,8 @@ impl AppState {
                 let Some(gist) = ranked.get(self.gist_index) else {
                     return KeyOutcome::None;
                 };
-                self.pending_return = Some(Screen::List);
                 return KeyOutcome::PreviewContent {
+                    entry: self.defer_entry(),
                     file: crate::domain::GistFileRef::new(
                         gist.file.gist_id.clone(),
                         gist.file.filename.clone(),
@@ -307,6 +308,7 @@ impl AppState {
                 if let Some(gist) = ranked.get(self.gist_index) {
                     let filename = gist.file.filename.clone();
                     return KeyOutcome::DownloadGist {
+                        entry: self.defer_entry(),
                         file: crate::domain::GistFileRef::new(
                             gist.file.gist_id.clone(),
                             filename.clone(),
@@ -334,6 +336,7 @@ impl AppState {
                     .unwrap_or(&self.cwd)
                     .join(&filename);
                 return KeyOutcome::PreviewDiff {
+                    entry: self.defer_entry(),
                     local_path,
                     file: crate::domain::GistFileRef::new(
                         gist.file.gist_id.clone(),
@@ -446,7 +449,6 @@ impl AppState {
         } else {
             gist.file.description.clone()
         };
-        self.pending_return = Some(Screen::List);
         let text = format!(
             "Remove file \"{filename}\" from gist {gist_id} ({label}).\n\nThe other files in this gist are kept. This cannot be undone."
         );
@@ -470,7 +472,6 @@ impl AppState {
         };
         self.editing_description = true;
         self.description_input.clear();
-        self.pending_return = Some(Screen::List);
         self.enter_confirm(
             PendingAction::Create {
                 local_path: local.path.clone(),
@@ -2085,10 +2086,11 @@ mod tests {
             modified: None,
         }];
         state.gists = vec![GistFile::fixture("g1", "a.txt")];
-        assert!(matches!(
-            state.handle_key(KeyCode::Char('S')),
-            KeyOutcome::SyncSelectedPair { .. }
-        ));
+        let KeyOutcome::SyncSelectedPair { entry, .. } = state.handle_key(KeyCode::Char('S'))
+        else {
+            panic!("expected deferred pair sync");
+        };
+        assert!(matches!(entry.return_to, Screen::List));
     }
 
     #[test]

--- a/src/tui/screens/pins.rs
+++ b/src/tui/screens/pins.rs
@@ -78,7 +78,10 @@ impl AppState {
                 let Some(index) = self.selected_pin_index() else {
                     return KeyOutcome::None;
                 };
-                return KeyOutcome::PreviewPinDiff { index };
+                return KeyOutcome::PreviewPinDiff {
+                    entry: self.defer_entry(),
+                    index,
+                };
             }
             KeyCode::Char('x') if pins_guard(self, code) => {
                 let Some(index) = self.selected_pin_index() else {
@@ -90,19 +93,28 @@ impl AppState {
                 let Some(index) = self.selected_pin_index() else {
                     return KeyOutcome::None;
                 };
-                return KeyOutcome::SyncPinAuto { index };
+                return KeyOutcome::SyncPinAuto {
+                    entry: self.defer_entry(),
+                    index,
+                };
             }
             KeyCode::Char('u') if pins_guard(self, code) => {
                 let Some(index) = self.selected_pin_index() else {
                     return KeyOutcome::None;
                 };
-                return KeyOutcome::SyncPinPush { index };
+                return KeyOutcome::SyncPinPush {
+                    entry: self.defer_entry(),
+                    index,
+                };
             }
             KeyCode::Char('d') if pins_guard(self, code) => {
                 let Some(index) = self.selected_pin_index() else {
                     return KeyOutcome::None;
                 };
-                return KeyOutcome::SyncPinPull { index };
+                return KeyOutcome::SyncPinPull {
+                    entry: self.defer_entry(),
+                    index,
+                };
             }
             KeyCode::Char('o') => {
                 if let Some(pins) = self.pins_mut() {
@@ -362,7 +374,7 @@ mod tests {
     #[test]
     fn confirm_upload_n_cancels_to_diff_return_screen() {
         let mut state = initial_state();
-        state.pending_return = Some(Screen::Pins(Box::default()));
+        state.screen = Screen::Pins(Box::default());
         set_pending(
             &mut state,
             PendingAction::Upload {
@@ -420,10 +432,10 @@ mod tests {
             direction: None,
             last_seen_hash: None,
         }];
-        assert!(matches!(
-            state.handle_key(KeyCode::Enter),
-            KeyOutcome::PreviewPinDiff { .. }
-        ));
+        let KeyOutcome::PreviewPinDiff { entry, .. } = state.handle_key(KeyCode::Enter) else {
+            panic!("expected deferred pin diff");
+        };
+        assert!(entry.return_to.is_pins());
     }
 
     #[test]

--- a/src/tui/screens/preview.rs
+++ b/src/tui/screens/preview.rs
@@ -40,14 +40,11 @@ pub(crate) fn stage_preview_content(
     Some((file, title))
 }
 
-/// Restage the return path and invalidate cached content before refetching a preview.
+/// Invalidate cached content and build the fetch payload for refreshing a preview.
 pub(crate) fn stage_refresh_preview(
     state: &mut AppState,
     mut file: crate::domain::GistFileRef,
 ) -> (crate::domain::GistFileRef, String) {
-    if state.screen.is_preview() {
-        state.pending_return = state.nav_stack.last().cloned();
-    }
     state.gist_content_cache.remove(&file.cache_key());
     if file.raw_url.is_none() {
         file.raw_url = state.gist_file_raw_url(&file.gist_id, &file.filename);
@@ -75,6 +72,9 @@ impl AppState {
                     return KeyOutcome::None;
                 };
                 return KeyOutcome::RefreshPreview {
+                    entry: self
+                        .defer_replacement()
+                        .unwrap_or_else(|| self.defer_entry()),
                     file: crate::domain::GistFileRef::id_name(gist_id, filename),
                 };
             }
@@ -217,6 +217,7 @@ pub(crate) fn render_preview_vm(
 /// `PreviewContent` outcome: cache the fetched content and open the read-only preview.
 pub(crate) fn on_preview_content(
     state: &mut AppState,
+    entry: crate::tui::DeferredEntry,
     result: std::result::Result<String, String>,
     file: crate::domain::GistFileRef,
     preview_title: String,
@@ -227,7 +228,17 @@ pub(crate) fn on_preview_content(
             state
                 .gist_content_cache
                 .insert(key.clone(), content.clone());
-            state.enter_preview(preview_title, content, Some(key));
+            state.open_deferred(
+                entry,
+                crate::tui::Screen::Preview(Box::new(crate::tui::PreviewState {
+                    title: preview_title,
+                    body: crate::tui::ScrollBody {
+                        text: content,
+                        ..crate::tui::ScrollBody::default()
+                    },
+                    gist_key: Some(key),
+                })),
+            );
         }
         Err(error) => state.set_status(format!("fetch failed: {error}")),
     }
@@ -268,7 +279,7 @@ mod tests {
     }
 
     #[test]
-    fn stage_refresh_preview_restages_return_drops_cache_and_returns_fetch_payload() {
+    fn stage_refresh_preview_drops_cache_and_returns_fetch_payload() {
         let mut state = state_with_gists();
         state.gists[0].raw_url = Some("https://example.test/a.txt".into());
         let file = gist_file_ref("g1", "a.txt");
@@ -277,9 +288,10 @@ mod tests {
             .insert(file.cache_key(), "cached".into());
         state.enter_preview("a.txt".into(), "cached".into(), Some(file.cache_key()));
 
+        let entry = state.defer_replacement().unwrap();
         let (file, title) = stage_refresh_preview(&mut state, file);
 
-        assert!(matches!(state.pending_return, Some(Screen::Gists(_))));
+        assert!(entry.return_to.is_gists());
         assert!(state.gist_content_cache.get(&file.cache_key()).is_none());
         assert_eq!(file.raw_url.as_deref(), Some("https://example.test/a.txt"));
         assert!(title.contains("a.txt"));
@@ -441,7 +453,13 @@ mod tests {
         let mut state = initial_state();
         let file = gist_file_ref("g1", "a.txt");
 
-        on_preview_content(&mut state, Ok("body".into()), file.clone(), "a.txt".into());
+        on_preview_content(
+            &mut state,
+            initial_state().defer_entry(),
+            Ok("body".into()),
+            file.clone(),
+            "a.txt".into(),
+        );
 
         assert_eq!(
             state.gist_content_cache.get(&file.cache_key()),
@@ -457,6 +475,7 @@ mod tests {
 
         on_preview_content(
             &mut state,
+            initial_state().defer_entry(),
             Err("boom".into()),
             gist_file_ref("g1", "a.txt"),
             "a.txt".into(),

--- a/src/tui/screens/revisions.rs
+++ b/src/tui/screens/revisions.rs
@@ -164,6 +164,7 @@ impl AppState {
         let new_label = format!("revision {child_label}");
         let owner_login = self.gist_owner_login(&gist_id);
         KeyOutcome::RevisionDiffIncremental {
+            entry: self.defer_entry(),
             gist_id,
             filename,
             child_version,
@@ -195,6 +196,7 @@ impl AppState {
         let raw_url = self.gist_file_raw_url(&gist_id, &filename);
         let owner_login = self.gist_owner_login(&gist_id);
         KeyOutcome::RevisionDiff {
+            entry: self.defer_entry(),
             gist_id,
             filename,
             version,
@@ -224,6 +226,7 @@ impl AppState {
         let raw_url = self.gist_file_raw_url(&gist_id, &filename);
         let owner_login = self.gist_owner_login(&gist_id);
         KeyOutcome::RestoreRevisionPreview {
+            entry: self.defer_entry(),
             gist_id,
             filename,
             version,
@@ -653,7 +656,7 @@ mod tests {
     #[test]
     fn revision_diff_omits_download_upload() {
         let mut state = initial_state();
-        state.pending_return = Some(Screen::Revisions(Box::default()));
+        state.screen = Screen::Revisions(Box::default());
         state.enter_diff("diff".into(), String::new(), PathBuf::new(), PathBuf::new());
         let footer = diff_footer(&state);
         assert!(!footer.contains("download"));

--- a/src/tui/test_support.rs
+++ b/src/tui/test_support.rs
@@ -53,8 +53,7 @@ pub(super) fn detail_mut(state: &mut AppState) -> &mut DetailState {
 }
 
 /// Open Confirm with the given action (keeps existing body text when already on Diff/Confirm).
-/// Mirrors production `enter_confirm`/`enter_confirm_from_diff`: a staged `pending_return`
-/// becomes the cancel path (via `AppState::enter`) when present, otherwise the live screen does.
+/// Mirrors production `enter_confirm`/`enter_confirm_from_diff` for synchronous tests.
 pub(super) fn set_pending(state: &mut AppState, action: PendingAction) {
     if state.screen.is_confirm() {
         if let Some(c) = state.confirm_mut() {


### PR DESCRIPTION
## Summary
- replace root-level async screen staging with moved DeferredEntry values
- capture return paths at key intent and consume them only on successful screen entry
- keep Jobs generation as the sole cancellation and supersession mechanism
- preserve Preview refresh parent without stacking duplicate screens

## Verification
- mise run check
- Standards review: clean
- Spec review: clean

Closes #398