### PR TITLE
refactor(tui): deepen mouse interaction handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Mouse double-clicks now respect close buttons, repository links, and top-bar shortcuts instead
+  of falling through to the row underneath.
+- Command-palette mouse clicks now execute the row under the pointer when disabled commands are
+  visible above it.
+
 ## [0.18.0] — 2026-08-21
 
 - The main screen's two file lists can now be resized with the mouse: hold the left button on

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -96,7 +96,20 @@ Help topics and `README.md` stay hand-written — the List topic is fifty lines 
 - **`focused`** drives border colour *and* selection highlight together (solid bar when focused, bold when not); single-pane screens pass `true`. `scrollbar` is `true` only for the two List panes.
 - **Empty state** is `ListPaneEmpty` plus a prebuilt `empty_message` from the builder. No screen hard-codes an empty message at paint time.
 
-**The two List panes are user-resizable** (issue #395): `AppState::list_split_percent` is the local pane's share, session-only (no config field, no Settings row, no key binding — a restart is back at `DEFAULT_SPLIT_PERCENT`). Percent is the stored fact but `render_list_vm` sizes the panes in **cells** (`split_cells` → `Length`/`Min`) — handing ratatui a second percentage makes the divider lag the pointer mid-drag. `clamp_split_percent` holds 15–85% *and* `list_pane::MIN_PANE_CELLS` on both sides, and returns `None` when no split leaves two readable panes. The drag itself is pure (`MouseInput::Drag`/`Release` → `handle_mouse`, hit-tested by `SplitHit::grabbed` and gated on width by `AppState::grabbable_divider` — the hit map records where the divider is, but how narrow a pane may get is the List screen's policy); the highlight belongs to neither pane, so it is `highlight_pane_divider`, not a `ListPaneVm::focused` variant. **Anything that takes the mouse away mid-drag swallows the release and would wedge `list_split_drag` on** — a background overlay, mouse support switched off in Settings, `$EDITOR` suspending the TUI. Rather than chase each one, four seams end the drag unconditionally: `handle_mouse` on `Release` before any screen dispatch and on `RightClick`, `handle_key_with` on *any* key, and `begin_bg_task`. A new mouse-stealing path needs no fifth.
+**The two List panes are user-resizable** (issue #395): `AppState::list_split_percent` is the local pane's share, session-only (no config field, no Settings row, no key binding — a restart is back at `DEFAULT_SPLIT_PERCENT`). Percent is the stored fact but `render_list_vm` sizes the panes in **cells** (`split_cells` → `Length`/`Min`) — handing ratatui a second percentage makes the divider lag the pointer mid-drag. `clamp_split_percent` holds 15–85% *and* `list_pane::MIN_PANE_CELLS` on both sides, and returns `None` when no split leaves two readable panes. The drag policy stays on the List screen; `MouseSession` owns only its lifecycle. The highlight belongs to neither pane, so it is `highlight_pane_divider`, not a `ListPaneVm::focused` variant.
+
+## Mouse interaction (`@src/tui/mouse.rs`)
+
+- `MouseFrame` is rebuilt on every paint. Renderers register closed `HitTarget` values; its
+  resolver owns cross-screen priority, independent of registration order. Palette overlays use
+  `intercept_all`, and palette row targets carry their original item index.
+- Screen adapters retain domain behavior: resolved row geometry still delegates selection and
+  activation to the active screen. The mouse module knows no Gist or navigation policy.
+- `MouseSession` owns facts that survive a frame: previous press identity and divider-drag state.
+  Any key, right-click, release, or background-task takeover calls `interrupt()`; render only asks
+  `is_dragging()`.
+- Non-mouse render output belongs in `RenderFeedback`. In particular, comments scroll-to-bottom
+  is consumed only after the comments renderer supplies `comments_max_scroll`.
 
 List-row horizontal scroll (issue #341) is **per selected row**, not pane-wide: `row_hscroll` applies the pane offset only to the highlighted index; `focused_hscroll_max` / Pins / Gists caps are that row's painted string. A non-zero offset prefixes `…` in `visible_list_row` (then `truncate_end` may still mark a clipped tail). Unselected rows stay at column 0.
 

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -68,7 +68,7 @@ impl AppState {
         // A keystroke means the hand left the mouse. Ending the drag here is what keeps the
         // flag from wedging when a key takes the mouse away before the release lands —
         // turning mouse support off in Settings, or suspending the TUI for $EDITOR (#395).
-        self.end_split_drag();
+        self.mouse_session.interrupt();
         if code == KeyCode::Char(';')
             && modifiers.is_empty()
             && !self.screen.is_palette()
@@ -210,7 +210,7 @@ impl AppState {
     /// `true` when a row was hit (so a double-click should "open" it). A click in a pane's
     /// blank area or border focuses it but selects nothing (returns `false`); a click off
     /// every list returns `false`.
-    fn click_select(&mut self, col: u16, row: u16, layout: &MouseLayout) -> bool {
+    fn click_select(&mut self, col: u16, row: u16, layout: &MouseFrame) -> bool {
         (super::screens::lookup(&self.screen).click_select)(self, col, row, layout)
     }
 
@@ -231,13 +231,13 @@ impl AppState {
     /// Translate a classified mouse intent into a state change, reusing existing keyboard
     /// logic. Pure (no IO, no clock); returns a `KeyOutcome` so `run_loop` can perform any
     /// follow-up IO (e.g. `PreviewDiff` on double-click).
-    pub fn handle_mouse(&mut self, input: MouseInput, layout: &MouseLayout) -> KeyOutcome {
-        // Before anything else: a release ends a divider drag whatever is on screen. An
-        // overlay that swallowed it would leave the flag stuck on, and every later
-        // press-and-move on the List screen would resize without a grab (#395).
+    pub fn handle_mouse(&mut self, input: MouseInput, layout: &MouseFrame) -> KeyOutcome {
         if input == MouseInput::Release {
-            self.end_split_drag();
+            self.mouse_session.interrupt();
             return KeyOutcome::None;
+        }
+        if matches!(input, MouseInput::RightClick { .. }) {
+            self.mouse_session.interrupt();
         }
         if self.screen.is_palette() {
             return match input {
@@ -262,17 +262,14 @@ impl AppState {
             };
         }
         match input {
-            // Divider drag (#395). `layout.list_split` is only recorded on the List screen,
-            // so this is a no-op everywhere else. `Release` was handled above.
+            // Divider geometry is only registered on the List screen, so this is a no-op
+            // everywhere else. `Release` was handled above.
             MouseInput::Drag { col } => {
                 self.drag_split_divider(col, layout);
                 KeyOutcome::None
             }
             MouseInput::Release => KeyOutcome::None,
             MouseInput::RightClick { col, row } => {
-                // Opening a menu ends any resize: leaving the drag alive would keep the
-                // divider accented under an overlay where dragging does nothing (#395).
-                self.end_split_drag();
                 if self.palette_blocked() {
                     return KeyOutcome::None;
                 }
@@ -292,58 +289,9 @@ impl AppState {
                 KeyOutcome::None
             }
             MouseInput::Click { col, row } => {
-                // Close button takes priority on non-List screens.
-                if let Some(rect) = layout.close_button {
-                    if point_in(rect, col, row) {
-                        // Esc is the universal cancel across all screens and all
-                        // pending-action variants (including the create-description
-                        // editing sub-state where 'n' would type into the field).
-                        return self.handle_key_with(KeyCode::Esc, KeyModifiers::NONE);
-                    }
-                }
-                // GitHub repo link click opens it in the browser.
-                if let Some(rect) = layout.repo_link {
-                    if point_in(rect, col, row) {
-                        return KeyOutcome::OpenRepoUrl {
-                            url: env!("CARGO_PKG_REPOSITORY").to_string(),
-                        };
-                    }
-                }
-                // Top-bar (g)ists / (P)ins / (C)onfig / (?)Help — same effect as pressing
-                // the key, from any screen (not just wherever that key happens to be bound).
-                if let Some(rect) = layout.top_bar_gists {
-                    if point_in(rect, col, row) {
-                        self.open_gist_manager();
-                        return KeyOutcome::None;
-                    }
-                }
-                if let Some(rect) = layout.top_bar_pins {
-                    if point_in(rect, col, row) {
-                        self.open_pins();
-                        return KeyOutcome::None;
-                    }
-                }
-                if let Some(rect) = layout.top_bar_config {
-                    if point_in(rect, col, row) {
-                        self.open_config();
-                        return KeyOutcome::None;
-                    }
-                }
-                if let Some(rect) = layout.top_bar_help {
-                    if point_in(rect, col, row) {
-                        self.open_help();
-                        return KeyOutcome::None;
-                    }
-                }
-                // A GistDetail tab header click switches focus (single-click action).
-                if let Some(outcome) = self.click_detail_tab(col, row, layout) {
+                if let Some(outcome) = self.activate_global_mouse_target(col, row, layout) {
                     return outcome;
                 }
-                if let Some(outcome) = self.click_comments_load_older(col, row, layout) {
-                    return outcome;
-                }
-                // Pressing the pane divider starts a resize instead of focusing a pane;
-                // the matching release must not select anything either (#395).
                 if self.grab_split_divider(col, row, layout) {
                     return KeyOutcome::None;
                 }
@@ -351,8 +299,7 @@ impl AppState {
                 KeyOutcome::None
             }
             MouseInput::DoubleClick { col, row } => {
-                // A tab double-click is just a tab switch (no "open").
-                if let Some(outcome) = self.click_detail_tab(col, row, layout) {
+                if let Some(outcome) = self.activate_global_mouse_target(col, row, layout) {
                     return outcome;
                 }
                 if self.reset_split_divider(col, row, layout) {
@@ -364,6 +311,41 @@ impl AppState {
                 }
                 KeyOutcome::None
             }
+        }
+    }
+
+    fn activate_global_mouse_target(
+        &mut self,
+        col: u16,
+        row: u16,
+        layout: &MouseFrame,
+    ) -> Option<KeyOutcome> {
+        match layout.resolve(col, row)? {
+            HitTarget::Close => Some(self.handle_key_with(KeyCode::Esc, KeyModifiers::NONE)),
+            HitTarget::Repo => Some(KeyOutcome::OpenRepoUrl {
+                url: env!("CARGO_PKG_REPOSITORY").to_string(),
+            }),
+            HitTarget::TopGists => {
+                self.open_gist_manager();
+                Some(KeyOutcome::None)
+            }
+            HitTarget::TopPins => {
+                self.open_pins();
+                Some(KeyOutcome::None)
+            }
+            HitTarget::TopConfig => {
+                self.open_config();
+                Some(KeyOutcome::None)
+            }
+            HitTarget::TopHelp => {
+                self.open_help();
+                Some(KeyOutcome::None)
+            }
+            HitTarget::DetailFilesTab | HitTarget::DetailCommentsTab => {
+                self.click_detail_tab(col, row, layout)
+            }
+            HitTarget::CommentsLoadOlder => self.click_comments_load_older(col, row, layout),
+            HitTarget::PaletteClose | HitTarget::Divider(_) | HitTarget::Row(_) => None,
         }
     }
 }
@@ -699,10 +681,8 @@ mod tests {
         state.handle_key(KeyCode::Right); // dirty the hscroll so the reset is observable
         assert!(pins_ref(&state).cursor.hscroll > 0);
         state.screen = Screen::Preview(Box::default());
-        let layout = MouseLayout {
-            top_bar_pins: Some(Rect::new(20, 0, 6, 1)),
-            ..Default::default()
-        };
+        let mut layout = MouseFrame::default();
+        layout.register(HitTarget::TopPins, Rect::new(20, 0, 6, 1));
         let out = state.handle_mouse(MouseInput::Click { col: 22, row: 0 }, &layout);
         assert!(state.screen.is_pins());
         assert_eq!(pins_ref(&state).cursor.hscroll, 0);
@@ -710,13 +690,26 @@ mod tests {
     }
 
     #[test]
+    fn double_click_uses_the_same_global_priority_as_click() {
+        let mut state = initial_state();
+        state.screen = Screen::Preview(Box::default());
+        let mut layout = MouseFrame::default();
+        let rect = Rect::new(20, 0, 6, 1);
+        layout.register_pane(PaneTarget::List, PaneHit { rect, offset: 0 }, 1);
+        layout.register(HitTarget::TopPins, rect);
+
+        let out = state.handle_mouse(MouseInput::DoubleClick { col: 22, row: 0 }, &layout);
+
+        assert_eq!(out, KeyOutcome::None);
+        assert!(state.screen.is_pins());
+    }
+
+    #[test]
     fn top_bar_help_click_while_already_on_help_does_not_trap_keyboard_exit() {
         let mut state = state_with_gists();
         state.screen = Screen::Preview(Box::default());
-        let layout = MouseLayout {
-            top_bar_help: Some(Rect::new(30, 0, 7, 1)),
-            ..Default::default()
-        };
+        let mut layout = MouseFrame::default();
+        layout.register(HitTarget::TopHelp, Rect::new(30, 0, 7, 1));
         // First click opens Help from Preview, remembering Preview as the return screen.
         state.handle_mouse(MouseInput::Click { col: 32, row: 0 }, &layout);
         assert!(state.screen.is_help());
@@ -748,10 +741,8 @@ mod tests {
     #[test]
     fn repo_link_click_opens_repo_url_regardless_of_which_screen_set_the_rect() {
         let mut state = initial_state();
-        let layout = MouseLayout {
-            repo_link: Some(Rect::new(5, 10, 20, 1)),
-            ..Default::default()
-        };
+        let mut layout = MouseFrame::default();
+        layout.register(HitTarget::Repo, Rect::new(5, 10, 20, 1));
         let out = state.handle_mouse(MouseInput::Click { col: 10, row: 10 }, &layout);
         assert!(matches!(out, KeyOutcome::OpenRepoUrl { .. }));
     }
@@ -768,7 +759,7 @@ mod tests {
         );
         assert!(state.screen.is_diff());
         assert_eq!(state.scroll_body().expect("Diff ScrollBody").scroll, 0);
-        state.handle_mouse(MouseInput::ScrollDown, &MouseLayout::default());
+        state.handle_mouse(MouseInput::ScrollDown, &MouseFrame::default());
         assert_eq!(state.scroll_body().expect("Diff ScrollBody").scroll, 3);
     }
 
@@ -782,7 +773,7 @@ mod tests {
             std::path::PathBuf::from("/tmp/cwd/x"),
         );
         set_diff_scroll(&mut state, 3);
-        state.handle_mouse(MouseInput::ScrollUp, &MouseLayout::default());
+        state.handle_mouse(MouseInput::ScrollUp, &MouseFrame::default());
         assert_eq!(state.scroll_body().expect("Diff ScrollBody").scroll, 0);
     }
 
@@ -791,10 +782,8 @@ mod tests {
         let mut state = state_with_gists();
         // Simulate entering Help (mirrors what open_help() does).
         state.screen = Screen::Help(Box::default());
-        let layout = MouseLayout {
-            close_button: Some(Rect::new(36, 0, 5, 1)),
-            ..Default::default()
-        };
+        let mut layout = MouseFrame::default();
+        layout.register(HitTarget::Close, Rect::new(36, 0, 5, 1));
         let out = state.handle_mouse(MouseInput::Click { col: 38, row: 0 }, &layout);
         assert_eq!(out, KeyOutcome::None);
         assert_eq!(state.screen, Screen::List);
@@ -807,10 +796,8 @@ mod tests {
         let mut state = state_with_gists();
         set_diff_body(&mut state, "line1\nline2\nline3");
         set_pending(&mut state, PendingAction::Download);
-        let layout = MouseLayout {
-            close_button: Some(Rect::new(36, 0, 5, 1)),
-            ..Default::default()
-        };
+        let mut layout = MouseFrame::default();
+        layout.register(HitTarget::Close, Rect::new(36, 0, 5, 1));
         let out = state.handle_mouse(MouseInput::Click { col: 38, row: 0 }, &layout);
         assert_eq!(out, KeyOutcome::None);
         assert!(state.pending_action().is_none());
@@ -833,10 +820,8 @@ mod tests {
         state.editing_description = true;
         // Pre-fill description so we can assert it was cleared (not grown by a typed 'n').
         state.description_input = "my desc".into();
-        let layout = MouseLayout {
-            close_button: Some(Rect::new(36, 0, 5, 1)),
-            ..Default::default()
-        };
+        let mut layout = MouseFrame::default();
+        layout.register(HitTarget::Close, Rect::new(36, 0, 5, 1));
         state.handle_mouse(MouseInput::Click { col: 38, row: 0 }, &layout);
         // Esc on create-description clears description, exits editing, and calls back_to_list.
         assert!(
@@ -856,7 +841,7 @@ mod tests {
         let mut state = crate::tui::initial_state();
         let out = state.handle_mouse(
             MouseInput::RightClick { col: 10, row: 5 },
-            &MouseLayout::default(),
+            &MouseFrame::default(),
         );
         assert_eq!(out, KeyOutcome::None);
         assert!(state.screen.is_palette());
@@ -868,32 +853,46 @@ mod tests {
     #[test]
     fn an_overlay_never_leaves_a_divider_drag_running() {
         let mut state = state_with_gists();
-        let layout = MouseLayout {
-            list_split: Some(crate::tui::SplitHit {
-                area: Rect::new(0, 1, 100, 20),
-                divider_x: 39,
-            }),
-            ..Default::default()
+        let mut layout = MouseFrame::default();
+        let split = crate::tui::SplitHit {
+            area: Rect::new(0, 1, 100, 20),
+            divider_x: 39,
         };
+        layout.register(HitTarget::Divider(split), split.area);
         state.handle_mouse(MouseInput::Click { col: 39, row: 5 }, &layout);
-        assert!(state.list_split_drag);
+        assert!(state.mouse_session.is_dragging());
 
         // Opening the context menu ends the resize, so the divider is not left accented
         // under an overlay where dragging does nothing.
         state.handle_mouse(MouseInput::RightClick { col: 39, row: 5 }, &layout);
         assert!(state.screen.is_palette());
-        assert!(!state.list_split_drag);
+        assert!(!state.mouse_session.is_dragging());
 
         // And a release that arrives while the overlay is up still clears the flag, whatever
         // put it there — otherwise every later press-and-move would resize without a grab.
-        state.list_split_drag = true;
+        state.mouse_session.begin_divider_drag();
         state.handle_mouse(MouseInput::Drag { col: 70 }, &layout);
         assert_eq!(state.list_split_percent, 40, "resized under the palette");
         state.handle_mouse(MouseInput::Release, &layout);
         assert!(
-            !state.list_split_drag,
+            !state.mouse_session.is_dragging(),
             "release under the palette left the drag stuck"
         );
+    }
+
+    #[test]
+    fn right_click_interrupts_a_drag_even_when_palette_is_already_open() {
+        let mut state = state_with_gists();
+        state.open_palette_menu(None);
+        state.mouse_session.begin_divider_drag();
+
+        let out = state.handle_mouse(
+            MouseInput::RightClick { col: 1, row: 1 },
+            &MouseFrame::default(),
+        );
+
+        assert_eq!(out, KeyOutcome::None);
+        assert!(!state.mouse_session.is_dragging());
     }
 
     /// #395: a keystroke means the hand left the mouse, and some keys take the mouse away
@@ -902,17 +901,16 @@ mod tests {
     #[test]
     fn a_keystroke_ends_a_divider_drag() {
         let mut state = state_with_gists();
-        let layout = MouseLayout {
-            list_split: Some(crate::tui::SplitHit {
-                area: Rect::new(0, 1, 100, 20),
-                divider_x: 39,
-            }),
-            ..Default::default()
+        let mut layout = MouseFrame::default();
+        let split = crate::tui::SplitHit {
+            area: Rect::new(0, 1, 100, 20),
+            divider_x: 39,
         };
+        layout.register(HitTarget::Divider(split), split.area);
         state.handle_mouse(MouseInput::Click { col: 39, row: 5 }, &layout);
-        assert!(state.list_split_drag);
+        assert!(state.mouse_session.is_dragging());
         state.handle_key(KeyCode::Tab);
-        assert!(!state.list_split_drag);
+        assert!(!state.mouse_session.is_dragging());
     }
 
     /// #395: a background-task overlay takes over the mouse and would swallow the release,
@@ -920,17 +918,16 @@ mod tests {
     #[test]
     fn a_background_task_ends_a_divider_drag() {
         let mut state = state_with_gists();
-        let layout = MouseLayout {
-            list_split: Some(crate::tui::SplitHit {
-                area: Rect::new(0, 1, 100, 20),
-                divider_x: 39,
-            }),
-            ..Default::default()
+        let mut layout = MouseFrame::default();
+        let split = crate::tui::SplitHit {
+            area: Rect::new(0, 1, 100, 20),
+            divider_x: 39,
         };
+        layout.register(HitTarget::Divider(split), split.area);
         state.handle_mouse(MouseInput::Click { col: 39, row: 5 }, &layout);
-        assert!(state.list_split_drag);
+        assert!(state.mouse_session.is_dragging());
         state.begin_bg_task();
-        assert!(!state.list_split_drag);
+        assert!(!state.mouse_session.is_dragging());
     }
 
     #[test]
@@ -938,9 +935,9 @@ mod tests {
         let mut state = state_with_gists();
         state.screen = Screen::Preview(Box::default());
         assert_eq!(
-            state.handle_mouse(MouseInput::Release, &MouseLayout::default()),
+            state.handle_mouse(MouseInput::Release, &MouseFrame::default()),
             KeyOutcome::None
         );
-        assert!(!state.list_split_drag);
+        assert!(!state.mouse_session.is_dragging());
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -9,9 +9,17 @@ use crossterm::{
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
-use ratatui::{backend::CrosstermBackend, layout::Rect, widgets::Clear, Terminal};
+#[cfg(test)]
+use ratatui::layout::Rect;
+use ratatui::{backend::CrosstermBackend, widgets::Clear, Terminal};
 use std::io;
 use std::path::PathBuf;
+
+mod mouse;
+pub use mouse::{
+    point_in, HitTarget, MouseFrame, MouseSession, PaneHit, PaneTarget, PressKind, RowTarget,
+    SplitHit,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FocusPane {
@@ -642,87 +650,6 @@ pub struct DeferredEntry {
     replaces_current: bool,
 }
 
-/// A clickable list pane recorded by `render` for the current frame.
-/// `offset` is ratatui's first-visible-item index, captured after the list renders.
-#[derive(Debug, Clone, Copy)]
-pub struct PaneHit {
-    pub rect: Rect,
-    pub offset: usize,
-}
-
-impl PaneHit {
-    /// Map an absolute terminal `row` to a list index, or `None` for border rows,
-    /// rows past the last item, or an empty list. `visible_len` is the count of
-    /// currently visible rows (e.g. `visible_locals().len()` / `ranked_gists().len()`).
-    pub fn index_at(&self, row: u16, visible_len: usize) -> Option<usize> {
-        let top = self.rect.y + 1; // skip the top border
-        let bottom = self.rect.bottom().saturating_sub(1); // exclusive of bottom border
-        if row < top || row >= bottom {
-            return None;
-        }
-        let idx = self.offset + (row - top) as usize;
-        (idx < visible_len).then_some(idx)
-    }
-}
-
-/// The draggable divider between the List screen's two panes, recorded by `render`.
-///
-/// `area` is the two panes' combined region — the denominator every column-to-percent
-/// conversion needs, which is why it is carried here rather than reconstructed from the
-/// `local` / `gist` hits (that would bake in an unwritten "panes are adjacent and fill
-/// the row" invariant).
-#[derive(Debug, Clone, Copy)]
-pub struct SplitHit {
-    pub area: Rect,
-    /// Column of the local pane's right border; the gist pane's left border sits at `+1`.
-    pub divider_x: u16,
-}
-
-impl SplitHit {
-    /// Whether a press at (`col`, `row`) grabs the divider: the two border columns widened
-    /// by one on each side (four cells, comfortable to hit), anywhere down the panes' height.
-    /// `row` is checked here and only here — once the drag is running the pointer is free to
-    /// leave the panes vertically.
-    pub fn grabbed(&self, col: u16, row: u16) -> bool {
-        row >= self.area.y
-            && row < self.area.bottom()
-            && col + 1 >= self.divider_x
-            && col <= self.divider_x + 2
-    }
-}
-
-/// Per-frame mouse hit regions, owned by `run_loop`, filled by `render`.
-#[derive(Debug, Default, Clone)]
-pub struct MouseLayout {
-    pub local: Option<PaneHit>,
-    pub gist: Option<PaneHit>,
-    /// Single-list screens (Gists / Pins / Revisions) and the Help topic index.
-    pub list: Option<PaneHit>,
-    /// List screen only: the draggable divider between the two panes.
-    pub list_split: Option<SplitHit>,
-    /// GistDetail file list (Files tab).
-    pub detail_files: Option<PaneHit>,
-    /// GistDetail "Files" / "Comments" tab headers (clickable to switch focus).
-    pub detail_tab_files: Option<Rect>,
-    pub detail_tab_comments: Option<Rect>,
-    pub close_button: Option<Rect>,
-    /// GistDetail Comments: the clickable "load older" affordance line.
-    pub comments_load_older: Option<Rect>,
-    /// GistDetail Comments: max useful vertical scroll (set by render; used by run_loop
-    /// to honour a one-shot scroll-to-bottom after the newest page loads).
-    pub comments_max_scroll: Option<u16>,
-    pub repo_link: Option<Rect>,
-    /// Cross-screen top-bar shortcut hit-rects — `(g)ists`, `(P)ins`, `(C)onfig`, `(?)Help`.
-    /// Set by `render_top_bar` on every screen except the transient `Confirm` y/n modal.
-    pub top_bar_gists: Option<Rect>,
-    pub top_bar_pins: Option<Rect>,
-    pub top_bar_config: Option<Rect>,
-    pub top_bar_help: Option<Rect>,
-    /// Palette overlay: one hit-rect per visible row, plus the `[✕]` close button.
-    pub palette_rows: Vec<Rect>,
-    pub palette_close: Option<Rect>,
-}
-
 /// A classified mouse intent handed to the pure `handle_mouse`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MouseInput {
@@ -747,25 +674,6 @@ pub enum MouseInput {
     },
     /// Left button released, ending any drag in progress.
     Release,
-}
-
-/// Max gap between two left-clicks on the same cell to count as a double-click.
-pub const DOUBLE_CLICK_MS: u128 = 400;
-
-/// Classify a left-button press as a single or double click. `prev` is the (col,row) of
-/// the previous left press; `elapsed_ms` is the time since it. Pure: the caller (run_loop)
-/// owns the clock and supplies the elapsed milliseconds.
-pub fn classify_click(
-    prev: Option<(u16, u16)>,
-    elapsed_ms: u128,
-    col: u16,
-    row: u16,
-) -> MouseInput {
-    if prev == Some((col, row)) && elapsed_ms <= DOUBLE_CLICK_MS {
-        MouseInput::DoubleClick { col, row }
-    } else {
-        MouseInput::Click { col, row }
-    }
 }
 
 /// Per-screen upload-diff state (the `u` flow). Data only — the upload methods
@@ -936,7 +844,7 @@ pub struct AppState {
     /// [`screens::list::DEFAULT_SPLIT_PERCENT`].
     pub list_split_percent: u16,
     /// The divider is being dragged: paint highlights it and pointer moves resize the panes.
-    pub list_split_drag: bool,
+    pub mouse_session: MouseSession,
     pub screen: Screen,
     pub gist_view: GistView,
     pub gist_type_filter: GistTypeFilter,
@@ -1396,7 +1304,7 @@ impl AppState {
     pub fn begin_bg_task(&mut self) -> u64 {
         // The overlay takes over the mouse, so it would swallow the release that ends a
         // divider drag (#395). End it here, when the overlay appears.
-        self.end_split_drag();
+        self.mouse_session.interrupt();
         self.bg_task_generation = self.bg_task_generation.wrapping_add(1);
         self.bg_task_generation
     }
@@ -2147,7 +2055,7 @@ pub fn initial_state() -> AppState {
         local_hscroll: 0,
         gist_hscroll: 0,
         list_split_percent: screens::list::DEFAULT_SPLIT_PERCENT,
-        list_split_drag: false,
+        mouse_session: MouseSession::default(),
         screen: Screen::List,
         gist_view: GistView::Description,
         gist_type_filter: GistTypeFilter::All,
@@ -2528,38 +2436,6 @@ mod tests {
         assert!(hit.grabbed(40, 10));
         assert!(!hit.grabbed(39, 0)); // top bar shares the column, not the divider
         assert!(!hit.grabbed(39, 11)); // below the panes (footer)
-    }
-
-    #[test]
-    fn classify_click_detects_double_click() {
-        // Same cell within the threshold -> DoubleClick.
-        let r = super::classify_click(Some((5, 5)), 100, 5, 5);
-        assert_eq!(r, MouseInput::DoubleClick { col: 5, row: 5 });
-    }
-
-    #[test]
-    fn classify_click_single_when_too_slow() {
-        let r = super::classify_click(Some((5, 5)), super::DOUBLE_CLICK_MS + 1, 5, 5);
-        assert_eq!(r, MouseInput::Click { col: 5, row: 5 });
-    }
-
-    #[test]
-    fn classify_click_single_on_different_cell() {
-        let r = super::classify_click(Some((5, 5)), 100, 6, 5);
-        assert_eq!(r, MouseInput::Click { col: 6, row: 5 });
-    }
-
-    #[test]
-    fn classify_click_single_when_no_prior() {
-        let r = super::classify_click(None, 0, 5, 5);
-        assert_eq!(r, MouseInput::Click { col: 5, row: 5 });
-    }
-
-    #[test]
-    fn classify_click_at_exact_threshold() {
-        // Exactly at the boundary: still counts as a double-click (inclusive `<=`).
-        let r = super::classify_click(Some((5, 5)), super::DOUBLE_CLICK_MS, 5, 5);
-        assert_eq!(r, MouseInput::DoubleClick { col: 5, row: 5 });
     }
 
     #[test]

--- a/src/tui/mouse.rs
+++ b/src/tui/mouse.rs
@@ -1,0 +1,234 @@
+//! Mouse hit registration, target resolution, and cross-frame gesture state.
+
+use ratatui::layout::Rect;
+
+/// A clickable list pane recorded after ratatui has chosen its scroll offset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PaneHit {
+    pub rect: Rect,
+    pub offset: usize,
+}
+
+impl PaneHit {
+    pub fn index_at(self, row: u16, visible_len: usize) -> Option<usize> {
+        let top = self.rect.y + 1;
+        let bottom = self.rect.bottom().saturating_sub(1);
+        if row < top || row >= bottom {
+            return None;
+        }
+        let idx = self.offset + (row - top) as usize;
+        (idx < visible_len).then_some(idx)
+    }
+}
+
+/// Rendered geometry for the List screen's draggable divider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SplitHit {
+    pub area: Rect,
+    pub divider_x: u16,
+}
+
+impl SplitHit {
+    pub fn grabbed(self, col: u16, row: u16) -> bool {
+        row >= self.area.y
+            && row < self.area.bottom()
+            && col + 1 >= self.divider_x
+            && col <= self.divider_x + 2
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PaneTarget {
+    Local,
+    Gist,
+    List,
+    DetailFiles,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RowTarget {
+    Pane {
+        pane: PaneTarget,
+        index: Option<usize>,
+    },
+    Palette(usize),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HitTarget {
+    PaletteClose,
+    Close,
+    Repo,
+    TopGists,
+    TopPins,
+    TopConfig,
+    TopHelp,
+    DetailFilesTab,
+    DetailCommentsTab,
+    CommentsLoadOlder,
+    Divider(SplitHit),
+    Row(RowTarget),
+}
+
+#[derive(Debug, Clone, Copy)]
+enum HitRegion {
+    Rect(HitTarget, Rect),
+    Pane(PaneTarget, PaneHit, usize),
+}
+
+/// Per-frame semantic mouse targets. Registration order never controls precedence.
+#[derive(Debug, Default, Clone)]
+pub struct MouseFrame {
+    hits: Vec<HitRegion>,
+    intercept_all: bool,
+}
+
+impl MouseFrame {
+    pub fn clear(&mut self) {
+        self.hits.clear();
+        self.intercept_all = false;
+    }
+
+    pub fn intercept_all(&mut self) {
+        self.intercept_all = true;
+    }
+
+    pub fn register(&mut self, target: HitTarget, rect: Rect) {
+        self.hits.push(HitRegion::Rect(target, rect));
+    }
+
+    pub fn register_pane(&mut self, pane: PaneTarget, hit: PaneHit, len: usize) {
+        self.hits.push(HitRegion::Pane(pane, hit, len));
+    }
+
+    pub fn pane(&self, target: PaneTarget) -> Option<PaneHit> {
+        self.hits.iter().rev().find_map(|hit| match hit {
+            HitRegion::Pane(pane, hit, _) if *pane == target => Some(*hit),
+            _ => None,
+        })
+    }
+
+    pub fn split(&self) -> Option<SplitHit> {
+        self.hits.iter().rev().find_map(|hit| match hit {
+            HitRegion::Rect(HitTarget::Divider(split), _) => Some(*split),
+            _ => None,
+        })
+    }
+
+    pub fn resolve(&self, col: u16, row: u16) -> Option<HitTarget> {
+        let mut found = self.hits.iter().filter_map(|hit| match *hit {
+            HitRegion::Rect(target, rect) if point_in(rect, col, row) => Some(target),
+            HitRegion::Pane(pane, hit, len) if point_in(hit.rect, col, row) => {
+                Some(HitTarget::Row(RowTarget::Pane {
+                    pane,
+                    index: hit.index_at(row, len),
+                }))
+            }
+            _ => None,
+        });
+        if self.intercept_all {
+            return found.find(|target| {
+                matches!(
+                    target,
+                    HitTarget::PaletteClose | HitTarget::Row(RowTarget::Palette(_))
+                )
+            });
+        }
+        found.min_by_key(priority)
+    }
+}
+
+fn priority(target: &HitTarget) -> u8 {
+    match target {
+        HitTarget::PaletteClose => 0,
+        HitTarget::Close => 1,
+        HitTarget::Repo => 2,
+        HitTarget::TopGists => 3,
+        HitTarget::TopPins => 4,
+        HitTarget::TopConfig => 5,
+        HitTarget::TopHelp => 6,
+        HitTarget::DetailFilesTab | HitTarget::DetailCommentsTab => 7,
+        HitTarget::CommentsLoadOlder => 8,
+        HitTarget::Divider(_) => 9,
+        HitTarget::Row(_) => 10,
+    }
+}
+
+pub fn point_in(rect: Rect, col: u16, row: u16) -> bool {
+    col >= rect.x && col < rect.right() && row >= rect.y && row < rect.bottom()
+}
+
+pub const DOUBLE_CLICK_MS: u128 = 400;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PressKind {
+    Click,
+    DoubleClick,
+}
+
+/// Gesture facts that outlive one rendered frame.
+#[derive(Debug, Default, Clone)]
+pub struct MouseSession {
+    last_press: Option<(u16, u16)>,
+    divider_drag: bool,
+}
+
+impl MouseSession {
+    pub fn press(&mut self, col: u16, row: u16, elapsed_ms: u128) -> PressKind {
+        let kind = if self.last_press == Some((col, row)) && elapsed_ms <= DOUBLE_CLICK_MS {
+            PressKind::DoubleClick
+        } else {
+            PressKind::Click
+        };
+        self.last_press = Some((col, row));
+        kind
+    }
+
+    pub fn begin_divider_drag(&mut self) {
+        self.divider_drag = true;
+    }
+
+    pub fn is_dragging(&self) -> bool {
+        self.divider_drag
+    }
+
+    pub fn interrupt(&mut self) {
+        self.divider_drag = false;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolution_uses_fixed_priority() {
+        let rect = Rect::new(0, 0, 5, 5);
+        let mut frame = MouseFrame::default();
+        frame.register(HitTarget::TopHelp, rect);
+        frame.register(HitTarget::Close, rect);
+        assert_eq!(frame.resolve(1, 1), Some(HitTarget::Close));
+    }
+
+    #[test]
+    fn palette_row_keeps_source_identity() {
+        let mut frame = MouseFrame::default();
+        frame.intercept_all();
+        frame.register(HitTarget::Row(RowTarget::Palette(3)), Rect::new(1, 2, 5, 1));
+        assert_eq!(
+            frame.resolve(2, 2),
+            Some(HitTarget::Row(RowTarget::Palette(3)))
+        );
+    }
+
+    #[test]
+    fn session_classifies_and_interrupts() {
+        let mut session = MouseSession::default();
+        assert_eq!(session.press(2, 3, u128::MAX), PressKind::Click);
+        assert_eq!(session.press(2, 3, DOUBLE_CLICK_MS), PressKind::DoubleClick);
+        session.begin_divider_drag();
+        assert!(session.is_dragging());
+        session.interrupt();
+        assert!(!session.is_dragging());
+    }
+}

--- a/src/tui/palette.rs
+++ b/src/tui/palette.rs
@@ -1,5 +1,5 @@
 use super::keymap::Category;
-use super::{keys::point_in, *};
+use super::*;
 use crossterm::event::{KeyCode, KeyModifiers};
 
 /// Menu = context-filtered actions near the click; Command = full list + fuzzy query.
@@ -124,22 +124,20 @@ impl AppState {
         }
     }
 
-    pub(crate) fn palette_click(&mut self, col: u16, row: u16, layout: &MouseLayout) -> KeyOutcome {
-        if let Some(rect) = layout.palette_close {
-            if point_in(rect, col, row) {
+    pub(crate) fn palette_click(&mut self, col: u16, row: u16, layout: &MouseFrame) -> KeyOutcome {
+        match layout.resolve(col, row) {
+            Some(HitTarget::PaletteClose) => {
                 self.close_palette();
-                return KeyOutcome::None;
+                KeyOutcome::None
             }
-        }
-        for (i, rect) in layout.palette_rows.iter().enumerate() {
-            if point_in(*rect, col, row) {
+            Some(HitTarget::Row(RowTarget::Palette(index))) => {
                 if let Some(p) = self.palette_mut() {
-                    p.selected = i;
+                    p.selected = index;
                 }
-                return self.execute_palette_selection();
+                self.execute_palette_selection()
             }
+            _ => KeyOutcome::None,
         }
-        KeyOutcome::None
     }
 }
 

--- a/src/tui/render/chrome.rs
+++ b/src/tui/render/chrome.rs
@@ -28,7 +28,7 @@ pub(crate) fn render_top_bar(
     area: Rect,
     theme: &Theme,
     mouse_enabled: bool,
-    layout: &mut MouseLayout,
+    layout: &mut MouseFrame,
 ) -> Rect {
     if area.height == 0 {
         return area;
@@ -68,12 +68,13 @@ pub(crate) fn render_top_bar(
         };
         frame.render_widget(Paragraph::new(line).style(theme.base_style()), rect);
         if mouse_enabled {
-            match item.index {
-                0 => layout.top_bar_gists = Some(rect),
-                1 => layout.top_bar_pins = Some(rect),
-                2 => layout.top_bar_config = Some(rect),
-                _ => layout.top_bar_help = Some(rect),
-            }
+            let target = match item.index {
+                0 => HitTarget::TopGists,
+                1 => HitTarget::TopPins,
+                2 => HitTarget::TopConfig,
+                _ => HitTarget::TopHelp,
+            };
+            layout.register(target, rect);
         }
     }
 
@@ -282,7 +283,7 @@ pub(crate) fn render_footer_line(
     title: &str,
     line: Line,
     theme: &Theme,
-    _layout: &mut MouseLayout,
+    _layout: &mut MouseFrame,
 ) {
     frame.render_widget(
         Paragraph::new(line)

--- a/src/tui/render/list_pane.rs
+++ b/src/tui/render/list_pane.rs
@@ -14,7 +14,7 @@ use super::{cell_width, fit_title, truncate_end, ELLIPSIS};
 use crate::tui::text::hscroll_str;
 use crate::tui::theme::Theme;
 use crate::tui::view_model::{ListPaneEmpty, ListPaneVm, RowEmphasis};
-use crate::tui::PaneHit;
+use crate::tui::{MouseFrame, PaneHit, PaneTarget};
 use ratatui::layout::{Margin, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::widgets::{
@@ -47,7 +47,8 @@ pub(crate) fn render_list_pane(
     pane: &ListPaneVm,
     theme: &Theme,
     mouse_enabled: bool,
-    hit: &mut Option<PaneHit>,
+    layout: &mut MouseFrame,
+    target: PaneTarget,
 ) {
     let items = pane_items(pane, area.width, theme);
     let item_count = items.len();
@@ -112,10 +113,14 @@ pub(crate) fn render_list_pane(
     }
 
     if mouse_enabled {
-        *hit = Some(PaneHit {
-            rect: area,
-            offset: list_state.offset(),
-        });
+        layout.register_pane(
+            target,
+            PaneHit {
+                rect: area,
+                offset: list_state.offset(),
+            },
+            item_count,
+        );
     }
 }
 
@@ -234,14 +239,25 @@ mod tests {
     fn paint(pane: &ListPaneVm, width: u16, height: u16, mouse: bool) -> (Buffer, Option<PaneHit>) {
         let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
         let theme = Theme::for_choice(ThemeChoice::Dark);
-        let mut hit = None;
+        let mut layout = MouseFrame::default();
         terminal
             .draw(|frame| {
                 let area = frame.area();
-                render_list_pane(frame, area, pane, &theme, mouse, &mut hit);
+                render_list_pane(
+                    frame,
+                    area,
+                    pane,
+                    &theme,
+                    mouse,
+                    &mut layout,
+                    PaneTarget::List,
+                );
             })
             .unwrap();
-        (terminal.backend().buffer().clone(), hit)
+        (
+            terminal.backend().buffer().clone(),
+            layout.pane(PaneTarget::List),
+        )
     }
 
     /// First cell of row `index`'s label: border, `Padding::horizontal(1)`, then the highlight

--- a/src/tui/render/mod.rs
+++ b/src/tui/render/mod.rs
@@ -26,8 +26,19 @@ use ratatui::{
 };
 use similar::{ChangeTag, TextDiff};
 
-pub(super) fn render(frame: &mut Frame, state: &AppState, layout: &mut MouseLayout) {
-    *layout = MouseLayout::default();
+#[derive(Debug, Default)]
+pub(super) struct RenderFeedback {
+    pub comments_max_scroll: Option<u16>,
+}
+
+pub(super) fn render(
+    frame: &mut Frame,
+    state: &AppState,
+    layout: &mut MouseFrame,
+    feedback: &mut RenderFeedback,
+) {
+    layout.clear();
+    *feedback = RenderFeedback::default();
     // Paint the full canvas so every unfilled cell uses the theme background (no-op for dark
     // theme where bg=Reset, effective for light theme which sets a grey canvas).
     frame.render_widget(
@@ -37,7 +48,7 @@ pub(super) fn render(frame: &mut Frame, state: &AppState, layout: &mut MouseLayo
     // Pure presentation seam (issues #241 / #250): every screen paints from the view model.
     // Pin sync IO is never done here — only cache reads.
     let vm = super::build_view_model(state);
-    render_screen_vm(frame, state, &vm.screen, &vm.chrome, layout);
+    render_screen_vm_with_feedback(frame, state, &vm.screen, &vm.chrome, layout, feedback);
     if let Some(ref msg) = vm.chrome.bg_task_msg {
         render_loading_overlay(frame, msg, vm.chrome.spinner_frame, &state.theme);
     }
@@ -46,17 +57,20 @@ pub(super) fn render(frame: &mut Frame, state: &AppState, layout: &mut MouseLayo
 /// Paints one `ScreenVm`. Shared by `render()` (the primary per-frame path) and
 /// `render_palette_vm` (the palette's already-built background, issue #272) — one seam, two
 /// real callers, so a new `Screen` variant only needs wiring here once.
-pub(crate) fn render_screen_vm(
+pub(crate) fn render_screen_vm_with_feedback(
     frame: &mut Frame,
     state: &AppState,
     screen: &super::ScreenVm,
     chrome: &super::view_model::ChromeVm,
-    layout: &mut MouseLayout,
+    layout: &mut MouseFrame,
+    feedback: &mut RenderFeedback,
 ) {
     match screen {
         ScreenVm::List(list) => render_list(frame, state, list, chrome, layout),
         ScreenVm::Gists(gists) => render_gists(frame, state, gists, chrome, layout),
-        ScreenVm::GistDetail(detail) => render_detail(frame, state, detail, chrome, layout),
+        ScreenVm::GistDetail(detail) => {
+            render_detail(frame, state, detail, chrome, layout, feedback)
+        }
         ScreenVm::Revisions(revs) => render_revisions(frame, state, revs, chrome, layout),
         ScreenVm::Config(config) => render_config(frame, state, config, chrome, layout),
         ScreenVm::Diff(diff) => render_diff(frame, state, diff, chrome, layout),
@@ -64,8 +78,28 @@ pub(crate) fn render_screen_vm(
         ScreenVm::Pins(pins) => render_pins(frame, state, pins, chrome, layout),
         ScreenVm::Confirm(confirm) => render_confirm(frame, state, confirm, chrome, layout),
         ScreenVm::Help(help) => render_help(frame, state, help, chrome, layout),
-        ScreenVm::Palette(palette) => render_palette(frame, state, palette, chrome, layout),
+        ScreenVm::Palette(palette) => {
+            render_palette(frame, state, palette, chrome, layout, feedback)
+        }
     }
+}
+
+#[cfg(test)]
+pub(crate) fn render_screen_vm(
+    frame: &mut Frame,
+    state: &AppState,
+    screen: &super::ScreenVm,
+    chrome: &super::view_model::ChromeVm,
+    layout: &mut MouseFrame,
+) {
+    render_screen_vm_with_feedback(
+        frame,
+        state,
+        screen,
+        chrome,
+        layout,
+        &mut RenderFeedback::default(),
+    );
 }
 
 mod chrome;
@@ -104,7 +138,7 @@ mod tests {
         let backend = TestBackend::new(100, 40);
         let mut terminal = Terminal::new(backend).unwrap();
         let vm = super::super::build_view_model(state);
-        let mut layout = MouseLayout::default();
+        let mut layout = MouseFrame::default();
         terminal
             .draw(|frame| render_screen_vm(frame, state, &vm.screen, &vm.chrome, &mut layout))
             .unwrap();
@@ -201,7 +235,7 @@ mod tests {
         let backend = TestBackend::new(137, 20);
         let mut terminal = Terminal::new(backend).unwrap();
         let vm = super::super::build_view_model(&state);
-        let mut layout = MouseLayout::default();
+        let mut layout = MouseFrame::default();
         terminal
             .draw(|frame| render_screen_vm(frame, &state, &vm.screen, &vm.chrome, &mut layout))
             .unwrap();
@@ -235,7 +269,7 @@ mod tests {
         let backend = TestBackend::new(70, 20);
         let mut terminal = Terminal::new(backend).unwrap();
         let vm = super::super::build_view_model(&state);
-        let mut layout = MouseLayout::default();
+        let mut layout = MouseFrame::default();
         terminal
             .draw(|frame| render_screen_vm(frame, &state, &vm.screen, &vm.chrome, &mut layout))
             .unwrap();
@@ -269,7 +303,7 @@ mod tests {
         let backend = TestBackend::new(width, height);
         let mut terminal = Terminal::new(backend).unwrap();
         let vm = super::super::build_view_model(state);
-        let mut layout = MouseLayout::default();
+        let mut layout = MouseFrame::default();
         terminal
             .draw(|frame| render_screen_vm(frame, state, &vm.screen, &vm.chrome, &mut layout))
             .unwrap();
@@ -487,7 +521,7 @@ mod tests {
         let backend = TestBackend::new(width, height);
         let mut terminal = Terminal::new(backend).unwrap();
         let vm = super::super::build_view_model(state);
-        let mut layout = MouseLayout::default();
+        let mut layout = MouseFrame::default();
         terminal
             .draw(|frame| render_screen_vm(frame, state, &vm.screen, &vm.chrome, &mut layout))
             .unwrap();

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -18,8 +18,9 @@ pub(super) fn run_loop(
     if state.mouse_enabled {
         execute!(terminal.backend_mut(), EnableMouseCapture)?;
     }
-    let mut mouse_layout = MouseLayout::default();
-    let mut last_click: Option<(u16, u16, std::time::Instant)> = None;
+    let mut mouse_layout = MouseFrame::default();
+    let mut render_feedback = super::render::RenderFeedback::default();
+    let mut last_press_at: Option<std::time::Instant> = None;
 
     // Background "is a newer release available?" check — off-thread, throttled to once a day,
     // silent on failure. The result (if any) is absorbed in the loop below.
@@ -54,15 +55,13 @@ pub(super) fn run_loop(
         }
         pin_sync_screen_active = pins_active;
 
-        terminal.draw(|frame| render(frame, &state, &mut mouse_layout))?;
+        terminal.draw(|frame| render(frame, &state, &mut mouse_layout, &mut render_feedback))?;
         if state.detail().is_some_and(|d| d.comments_scroll_to_bottom) {
-            if let Some(max) = mouse_layout.comments_max_scroll {
+            if let Some(max) = render_feedback.comments_max_scroll {
                 if let Some(d) = state.detail_mut() {
                     d.scroll = max;
+                    d.comments_scroll_to_bottom = false;
                 }
-            }
-            if let Some(d) = state.detail_mut() {
-                d.comments_scroll_to_bottom = false;
             }
         }
         // Advance the spinner once per iteration; the poll below caps the loop at ~150ms, so
@@ -104,13 +103,21 @@ pub(super) fn run_loop(
                     MouseEventKind::ScrollUp => Some(super::MouseInput::ScrollUp),
                     MouseEventKind::ScrollDown => Some(super::MouseInput::ScrollDown),
                     MouseEventKind::Down(MouseButton::Left) => {
-                        let prev = last_click.map(|(c, r, _)| (c, r));
-                        let elapsed = last_click
-                            .map(|(_, _, t)| t.elapsed().as_millis())
+                        let elapsed = last_press_at
+                            .map(|t| t.elapsed().as_millis())
                             .unwrap_or(u128::MAX);
-                        let classified = super::classify_click(prev, elapsed, m.column, m.row);
-                        last_click = Some((m.column, m.row, std::time::Instant::now()));
-                        Some(classified)
+                        let kind = state.mouse_session.press(m.column, m.row, elapsed);
+                        last_press_at = Some(std::time::Instant::now());
+                        Some(match kind {
+                            PressKind::Click => super::MouseInput::Click {
+                                col: m.column,
+                                row: m.row,
+                            },
+                            PressKind::DoubleClick => super::MouseInput::DoubleClick {
+                                col: m.column,
+                                row: m.row,
+                            },
+                        })
                     }
                     MouseEventKind::Drag(MouseButton::Left) => {
                         Some(super::MouseInput::Drag { col: m.column })

--- a/src/tui/screens/config.rs
+++ b/src/tui/screens/config.rs
@@ -4,7 +4,8 @@
 use crate::tui::keys::{point_in, NavAction};
 use crate::tui::view_model::{ChromeVm, ConfigVm};
 use crate::tui::{
-    AppState, ConfigField, HelpTopic, KeyOutcome, MouseLayout, PaneHit, Screen, Theme,
+    AppState, ConfigField, HelpTopic, HitTarget, KeyOutcome, MouseFrame, PaneHit, PaneTarget,
+    Screen, Theme,
 };
 use crossterm::event::KeyCode;
 use ratatui::{
@@ -148,11 +149,11 @@ impl AppState {
     }
 
     /// Select the clicked field row on `Screen::Config`. Returns `true` when a row was hit.
-    pub(crate) fn click_select_config(&mut self, col: u16, row: u16, layout: &MouseLayout) -> bool {
+    pub(crate) fn click_select_config(&mut self, col: u16, row: u16, layout: &MouseFrame) -> bool {
         let Screen::Config(cfg) = &mut self.screen else {
             return false;
         };
-        if let Some(hit) = layout.list {
+        if let Some(hit) = layout.pane(PaneTarget::List) {
             if point_in(hit.rect, col, row) {
                 if let Some(idx) = hit.index_at(row, ConfigField::ALL.len()) {
                     cfg.index = idx;
@@ -191,7 +192,7 @@ pub(crate) fn render_config_vm(
     state: &AppState,
     config: &ConfigVm,
     chrome: &ChromeVm,
-    layout: &mut MouseLayout,
+    layout: &mut MouseFrame,
 ) {
     let area = frame.area();
     let area = crate::tui::render_top_bar(frame, area, &state.theme, chrome.mouse_enabled, layout);
@@ -232,15 +233,16 @@ pub(crate) fn render_config_vm(
         .highlight_symbol("▸ ");
     frame.render_stateful_widget(list, chunks[0], &mut list_state);
     if chrome.mouse_enabled {
-        layout.close_button = Some(crate::tui::render_close_button(
-            frame,
-            chunks[0],
-            &state.theme,
-        ));
-        layout.list = Some(PaneHit {
-            rect: chunks[0],
-            offset: 0,
-        });
+        let close = crate::tui::render_close_button(frame, chunks[0], &state.theme);
+        layout.register(HitTarget::Close, close);
+        layout.register_pane(
+            PaneTarget::List,
+            PaneHit {
+                rect: chunks[0],
+                offset: 0,
+            },
+            config.rows.len(),
+        );
     }
     if let Some(ref status) = config.status {
         frame.render_widget(

--- a/src/tui/screens/confirm.rs
+++ b/src/tui/screens/confirm.rs
@@ -3,7 +3,7 @@
 
 use crate::tui::bg::LoopFlow;
 use crate::tui::view_model::{ConfirmBackgroundVm, ConfirmModalKind, ConfirmVm};
-use crate::tui::{AppState, HelpTopic, KeyOutcome, MouseLayout, PendingAction, Screen};
+use crate::tui::{AppState, HelpTopic, HitTarget, KeyOutcome, MouseFrame, PendingAction, Screen};
 use crossterm::event::KeyCode;
 use ratatui::{style::Color, Frame};
 use std::path::PathBuf;
@@ -203,7 +203,7 @@ pub(crate) fn render_confirm_vm(
     state: &AppState,
     confirm: &ConfirmVm,
     chrome: &crate::tui::view_model::ChromeVm,
-    layout: &mut MouseLayout,
+    layout: &mut MouseFrame,
 ) {
     match &confirm.background {
         ConfirmBackgroundVm::CompactGist(bg) => {
@@ -238,11 +238,8 @@ pub(crate) fn render_confirm_vm(
     };
     if chrome.mouse_enabled {
         // Put the close button on the modal box itself, not the full-screen corner.
-        layout.close_button = Some(crate::tui::render::render_close_button(
-            frame,
-            modal,
-            &state.theme,
-        ));
+        let close = crate::tui::render::render_close_button(frame, modal, &state.theme);
+        layout.register(HitTarget::Close, close);
     }
 }
 

--- a/src/tui/screens/detail.rs
+++ b/src/tui/screens/detail.rs
@@ -8,7 +8,9 @@ use crate::tui::text::comment_lines_count;
 use crate::tui::view_model::{
     ChromeVm, CommentLineVm, CommentsAffordance, CommentsPaneVm, GistDetailVm,
 };
-use crate::tui::{AppState, DetailFocus, HelpTopic, KeyOutcome, MouseLayout, PaneHit};
+use crate::tui::{
+    AppState, DetailFocus, HelpTopic, HitTarget, KeyOutcome, MouseFrame, PaneHit, PaneTarget,
+};
 
 pub(crate) const HELP_TOPIC: HelpTopic = HelpTopic::GistDetail;
 
@@ -339,8 +341,8 @@ impl AppState {
 
     /// Select the clicked row on `Screen::GistDetail`'s Files tab, focusing it. Returns `true`
     /// when a row was hit (so a double-click should "open"/preview it).
-    pub(crate) fn click_select_detail(&mut self, col: u16, row: u16, layout: &MouseLayout) -> bool {
-        if let Some(hit) = layout.detail_files {
+    pub(crate) fn click_select_detail(&mut self, col: u16, row: u16, layout: &MouseFrame) -> bool {
+        if let Some(hit) = layout.pane(PaneTarget::DetailFiles) {
             if point_in(hit.rect, col, row) {
                 // Clicking the file list focuses the Files tab; a row also moves the cursor.
                 let count = self
@@ -367,34 +369,30 @@ impl AppState {
         &mut self,
         col: u16,
         row: u16,
-        layout: &MouseLayout,
+        layout: &MouseFrame,
     ) -> Option<KeyOutcome> {
         if !self.screen.is_gist_detail() {
             return None;
         }
-        if let Some(rect) = layout.detail_tab_files {
-            if point_in(rect, col, row) {
-                if let Some(d) = self.detail_mut() {
-                    d.focus = DetailFocus::Files;
-                }
-                return Some(KeyOutcome::None);
+        if matches!(layout.resolve(col, row), Some(HitTarget::DetailFilesTab)) {
+            if let Some(d) = self.detail_mut() {
+                d.focus = DetailFocus::Files;
             }
+            return Some(KeyOutcome::None);
         }
-        if let Some(rect) = layout.detail_tab_comments {
-            if point_in(rect, col, row) {
-                let fetch = if let Some(d) = self.detail_mut() {
-                    d.focus = DetailFocus::Comments;
-                    d.comments.is_none() && !d.comments_loading
-                } else {
-                    false
-                };
-                if fetch {
-                    if let Some(gist_id) = self.detail().and_then(|d| d.gist_id.clone()) {
-                        return Some(KeyOutcome::FetchComments { gist_id });
-                    }
+        if matches!(layout.resolve(col, row), Some(HitTarget::DetailCommentsTab)) {
+            let fetch = if let Some(d) = self.detail_mut() {
+                d.focus = DetailFocus::Comments;
+                d.comments.is_none() && !d.comments_loading
+            } else {
+                false
+            };
+            if fetch {
+                if let Some(gist_id) = self.detail().and_then(|d| d.gist_id.clone()) {
+                    return Some(KeyOutcome::FetchComments { gist_id });
                 }
-                return Some(KeyOutcome::None);
             }
+            return Some(KeyOutcome::None);
         }
         None
     }
@@ -404,7 +402,7 @@ impl AppState {
         &mut self,
         col: u16,
         row: u16,
-        layout: &MouseLayout,
+        layout: &MouseFrame,
     ) -> Option<KeyOutcome> {
         if !self.screen.is_gist_detail()
             || !self
@@ -413,8 +411,9 @@ impl AppState {
         {
             return None;
         }
-        let rect = layout.comments_load_older?;
-        if point_in(rect, col, row) && self.can_load_older_comments() {
+        if matches!(layout.resolve(col, row), Some(HitTarget::CommentsLoadOlder))
+            && self.can_load_older_comments()
+        {
             if let Some(gist_id) = self.detail().and_then(|d| d.gist_id.clone()) {
                 let page = self
                     .detail()
@@ -674,7 +673,8 @@ pub(crate) fn render_gist_detail_vm(
     state: &AppState,
     detail: &GistDetailVm,
     chrome: &ChromeVm,
-    layout: &mut MouseLayout,
+    layout: &mut MouseFrame,
+    feedback: &mut crate::tui::render::RenderFeedback,
 ) {
     let area = frame.area();
     let area = crate::tui::render_top_bar(frame, area, &state.theme, chrome.mouse_enabled, layout);
@@ -699,9 +699,14 @@ pub(crate) fn render_gist_detail_vm(
             DetailFocus::Files => {
                 render_gist_file_list_vm(frame, chunks[1], detail, chrome, &state.theme, layout)
             }
-            DetailFocus::Comments => {
-                render_gist_comments_vm(frame, chunks[1], &detail.comments, &state.theme, layout)
-            }
+            DetailFocus::Comments => render_gist_comments_vm(
+                frame,
+                chunks[1],
+                &detail.comments,
+                &state.theme,
+                layout,
+                feedback,
+            ),
         }
     }
     crate::tui::render_footer(
@@ -717,10 +722,7 @@ pub(crate) fn render_gist_detail_vm(
     let edit_modal = if let Some(input) = &detail.description_input {
         // The modal covers the file list and tabs; drop their hit regions so a click
         // behind the modal doesn't move the cursor or switch tabs.
-        layout.detail_files = None;
-        layout.detail_tab_files = None;
-        layout.detail_tab_comments = None;
-        layout.comments_load_older = None;
+        layout.clear();
         Some(crate::tui::render::render_centered_modal_input(
             frame,
             "Edit description (Enter apply · Esc cancel)",
@@ -736,11 +738,9 @@ pub(crate) fn render_gist_detail_vm(
     if chrome.mouse_enabled {
         // When the edit-description modal is open, the close button belongs on it;
         // otherwise it sits on the full-screen detail view's top-right corner.
-        layout.close_button = Some(crate::tui::render_close_button(
-            frame,
-            edit_modal.unwrap_or(area),
-            &state.theme,
-        ));
+        let close =
+            crate::tui::render_close_button(frame, edit_modal.unwrap_or(area), &state.theme);
+        layout.register(HitTarget::Close, close);
     }
 }
 
@@ -750,7 +750,7 @@ fn render_detail_header_vm(
     detail: &GistDetailVm,
     chrome: &ChromeVm,
     theme: &crate::tui::Theme,
-    layout: &mut MouseLayout,
+    layout: &mut MouseFrame,
 ) {
     let lines = vec![
         Line::from(detail.info_line.clone()),
@@ -777,14 +777,15 @@ fn render_detail_header_vm(
         // count, so derive its click target from the same formatted label as the renderer.
         let content_x = area.x + 2;
         let tabs_y = area.y + 2;
-        layout.detail_tab_files = Some(ratatui::layout::Rect::new(content_x, tabs_y, 7, 1));
+        layout.register(
+            HitTarget::DetailFilesTab,
+            ratatui::layout::Rect::new(content_x, tabs_y, 7, 1),
+        );
         let comments_width = format!(" Comments ({}) ", detail.comments_count).len() as u16;
-        layout.detail_tab_comments = Some(ratatui::layout::Rect::new(
-            content_x + 10,
-            tabs_y,
-            comments_width,
-            1,
-        ));
+        layout.register(
+            HitTarget::DetailCommentsTab,
+            ratatui::layout::Rect::new(content_x + 10, tabs_y, comments_width, 1),
+        );
     }
 }
 
@@ -795,7 +796,7 @@ fn render_gist_file_list_vm(
     detail: &GistDetailVm,
     chrome: &ChromeVm,
     theme: &crate::tui::Theme,
-    layout: &mut MouseLayout,
+    layout: &mut MouseFrame,
 ) {
     let file_list_height = u16::try_from(detail.files.len().saturating_add(2))
         .unwrap_or(u16::MAX)
@@ -806,7 +807,11 @@ fn render_gist_file_list_vm(
     let visible_rows = (area.height as usize).saturating_sub(2);
     let offset = crate::tui::render::file_list_scroll(cursor, visible_rows, files.len());
     if chrome.mouse_enabled {
-        layout.detail_files = Some(PaneHit { rect: area, offset });
+        layout.register_pane(
+            PaneTarget::DetailFiles,
+            PaneHit { rect: area, offset },
+            files.len(),
+        );
     }
     let lines = crate::tui::render::file_rows(files, cursor, offset, visible_rows, true, theme);
     frame.render_widget(
@@ -832,7 +837,8 @@ fn render_gist_comments_vm(
     area: ratatui::layout::Rect,
     comments: &CommentsPaneVm,
     theme: &crate::tui::Theme,
-    layout: &mut MouseLayout,
+    layout: &mut MouseFrame,
+    feedback: &mut crate::tui::render::RenderFeedback,
 ) {
     let mut body: Vec<Line> = Vec::new();
     let mut affordance_present = false;
@@ -901,20 +907,16 @@ fn render_gist_comments_vm(
         }
     }
 
-    layout.comments_load_older = if affordance_present {
-        Some(ratatui::layout::Rect::new(
-            area.x + 1,
-            area.y + 1,
-            area.width.saturating_sub(2),
-            1,
-        ))
-    } else {
-        None
-    };
+    if affordance_present {
+        layout.register(
+            HitTarget::CommentsLoadOlder,
+            ratatui::layout::Rect::new(area.x + 1, area.y + 1, area.width.saturating_sub(2), 1),
+        );
+    }
 
     let total_lines = body.len();
     let inner_rows = area.height.saturating_sub(2);
-    layout.comments_max_scroll = Some((total_lines as u16).saturating_sub(inner_rows));
+    feedback.comments_max_scroll = Some((total_lines as u16).saturating_sub(inner_rows));
 
     frame.render_widget(
         Paragraph::new(body)
@@ -1382,7 +1384,7 @@ mod tests {
         detail_mut(&mut state).focus = DetailFocus::Comments;
         detail_mut(&mut state).comments = Some(Vec::new());
         assert_eq!(detail_ref(&state).scroll, 0);
-        state.handle_mouse(MouseInput::ScrollDown, &MouseLayout::default());
+        state.handle_mouse(MouseInput::ScrollDown, &MouseFrame::default());
         assert_eq!(detail_ref(&state).scroll, 3);
     }
 
@@ -1396,10 +1398,8 @@ mod tests {
             rect: Rect::new(0, 0, 40, 10),
             offset: 0,
         };
-        let layout = MouseLayout {
-            detail_files: Some(hit),
-            ..Default::default()
-        };
+        let mut layout = MouseFrame::default();
+        layout.register_pane(PaneTarget::DetailFiles, hit, 2);
         // Click the 2nd file row -> Files focus + cursor 1, but no open yet.
         let out = state.handle_mouse(MouseInput::Click { col: 5, row: 2 }, &layout);
         assert_eq!(out, KeyOutcome::None);
@@ -1423,11 +1423,9 @@ mod tests {
         detail_mut(&mut state).gist_id = Some("g1".into());
         detail_mut(&mut state).focus = DetailFocus::Files;
         // Header at chunks[0] y=0: content_x = 2, tabs_y = 2; " Files " (7), " Comments " (10 @ +10).
-        let layout = MouseLayout {
-            detail_tab_files: Some(Rect::new(2, 2, 7, 1)),
-            detail_tab_comments: Some(Rect::new(12, 2, 10, 1)),
-            ..Default::default()
-        };
+        let mut layout = MouseFrame::default();
+        layout.register(HitTarget::DetailFilesTab, Rect::new(2, 2, 7, 1));
+        layout.register(HitTarget::DetailCommentsTab, Rect::new(12, 2, 10, 1));
         // Click the Comments tab: switches focus and (comments unloaded) requests a fetch.
         let out = state.handle_mouse(MouseInput::Click { col: 14, row: 2 }, &layout);
         assert_eq!(detail_ref(&state).focus, DetailFocus::Comments);
@@ -1446,7 +1444,7 @@ mod tests {
         detail_mut(&mut state).gist_id = Some("g1".into());
         detail_mut(&mut state).focus = DetailFocus::Files;
         detail_mut(&mut state).file_cursor = 0;
-        state.handle_mouse(MouseInput::ScrollDown, &MouseLayout::default());
+        state.handle_mouse(MouseInput::ScrollDown, &MouseFrame::default());
         assert_eq!(detail_ref(&state).file_cursor, 1);
     }
 

--- a/src/tui/screens/diff.rs
+++ b/src/tui/screens/diff.rs
@@ -4,7 +4,7 @@
 use crate::tui::bg::{record_pin_sync, refresh_locals, LocalScanMode, LoopFlow};
 use crate::tui::render::{diff_labels, preview_diff_text};
 use crate::tui::view_model::{ChromeVm, DiffVm};
-use crate::tui::{AppState, HelpTopic, KeyOutcome, PendingAction};
+use crate::tui::{AppState, HelpTopic, HitTarget, KeyOutcome, PendingAction};
 use crossterm::event::KeyCode;
 use ratatui::{
     layout::{Constraint, Direction, Layout},
@@ -219,7 +219,7 @@ pub(crate) fn render_diff_vm(
     state: &AppState,
     diff: &DiffVm,
     chrome: &ChromeVm,
-    layout: &mut crate::tui::MouseLayout,
+    layout: &mut crate::tui::MouseFrame,
 ) {
     let area = frame.area();
     let area = crate::tui::render_top_bar(frame, area, &state.theme, chrome.mouse_enabled, layout);
@@ -242,7 +242,8 @@ pub(crate) fn render_diff_vm(
         &state.theme,
     );
     if chrome.mouse_enabled {
-        layout.close_button = Some(crate::tui::render_close_button(frame, area, &state.theme));
+        let close = crate::tui::render_close_button(frame, area, &state.theme);
+        layout.register(HitTarget::Close, close);
     }
 }
 

--- a/src/tui/screens/gists.rs
+++ b/src/tui/screens/gists.rs
@@ -6,7 +6,7 @@ use crate::tui::render::list_pane::render_list_pane;
 use crate::tui::view_model::{
     ChromeVm, GistsVm, ListPaneEmpty, ListPaneVm, PaneTitleVm, RowEmphasis, RowVm,
 };
-use crate::tui::{AppState, HelpTopic, KeyOutcome, MouseLayout, Screen};
+use crate::tui::{AppState, HelpTopic, HitTarget, KeyOutcome, MouseFrame, PaneTarget, Screen};
 use crossterm::event::KeyCode;
 use ratatui::{
     layout::{Constraint, Direction, Layout},
@@ -122,8 +122,8 @@ impl AppState {
 
     /// Select the clicked row on `Screen::Gists`, moving the list cursor. Returns `true` when
     /// a row was hit.
-    pub(crate) fn click_select_gists(&mut self, col: u16, row: u16, layout: &MouseLayout) -> bool {
-        if let Some(hit) = layout.list {
+    pub(crate) fn click_select_gists(&mut self, col: u16, row: u16, layout: &MouseFrame) -> bool {
+        if let Some(hit) = layout.pane(PaneTarget::List) {
             if point_in(hit.rect, col, row) {
                 let count = self.visible_gist_groups().len();
                 if let Some(idx) = hit.index_at(row, count) {
@@ -229,7 +229,7 @@ pub(crate) fn render_gists_vm(
     state: &AppState,
     gists: &GistsVm,
     chrome: &ChromeVm,
-    layout: &mut MouseLayout,
+    layout: &mut MouseFrame,
 ) {
     let area = frame.area();
     let area = crate::tui::render_top_bar(frame, area, &state.theme, chrome.mouse_enabled, layout);
@@ -253,7 +253,8 @@ pub(crate) fn render_gists_vm(
         &gists.pane,
         &state.theme,
         chrome.mouse_enabled,
-        &mut layout.list,
+        layout,
+        PaneTarget::List,
     );
 
     if gists.filtering {
@@ -277,7 +278,8 @@ pub(crate) fn render_gists_vm(
         );
     }
     if chrome.mouse_enabled {
-        layout.close_button = Some(crate::tui::render_close_button(frame, area, &state.theme));
+        let close = crate::tui::render_close_button(frame, area, &state.theme);
+        layout.register(HitTarget::Close, close);
     }
 }
 
@@ -558,10 +560,8 @@ mod tests {
             rect: Rect::new(0, 0, 40, 10),
             offset: 0,
         };
-        let layout = MouseLayout {
-            list: Some(hit),
-            ..Default::default()
-        };
+        let mut layout = MouseFrame::default();
+        layout.register_pane(PaneTarget::List, hit, 2);
         // Row 2 is the 2nd content row (border at row 0) -> idx 1.
         let out = state.handle_mouse(MouseInput::Click { col: 5, row: 2 }, &layout);
         assert_eq!(out, KeyOutcome::None);

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -3,7 +3,9 @@
 
 use crate::tui::keys::{point_in, NavAction, PAGE_SCROLL};
 use crate::tui::view_model::{ChromeVm, HelpIndexItemVm, HelpModeVm, HelpVm};
-use crate::tui::{AppState, HelpState, HelpTopic, KeyOutcome, MouseLayout, PaneHit, Screen};
+use crate::tui::{
+    AppState, HelpState, HelpTopic, HitTarget, KeyOutcome, MouseFrame, PaneHit, PaneTarget, Screen,
+};
 use crossterm::event::KeyCode;
 use ratatui::{
     layout::Rect,
@@ -144,11 +146,11 @@ impl AppState {
     /// Select the clicked topic-index row on `Screen::Help`. Only set when the topic index is
     /// open (render_help), so this is a no-op while viewing a topic's body. Returns `true`
     /// when a row was hit.
-    pub(crate) fn click_select_help(&mut self, col: u16, row: u16, layout: &MouseLayout) -> bool {
+    pub(crate) fn click_select_help(&mut self, col: u16, row: u16, layout: &MouseFrame) -> bool {
         let Screen::Help(help) = &mut self.screen else {
             return false;
         };
-        if let Some(hit) = layout.list {
+        if let Some(hit) = layout.pane(PaneTarget::List) {
             if point_in(hit.rect, col, row) {
                 if let Some(idx) = hit.index_at(row, HelpTopic::all().len()) {
                     help.index_sel = idx;
@@ -202,7 +204,7 @@ pub(crate) fn build_help_vm(state: &AppState) -> HelpVm {
 }
 
 /// Fixed row (0-indexed, within the topic body) of the clickable repo-URL line — used to
-/// place `MouseLayout::repo_link`'s hit-rect. Kept stable regardless of update-check state
+/// place `MouseFrame::repo_link`'s hit-rect. Kept stable regardless of update-check state
 /// (see `about_topic_lines`) so this constant never has to change.
 pub(crate) const ABOUT_REPO_LINE: usize = 2;
 
@@ -433,7 +435,7 @@ pub(crate) fn render_help_vm(
     state: &AppState,
     help: &HelpVm,
     chrome: &ChromeVm,
-    layout: &mut MouseLayout,
+    layout: &mut MouseFrame,
 ) {
     let area = frame.area();
     let area = crate::tui::render_top_bar(frame, area, &state.theme, chrome.mouse_enabled, layout);
@@ -467,10 +469,14 @@ pub(crate) fn render_help_vm(
             list_state.select(Some(*selected));
             frame.render_stateful_widget(list, area, &mut list_state);
             if chrome.mouse_enabled {
-                layout.list = Some(PaneHit {
-                    rect: area,
-                    offset: list_state.offset(),
-                });
+                layout.register_pane(
+                    PaneTarget::List,
+                    PaneHit {
+                        rect: area,
+                        offset: list_state.offset(),
+                    },
+                    items.len(),
+                );
             }
         }
         HelpModeVm::Topic {
@@ -527,18 +533,22 @@ pub(crate) fn render_help_vm(
                 let visible_row = repo_line as i32 - *scroll as i32;
                 let inner_height = area.height.saturating_sub(2);
                 if visible_row >= 0 && (visible_row as u16) < inner_height {
-                    layout.repo_link = Some(Rect::new(
-                        area.x + 1,
-                        area.y + 1 + visible_row as u16,
-                        area.width.saturating_sub(2),
-                        1,
-                    ));
+                    layout.register(
+                        HitTarget::Repo,
+                        Rect::new(
+                            area.x + 1,
+                            area.y + 1 + visible_row as u16,
+                            area.width.saturating_sub(2),
+                            1,
+                        ),
+                    );
                 }
             }
         }
     }
     if chrome.mouse_enabled {
-        layout.close_button = Some(crate::tui::render_close_button(frame, area, &state.theme));
+        let close = crate::tui::render_close_button(frame, area, &state.theme);
+        layout.register(HitTarget::Close, close);
     }
 }
 
@@ -666,10 +676,8 @@ mod tests {
     fn close_button_click_outside_is_noop() {
         let mut state = state_with_gists();
         state.screen = Screen::Help(Box::default());
-        let layout = MouseLayout {
-            close_button: Some(Rect::new(36, 0, 5, 1)),
-            ..Default::default()
-        };
+        let mut layout = MouseFrame::default();
+        layout.register(HitTarget::Close, Rect::new(36, 0, 5, 1));
         // col 35 is just outside the left edge of the close button
         let out = state.handle_mouse(MouseInput::Click { col: 35, row: 0 }, &layout);
         assert_eq!(out, KeyOutcome::None);
@@ -684,10 +692,8 @@ mod tests {
             rect: Rect::new(20, 0, 20, 10),
             offset: 0,
         };
-        let layout = MouseLayout {
-            gist: Some(hit),
-            ..Default::default()
-        };
+        let mut layout = MouseFrame::default();
+        layout.register_pane(PaneTarget::Gist, hit, 1);
         let before_screen = state.screen.clone();
         let out = state.handle_mouse(MouseInput::Click { col: 25, row: 1 }, &layout);
         assert_eq!(out, KeyOutcome::None);
@@ -701,7 +707,7 @@ mod tests {
         state.screen = Screen::Help(Box::default());
         help_mut(&mut state).index_open = false;
         help_mut(&mut state).scroll = 0;
-        state.handle_mouse(MouseInput::ScrollDown, &MouseLayout::default());
+        state.handle_mouse(MouseInput::ScrollDown, &MouseFrame::default());
         assert_eq!(help_ref(&state).scroll, 3);
     }
 
@@ -712,7 +718,7 @@ mod tests {
         state.screen = Screen::Help(Box::default());
         help_mut(&mut state).index_open = true;
         help_mut(&mut state).index_sel = 0;
-        state.handle_mouse(MouseInput::ScrollDown, &MouseLayout::default());
+        state.handle_mouse(MouseInput::ScrollDown, &MouseFrame::default());
         assert_eq!(help_ref(&state).index_sel, 1);
     }
 
@@ -725,10 +731,8 @@ mod tests {
             rect: Rect::new(0, 0, 40, 15),
             offset: 0,
         };
-        let layout = MouseLayout {
-            list: Some(hit),
-            ..Default::default()
-        };
+        let mut layout = MouseFrame::default();
+        layout.register_pane(PaneTarget::List, hit, usize::MAX);
         // Row 2 is the 2nd content row (border at row 0) -> idx 1 (Pins).
         let out = state.handle_mouse(MouseInput::Click { col: 5, row: 2 }, &layout);
         assert_eq!(out, KeyOutcome::None);

--- a/src/tui/screens/list.rs
+++ b/src/tui/screens/list.rs
@@ -8,8 +8,8 @@ use crate::tui::view_model::{
     ChromeVm, ListFooterVm, ListPaneEmpty, ListPaneVm, ListVm, PaneTitleVm, RowEmphasis, RowVm,
 };
 use crate::tui::{
-    AppState, FocusPane, GistView, HelpTopic, KeyOutcome, MouseLayout, PendingAction, Screen,
-    SplitHit,
+    AppState, FocusPane, GistView, HelpTopic, HitTarget, KeyOutcome, MouseFrame, PaneTarget,
+    PendingAction, Screen, SplitHit,
 };
 use crossterm::event::KeyCode;
 
@@ -501,10 +501,10 @@ impl AppState {
     /// a resize to mean anything. Both the grab and the double-click reset go through it, so
     /// a too-narrow terminal swallows neither press — they fall through to the normal
     /// focus/select handling instead of being eaten by a gesture that can only be clamped
-    /// away. It lives here rather than on `MouseLayout` because the width policy is the List
+    /// away. It lives here rather than on `MouseFrame` because the width policy is the List
     /// screen's (`clamp_split_percent`), not the hit map's.
-    fn grabbable_divider(&self, col: u16, row: u16, layout: &MouseLayout) -> bool {
-        layout.list_split.is_some_and(|hit| {
+    fn grabbable_divider(&self, col: u16, row: u16, layout: &MouseFrame) -> bool {
+        layout.split().is_some_and(|hit| {
             hit.grabbed(col, row)
                 && clamp_split_percent(self.list_split_percent, hit.area.width).is_some()
         })
@@ -512,21 +512,21 @@ impl AppState {
 
     /// Grab the divider if the press landed on it, starting a drag. Returns `true` when
     /// grabbed, so the caller can skip the click's usual focus/select handling.
-    pub(crate) fn grab_split_divider(&mut self, col: u16, row: u16, layout: &MouseLayout) -> bool {
+    pub(crate) fn grab_split_divider(&mut self, col: u16, row: u16, layout: &MouseFrame) -> bool {
         let grabbed = self.grabbable_divider(col, row, layout);
         if grabbed {
-            self.list_split_drag = true;
+            self.mouse_session.begin_divider_drag();
         }
         grabbed
     }
 
     /// Move the divider under `col` while a drag is in progress. Only `col` is consulted:
     /// letting the pointer wander above or below the panes must not break the drag.
-    pub(crate) fn drag_split_divider(&mut self, col: u16, layout: &MouseLayout) {
-        if !self.list_split_drag {
+    pub(crate) fn drag_split_divider(&mut self, col: u16, layout: &MouseFrame) {
+        if !self.mouse_session.is_dragging() {
             return;
         }
-        let Some(hit) = layout.list_split else {
+        let Some(hit) = layout.split() else {
             return;
         };
         if let Some(percent) = clamp_split_percent(percent_for_col(hit.area, col), hit.area.width) {
@@ -536,17 +536,13 @@ impl AppState {
 
     /// End any divider drag. Called on mouse-up and whenever a background-task overlay
     /// takes over the mouse, which would otherwise swallow the release and wedge the drag.
-    pub(crate) fn end_split_drag(&mut self) {
-        self.list_split_drag = false;
-    }
-
     /// Restore the default split — the double-click action on the divider. Returns `true`
     /// when the double-click landed on it.
-    pub(crate) fn reset_split_divider(&mut self, col: u16, row: u16, layout: &MouseLayout) -> bool {
+    pub(crate) fn reset_split_divider(&mut self, col: u16, row: u16, layout: &MouseFrame) -> bool {
         let grabbed = self.grabbable_divider(col, row, layout);
         if grabbed {
             self.list_split_percent = DEFAULT_SPLIT_PERCENT;
-            self.list_split_drag = false;
+            self.mouse_session.interrupt();
         }
         grabbed
     }
@@ -554,8 +550,8 @@ impl AppState {
     /// Select the clicked row on `Screen::List`, focusing its pane. Returns `true` when a row
     /// was hit (so a double-click should "open" it). A click in a pane's blank area or border
     /// focuses it but selects nothing (returns `false`); a click off every list returns `false`.
-    pub(crate) fn click_select_list(&mut self, col: u16, row: u16, layout: &MouseLayout) -> bool {
-        if let Some(hit) = layout.local {
+    pub(crate) fn click_select_list(&mut self, col: u16, row: u16, layout: &MouseFrame) -> bool {
+        if let Some(hit) = layout.pane(PaneTarget::Local) {
             if point_in(hit.rect, col, row) {
                 // A click anywhere in the pane (incl. blank/border) focuses it; a
                 // click on a row also selects it.
@@ -571,7 +567,7 @@ impl AppState {
                 return false;
             }
         }
-        if let Some(hit) = layout.gist {
+        if let Some(hit) = layout.pane(PaneTarget::Gist) {
             if point_in(hit.rect, col, row) {
                 self.focus = FocusPane::Gist;
                 if let Some(idx) = hit.index_at(row, self.ranked_gists().len()) {
@@ -753,7 +749,7 @@ pub(crate) fn build_list_vm(state: &AppState) -> ListVm {
         },
         footer,
         split_percent: state.list_split_percent,
-        split_dragging: state.list_split_drag,
+        split_dragging: state.mouse_session.is_dragging(),
     }
 }
 
@@ -772,7 +768,7 @@ pub(crate) fn render_list_vm(
     state: &AppState,
     list: &ListVm,
     chrome: &ChromeVm,
-    layout: &mut MouseLayout,
+    layout: &mut MouseFrame,
 ) {
     let area = frame.area();
     let area = crate::tui::render_top_bar(frame, area, &state.theme, chrome.mouse_enabled, layout);
@@ -819,7 +815,8 @@ pub(crate) fn render_list_vm(
         &list.local,
         &state.theme,
         chrome.mouse_enabled,
-        &mut layout.local,
+        layout,
+        PaneTarget::Local,
     );
     render_list_pane(
         frame,
@@ -827,7 +824,8 @@ pub(crate) fn render_list_vm(
         &list.gist,
         &state.theme,
         chrome.mouse_enabled,
-        &mut layout.gist,
+        layout,
+        PaneTarget::Gist,
     );
 
     let divider_x = columns[0].right().saturating_sub(1);
@@ -835,10 +833,11 @@ pub(crate) fn render_list_vm(
         highlight_pane_divider(frame, chunks[0], divider_x, state.theme.accent);
     }
     if chrome.mouse_enabled {
-        layout.list_split = Some(SplitHit {
+        let split = SplitHit {
             area: chunks[0],
             divider_x,
-        });
+        };
+        layout.register(HitTarget::Divider(split), split.area);
     }
 
     match &list.footer {
@@ -1175,7 +1174,7 @@ mod tests {
         state.screen = Screen::List;
         state.focus = FocusPane::Local;
         state.local_index = 0;
-        let out = state.handle_mouse(MouseInput::ScrollDown, &MouseLayout::default());
+        let out = state.handle_mouse(MouseInput::ScrollDown, &MouseFrame::default());
         assert_eq!(out, KeyOutcome::None);
         assert_eq!(state.local_index, 1);
     }
@@ -1186,7 +1185,7 @@ mod tests {
         state.screen = Screen::List;
         state.focus = FocusPane::Local;
         state.local_index = 2;
-        let out = state.handle_mouse(MouseInput::ScrollUp, &MouseLayout::default());
+        let out = state.handle_mouse(MouseInput::ScrollUp, &MouseFrame::default());
         assert_eq!(out, KeyOutcome::None);
         assert_eq!(state.local_index, 1);
     }
@@ -1201,10 +1200,8 @@ mod tests {
             rect: Rect::new(20, 0, 20, 10),
             offset: 0,
         };
-        let layout = MouseLayout {
-            gist: Some(hit),
-            ..Default::default()
-        };
+        let mut layout = MouseFrame::default();
+        layout.register_pane(PaneTarget::Gist, hit, 2);
         // row 2 -> content idx 1 (top border is row 0, row 1 = idx 0, row 2 = idx 1)
         let out = state.handle_mouse(MouseInput::Click { col: 25, row: 2 }, &layout);
         assert_eq!(out, KeyOutcome::None);
@@ -1224,10 +1221,8 @@ mod tests {
             rect: Rect::new(0, 0, 20, 10),
             offset: 0,
         };
-        let layout = MouseLayout {
-            local: Some(hit),
-            ..Default::default()
-        };
+        let mut layout = MouseFrame::default();
+        layout.register_pane(PaneTarget::Local, hit, 3);
         // row 1 -> idx 0 (first content row after top border)
         let out = state.handle_mouse(MouseInput::Click { col: 5, row: 1 }, &layout);
         assert_eq!(out, KeyOutcome::None);
@@ -1244,10 +1239,8 @@ mod tests {
             rect: Rect::new(20, 0, 20, 10),
             offset: 0,
         };
-        let layout = MouseLayout {
-            gist: Some(hit),
-            ..Default::default()
-        };
+        let mut layout = MouseFrame::default();
+        layout.register_pane(PaneTarget::Gist, hit, 2);
         // row 1 -> idx 0 (first gist)
         let out = state.handle_mouse(MouseInput::DoubleClick { col: 25, row: 1 }, &layout);
         assert_eq!(state.focus, FocusPane::Gist);
@@ -1265,10 +1258,8 @@ mod tests {
             rect: Rect::new(20, 0, 20, 4),
             offset: 0,
         };
-        let layout = MouseLayout {
-            gist: Some(hit),
-            ..Default::default()
-        };
+        let mut layout = MouseFrame::default();
+        layout.register_pane(PaneTarget::Gist, hit, 2);
         // row 0 is the top border (no row there): clicking the gist pane's blank/border area
         // switches focus to it but selects nothing.
         let out = state.handle_mouse(MouseInput::Click { col: 25, row: 0 }, &layout);
@@ -1284,7 +1275,7 @@ mod tests {
         state.screen = Screen::List;
         state.focus = FocusPane::Local;
         state.local_index = 0;
-        state.handle_mouse(MouseInput::ScrollDown, &MouseLayout::default());
+        state.handle_mouse(MouseInput::ScrollDown, &MouseFrame::default());
         assert_eq!(state.local_index, 0);
     }
 
@@ -2339,14 +2330,14 @@ mod tests {
     }
 
     /// A `SplitHit` for a 100-column List screen split at the default 40%.
-    fn split_layout() -> MouseLayout {
-        MouseLayout {
-            list_split: Some(SplitHit {
-                area: Rect::new(0, 1, 100, 20),
-                divider_x: 39,
-            }),
-            ..Default::default()
-        }
+    fn split_layout() -> MouseFrame {
+        let mut layout = MouseFrame::default();
+        let split = SplitHit {
+            area: Rect::new(0, 1, 100, 20),
+            divider_x: 39,
+        };
+        layout.register(HitTarget::Divider(split), split.area);
+        layout
     }
 
     #[test]
@@ -2359,13 +2350,13 @@ mod tests {
             state.handle_mouse(MouseInput::Click { col: 39, row: 5 }, &layout),
             KeyOutcome::None
         );
-        assert!(state.list_split_drag);
+        assert!(state.mouse_session.is_dragging());
 
         state.handle_mouse(MouseInput::Drag { col: 59 }, &layout);
         assert_eq!(state.list_split_percent, 60);
 
         state.handle_mouse(MouseInput::Release, &layout);
-        assert!(!state.list_split_drag);
+        assert!(!state.mouse_session.is_dragging());
         // A release after the drag must not keep resizing.
         state.handle_mouse(MouseInput::Drag { col: 20 }, &layout);
         assert_eq!(state.list_split_percent, 60);
@@ -2379,13 +2370,17 @@ mod tests {
         state.local_index = 1;
         let mut layout = split_layout();
         // The local pane reaches the divider, so without the grab check this would focus it.
-        layout.local = Some(PaneHit {
-            rect: Rect::new(0, 1, 40, 20),
-            offset: 0,
-        });
+        layout.register_pane(
+            PaneTarget::Local,
+            PaneHit {
+                rect: Rect::new(0, 1, 40, 20),
+                offset: 0,
+            },
+            2,
+        );
 
         state.handle_mouse(MouseInput::Click { col: 39, row: 5 }, &layout);
-        assert!(state.list_split_drag);
+        assert!(state.mouse_session.is_dragging());
         assert_eq!(state.focus, FocusPane::Gist);
         assert_eq!(state.local_index, 1);
     }
@@ -2397,13 +2392,19 @@ mod tests {
             let mut state = state_with_local_paths(&["a.rs"]);
             state.screen = Screen::List;
             state.handle_mouse(MouseInput::Click { col, row: 5 }, &layout);
-            assert!(state.list_split_drag, "col {col} missed the divider");
+            assert!(
+                state.mouse_session.is_dragging(),
+                "col {col} missed the divider"
+            );
         }
         for col in [37, 42] {
             let mut state = state_with_local_paths(&["a.rs"]);
             state.screen = Screen::List;
             state.handle_mouse(MouseInput::Click { col, row: 5 }, &layout);
-            assert!(!state.list_split_drag, "col {col} grabbed the divider");
+            assert!(
+                !state.mouse_session.is_dragging(),
+                "col {col} grabbed the divider"
+            );
         }
     }
 
@@ -2436,17 +2437,20 @@ mod tests {
         state.screen = Screen::List;
         state.focus = FocusPane::Gist;
         let width = MIN_PANE_CELLS * 2 - 1;
-        let layout = MouseLayout {
-            list_split: Some(SplitHit {
-                area: Rect::new(0, 1, width, 20),
-                divider_x: width / 2,
-            }),
-            local: Some(PaneHit {
+        let mut layout = MouseFrame::default();
+        let split = SplitHit {
+            area: Rect::new(0, 1, width, 20),
+            divider_x: width / 2,
+        };
+        layout.register(HitTarget::Divider(split), split.area);
+        layout.register_pane(
+            PaneTarget::Local,
+            PaneHit {
                 rect: Rect::new(0, 1, width / 2 + 1, 20),
                 offset: 0,
-            }),
-            ..Default::default()
-        };
+            },
+            2,
+        );
         state.handle_mouse(
             MouseInput::Click {
                 col: width / 2,
@@ -2454,7 +2458,7 @@ mod tests {
             },
             &layout,
         );
-        assert!(!state.list_split_drag);
+        assert!(!state.mouse_session.is_dragging());
         // The press is not swallowed: it focuses the pane it landed in, as any other click would.
         assert_eq!(state.focus, FocusPane::Local);
 
@@ -2472,7 +2476,7 @@ mod tests {
         let layout = split_layout();
         state.handle_mouse(MouseInput::Drag { col: 70 }, &layout);
         assert_eq!(state.list_split_percent, DEFAULT_SPLIT_PERCENT);
-        assert!(!state.list_split_drag);
+        assert!(!state.mouse_session.is_dragging());
     }
 
     #[test]
@@ -2486,7 +2490,7 @@ mod tests {
             KeyOutcome::None
         );
         assert_eq!(state.list_split_percent, DEFAULT_SPLIT_PERCENT);
-        assert!(!state.list_split_drag);
+        assert!(!state.mouse_session.is_dragging());
     }
 
     #[test]
@@ -2497,7 +2501,7 @@ mod tests {
         let vm = build_list_vm(&state);
         assert_eq!(vm.split_percent, 55);
         assert!(!vm.split_dragging);
-        state.list_split_drag = true;
+        state.mouse_session.begin_divider_drag();
         assert!(build_list_vm(&state).split_dragging);
     }
 
@@ -2511,7 +2515,7 @@ mod tests {
         let backend = ratatui::backend::TestBackend::new(100, 20);
         let mut terminal = ratatui::Terminal::new(backend).unwrap();
         let vm = crate::tui::build_view_model(&state);
-        let mut layout = MouseLayout::default();
+        let mut layout = MouseFrame::default();
         let ScreenVm::List(list) = &vm.screen else {
             panic!("not the List screen");
         };
@@ -2525,7 +2529,7 @@ mod tests {
         assert_eq!(buffer.cell((40, 2)).unwrap().symbol(), "│");
         assert_eq!(buffer.cell((20, 2)).unwrap().symbol(), " ");
 
-        let hit = layout.list_split.expect("divider hit recorded");
+        let hit = layout.split().expect("divider hit recorded");
         assert_eq!(hit.divider_x, 39);
         assert_eq!(hit.area.width, 100);
     }

--- a/src/tui/screens/mod.rs
+++ b/src/tui/screens/mod.rs
@@ -10,7 +10,7 @@
 
 use super::keys::NavAction;
 use super::view_model::ScreenVm;
-use super::{AppState, HelpTopic, KeyOutcome, MouseLayout, Screen};
+use super::{AppState, HelpTopic, KeyOutcome, MouseFrame, Screen};
 use crossterm::event::{KeyCode, KeyModifiers};
 
 pub(crate) mod config;
@@ -35,14 +35,14 @@ pub(crate) struct ScreenLookup {
     pub build_vm: fn(&AppState) -> ScreenVm,
     pub handle_key: fn(&mut AppState, KeyCode, KeyModifiers) -> KeyOutcome,
     pub apply_navigation: fn(&mut AppState, NavAction) -> bool,
-    pub click_select: fn(&mut AppState, u16, u16, &MouseLayout) -> bool,
+    pub click_select: fn(&mut AppState, u16, u16, &MouseFrame) -> bool,
 }
 
 fn ungated(_: &AppState, _: KeyCode) -> bool {
     true
 }
 
-fn no_click(_: &mut AppState, _: u16, _: u16, _: &MouseLayout) -> bool {
+fn no_click(_: &mut AppState, _: u16, _: u16, _: &MouseFrame) -> bool {
     false
 }
 fn scroll_navigation(state: &mut AppState, action: NavAction) -> bool {

--- a/src/tui/screens/palette.rs
+++ b/src/tui/screens/palette.rs
@@ -4,7 +4,7 @@
 use crate::tui::palette::{CrossAction, PaletteExec, PaletteMode};
 use crate::tui::view_model::{ChromeVm, PaletteVm};
 use crate::tui::EditResult;
-use crate::tui::{AppState, HelpTopic, KeyOutcome, MouseLayout, Screen};
+use crate::tui::{AppState, HelpTopic, HitTarget, KeyOutcome, MouseFrame, RowTarget, Screen};
 use crossterm::event::{KeyCode, KeyModifiers};
 use ratatui::{
     layout::{Margin, Rect},
@@ -184,11 +184,19 @@ pub(crate) fn render_palette_vm(
     state: &AppState,
     palette: &PaletteVm,
     chrome: &ChromeVm,
-    layout: &mut MouseLayout,
+    layout: &mut MouseFrame,
+    feedback: &mut crate::tui::render::RenderFeedback,
 ) {
-    let mut bg_layout = MouseLayout::default();
+    let mut bg_layout = MouseFrame::default();
     if let Some(background) = &palette.background {
-        crate::tui::render::render_screen_vm(frame, state, background, chrome, &mut bg_layout);
+        crate::tui::render::render_screen_vm_with_feedback(
+            frame,
+            state,
+            background,
+            chrome,
+            &mut bg_layout,
+            feedback,
+        );
     }
 
     let area = frame.area();
@@ -230,7 +238,7 @@ pub(crate) fn render_palette_vm(
 
     frame.render_widget(Clear, rect);
 
-    layout.palette_rows.clear();
+    layout.intercept_all();
     let dim = Style::default().fg(state.theme.dim);
     let active = Style::default()
         .fg(state.theme.fg_on_accent)
@@ -278,22 +286,80 @@ pub(crate) fn render_palette_vm(
 
     let inner = rect.inner(Margin::new(1, 1));
     let mut y = inner.y + u16::from(palette.has_query);
-    for item in palette.items.iter() {
+    for (index, item) in palette.items.iter().enumerate() {
         if y >= inner.bottom() {
             break;
         }
         if chrome.mouse_enabled && item.enabled {
-            layout
-                .palette_rows
-                .push(Rect::new(inner.x, y, inner.width, 1));
+            layout.register(
+                HitTarget::Row(RowTarget::Palette(index)),
+                Rect::new(inner.x, y, inner.width, 1),
+            );
         }
         y = y.saturating_add(1);
     }
     if chrome.mouse_enabled {
-        layout.palette_close = Some(crate::tui::render::render_close_button(
-            frame,
-            rect,
-            &state.theme,
-        ));
+        let close = crate::tui::render::render_close_button(frame, rect, &state.theme);
+        layout.register(HitTarget::PaletteClose, close);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::initial_state;
+    use crate::tui::keymap::Category;
+    use crate::tui::palette::{PaletteItem, PaletteState};
+    use ratatui::{backend::TestBackend, Terminal};
+
+    #[test]
+    fn enabled_row_after_disabled_row_keeps_its_palette_index() {
+        let mut state = initial_state();
+        state.screen = Screen::Palette(Box::new(PaletteState {
+            mode: PaletteMode::Command,
+            items: vec![
+                PaletteItem {
+                    key_hint: "x".into(),
+                    label: "Disabled".into(),
+                    exec: PaletteExec::Cross(CrossAction::Quit),
+                    enabled: false,
+                    category: Category::Nav,
+                    search: "x disabled".into(),
+                },
+                PaletteItem {
+                    key_hint: "t".into(),
+                    label: "Toggle theme".into(),
+                    exec: PaletteExec::Cross(CrossAction::ToggleTheme),
+                    enabled: true,
+                    category: Category::Nav,
+                    search: "t toggle theme".into(),
+                },
+            ],
+            origin_screen: Screen::List,
+            ..PaletteState::default()
+        }));
+        let vm = build_palette_vm(&state);
+        let chrome = ChromeVm {
+            mouse_enabled: true,
+            bg_task_msg: None,
+            spinner_frame: 0,
+        };
+        let mut mouse = MouseFrame::default();
+        let mut feedback = crate::tui::render::RenderFeedback::default();
+        let mut terminal = Terminal::new(TestBackend::new(80, 20)).unwrap();
+        terminal
+            .draw(|frame| render_palette_vm(frame, &state, &vm, &chrome, &mut mouse, &mut feedback))
+            .unwrap();
+        let (col, row) = (0..20)
+            .flat_map(|row| (0..80).map(move |col| (col, row)))
+            .find(|&(col, row)| {
+                mouse.resolve(col, row) == Some(HitTarget::Row(RowTarget::Palette(1)))
+            })
+            .expect("enabled row hit");
+
+        let outcome = state.palette_click(col, row, &mouse);
+
+        assert_eq!(outcome, KeyOutcome::ThemeToggle);
+        assert_eq!(state.theme_choice, crate::config::ThemeChoice::Light);
     }
 }

--- a/src/tui/screens/pins.rs
+++ b/src/tui/screens/pins.rs
@@ -6,7 +6,7 @@ use crate::tui::render::list_pane::render_list_pane;
 use crate::tui::view_model::{
     ChromeVm, ListPaneEmpty, ListPaneVm, PaneTitleVm, PinsVm, RowEmphasis, RowVm,
 };
-use crate::tui::{AppState, HelpTopic, KeyOutcome, MouseLayout, Screen};
+use crate::tui::{AppState, HelpTopic, HitTarget, KeyOutcome, MouseFrame, PaneTarget, Screen};
 use crossterm::event::KeyCode;
 use ratatui::{
     layout::{Constraint, Direction, Layout},
@@ -143,8 +143,8 @@ impl AppState {
 
     /// Select the clicked row on `Screen::Pins`, moving the list cursor. Returns `true` when
     /// a row was hit.
-    pub(crate) fn click_select_pins(&mut self, col: u16, row: u16, layout: &MouseLayout) -> bool {
-        if let Some(hit) = layout.list {
+    pub(crate) fn click_select_pins(&mut self, col: u16, row: u16, layout: &MouseFrame) -> bool {
+        if let Some(hit) = layout.pane(PaneTarget::List) {
             if point_in(hit.rect, col, row) {
                 let count = self.visible_pin_indices().len();
                 if let Some(idx) = hit.index_at(row, count) {
@@ -300,7 +300,7 @@ pub(crate) fn render_pins_vm(
     state: &AppState,
     pins: &PinsVm,
     chrome: &ChromeVm,
-    layout: &mut MouseLayout,
+    layout: &mut MouseFrame,
 ) {
     let area = frame.area();
     let area = crate::tui::render_top_bar(frame, area, &state.theme, chrome.mouse_enabled, layout);
@@ -324,7 +324,8 @@ pub(crate) fn render_pins_vm(
         &pins.pane,
         &state.theme,
         chrome.mouse_enabled,
-        &mut layout.list,
+        layout,
+        PaneTarget::List,
     );
 
     if pins.filtering {
@@ -348,7 +349,8 @@ pub(crate) fn render_pins_vm(
         );
     }
     if chrome.mouse_enabled {
-        layout.close_button = Some(crate::tui::render_close_button(frame, area, &state.theme));
+        let close = crate::tui::render_close_button(frame, area, &state.theme);
+        layout.register(HitTarget::Close, close);
     }
 }
 
@@ -633,10 +635,8 @@ mod tests {
             rect: Rect::new(0, 0, 40, 10),
             offset: 0,
         };
-        let layout = MouseLayout {
-            list: Some(hit),
-            ..Default::default()
-        };
+        let mut layout = MouseFrame::default();
+        layout.register_pane(PaneTarget::List, hit, 2);
         let out = state.handle_mouse(MouseInput::Click { col: 5, row: 2 }, &layout);
         assert_eq!(out, KeyOutcome::None);
         assert_eq!(pins_ref(&state).cursor.index, 1);

--- a/src/tui/screens/preview.rs
+++ b/src/tui/screens/preview.rs
@@ -3,7 +3,7 @@
 
 use crate::tui::bg::LoopFlow;
 use crate::tui::view_model::{ChromeVm, PreviewVm};
-use crate::tui::{AppState, HelpTopic, KeyOutcome, MouseLayout};
+use crate::tui::{AppState, HelpTopic, HitTarget, KeyOutcome, MouseFrame};
 use crossterm::event::KeyCode;
 use ratatui::{
     layout::{Constraint, Direction, Layout},
@@ -142,7 +142,7 @@ pub(crate) fn render_preview_vm(
     state: &AppState,
     preview: &PreviewVm,
     chrome: &ChromeVm,
-    layout: &mut MouseLayout,
+    layout: &mut MouseFrame,
 ) {
     let area = frame.area();
     let area = crate::tui::render_top_bar(frame, area, &state.theme, chrome.mouse_enabled, layout);
@@ -210,7 +210,8 @@ pub(crate) fn render_preview_vm(
         &state.theme,
     );
     if chrome.mouse_enabled {
-        layout.close_button = Some(crate::tui::render_close_button(frame, area, &state.theme));
+        let close = crate::tui::render_close_button(frame, area, &state.theme);
+        layout.register(HitTarget::Close, close);
     }
 }
 
@@ -359,10 +360,8 @@ mod tests {
     fn top_bar_gists_click_opens_gist_manager_from_any_screen() {
         let mut state = state_with_gists();
         state.screen = Screen::Preview(Box::default()); // arbitrary screen that has no 'g' binding of its own
-        let layout = MouseLayout {
-            top_bar_gists: Some(Rect::new(10, 0, 7, 1)),
-            ..Default::default()
-        };
+        let mut layout = MouseFrame::default();
+        layout.register(HitTarget::TopGists, Rect::new(10, 0, 7, 1));
         let out = state.handle_mouse(MouseInput::Click { col: 12, row: 0 }, &layout);
         assert!(state.screen.is_gists());
         assert_eq!(out, KeyOutcome::None);
@@ -372,10 +371,8 @@ mod tests {
     fn top_bar_config_click_opens_settings_from_any_screen() {
         let mut state = state_with_gists();
         state.screen = Screen::Preview(Box::default());
-        let layout = MouseLayout {
-            top_bar_config: Some(Rect::new(28, 0, 8, 1)),
-            ..Default::default()
-        };
+        let mut layout = MouseFrame::default();
+        layout.register(HitTarget::TopConfig, Rect::new(28, 0, 8, 1));
         let out = state.handle_mouse(MouseInput::Click { col: 30, row: 0 }, &layout);
         assert!(state.screen.is_config());
         assert!(state.nav_stack.last().is_some_and(Screen::is_preview));
@@ -386,10 +383,8 @@ mod tests {
     fn top_bar_config_click_while_already_on_config_does_not_trap_keyboard_exit() {
         let mut state = state_with_gists();
         state.screen = Screen::Preview(Box::default());
-        let layout = MouseLayout {
-            top_bar_config: Some(Rect::new(28, 0, 8, 1)),
-            ..Default::default()
-        };
+        let mut layout = MouseFrame::default();
+        layout.register(HitTarget::TopConfig, Rect::new(28, 0, 8, 1));
         state.handle_mouse(MouseInput::Click { col: 30, row: 0 }, &layout);
         assert!(state.screen.is_config());
         assert!(state.nav_stack.last().is_some_and(Screen::is_preview));
@@ -408,10 +403,8 @@ mod tests {
     fn top_bar_help_click_opens_help_and_remembers_return_screen_from_any_screen() {
         let mut state = state_with_gists();
         state.screen = Screen::Preview(Box::default());
-        let layout = MouseLayout {
-            top_bar_help: Some(Rect::new(30, 0, 7, 1)),
-            ..Default::default()
-        };
+        let mut layout = MouseFrame::default();
+        layout.register(HitTarget::TopHelp, Rect::new(30, 0, 7, 1));
         let out = state.handle_mouse(MouseInput::Click { col: 32, row: 0 }, &layout);
         assert!(state.screen.is_help());
         assert!(state.nav_stack.last().is_some_and(Screen::is_preview));

--- a/src/tui/screens/revisions.rs
+++ b/src/tui/screens/revisions.rs
@@ -8,7 +8,7 @@ use crate::tui::render::list_pane::render_list_pane;
 use crate::tui::view_model::{
     ChromeVm, ListPaneEmpty, ListPaneVm, PaneTitleVm, RevisionsVm, RowEmphasis, RowVm,
 };
-use crate::tui::{AppState, HelpTopic, KeyOutcome, MouseLayout, Screen};
+use crate::tui::{AppState, HelpTopic, HitTarget, KeyOutcome, MouseFrame, PaneTarget, Screen};
 use crossterm::event::KeyCode;
 use ratatui::{
     layout::{Constraint, Direction, Layout},
@@ -295,12 +295,12 @@ impl AppState {
         &mut self,
         col: u16,
         row: u16,
-        layout: &MouseLayout,
+        layout: &MouseFrame,
     ) -> bool {
         let Screen::Revisions(rev) = &mut self.screen else {
             return false;
         };
-        if let Some(hit) = layout.list {
+        if let Some(hit) = layout.pane(PaneTarget::List) {
             if point_in(hit.rect, col, row) {
                 let count = rev.entries.as_ref().map_or(0, |e| e.len());
                 if let Some(idx) = hit.index_at(row, count) {
@@ -414,7 +414,7 @@ pub(crate) fn render_revisions_vm(
     state: &AppState,
     revs: &RevisionsVm,
     chrome: &ChromeVm,
-    layout: &mut MouseLayout,
+    layout: &mut MouseFrame,
 ) {
     let area = frame.area();
     let area = crate::tui::render_top_bar(frame, area, &state.theme, chrome.mouse_enabled, layout);
@@ -431,7 +431,8 @@ pub(crate) fn render_revisions_vm(
         &revs.pane,
         &state.theme,
         chrome.mouse_enabled,
-        &mut layout.list,
+        layout,
+        PaneTarget::List,
     );
     crate::tui::render_footer(
         frame,
@@ -443,7 +444,8 @@ pub(crate) fn render_revisions_vm(
         &state.theme,
     );
     if chrome.mouse_enabled {
-        layout.close_button = Some(crate::tui::render_close_button(frame, area, &state.theme));
+        let close = crate::tui::render_close_button(frame, area, &state.theme);
+        layout.register(HitTarget::Close, close);
     }
 }
 
@@ -729,10 +731,8 @@ mod tests {
             rect: Rect::new(0, 0, 40, 10),
             offset: 0,
         };
-        let layout = MouseLayout {
-            list: Some(hit),
-            ..Default::default()
-        };
+        let mut layout = MouseFrame::default();
+        layout.register_pane(PaneTarget::List, hit, 2);
         let out = state.handle_mouse(MouseInput::Click { col: 5, row: 2 }, &layout);
         assert_eq!(out, KeyOutcome::None);
         assert_eq!(revision_ref(&state).index, 1);


### PR DESCRIPTION
## Summary

- replace the per-frame mouse geometry field bag with semantic `MouseFrame` registration and fixed target priority
- move double-click classification and divider gesture lifecycle into `MouseSession`
- preserve screen-owned selection/activation and right-click context behavior
- separate comments render feedback from mouse hits
- fix palette row identity across disabled commands and double-click global routing

## Verification

- `mise run check` (758 unit tests, 12 integration tests)
- Standards review: clean
- Spec review: clean

Closes #400