### PR TITLE
refactor(tui): deepen gist refresh orchestration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Gist refreshes now keep the last usable list and counts when one GitHub request fails, and a
+  superseded refresh can no longer overwrite newer results.
 - Mouse double-clicks now respect close buttons, repository links, and top-bar shortcuts instead
   of falling through to the row underneath.
 - Command-palette mouse clicks now execute the row under the pointer when disabled commands are

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -7,3 +7,7 @@ A terminal UI for browsing, comparing, and managing GitHub Gists.
 **Gist mutation**:
 A change to a gist itself (create, delete, edit a file, description, star, fork, compact, upload-replace). Its async outcome belongs to no single screen — List, Gists, GistDetail, and Confirm can all launch one.
 _Avoid_: screen action, background job result, apply handler
+
+**Gist catalog**:
+The publishable, cacheable collection of owned and starred Gists together with the account and enrichment metadata needed to browse them. A refresh may publish newer stages of one catalog over time, but never mixes stages from different refreshes.
+_Avoid_: gist list, cache snapshot, fetch result

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -7,7 +7,7 @@ Index: [`AGENTS.md`](../../AGENTS.md). Source of truth for types lives in the mo
 | Kind | Modules | Testing |
 | --- | --- | --- |
 | **Pure** (unit-tested) | `domain`, `config`, `ranking`, `local`, `diff`, actions **plan/guard**, `tui::view_model`, `tui::list_ranking` | In-crate unit tests |
-| **Impure** (thin IO) | `gh`, actions **execute**, `tui::run_loop` / `tui::bg` / `tui::pin_sync` | No live `gh`. Spawn/absorb is thin IO; action-job `on_*` apply handlers (screen modules / `gist_mutation.rs`) are unit-tested (#298, #383) |
+| **Impure** (thin IO) | `gh`, actions **execute**, `tui::run_loop` / `tui::bg` / `tui::gist_refresh` / `tui::pin_sync` | No live `gh`. Spawn/absorb is thin IO; action-job `on_*` apply handlers (screen modules / `gist_mutation.rs`) are unit-tested (#298, #383) |
 
 `build_view_model` (`@src/tui/view_model.rs`): `AppState` + pin-sync cache → presentation facts. Paint helpers apply theme/layout only — no business rules, FS, or network.
 
@@ -71,6 +71,8 @@ Help topics and `README.md` stay hand-written — the List topic is fifty lines 
 ## Background jobs
 
 - **`Jobs`** is the single registry: spawn / absorb / cancel (`@src/tui/bg.rs`, issue #243). It keeps seven methods: `startup`, `spawn_action`, `spawn_gist_fetch_action`, `cancel_action`, `request_local_scan`, `set_upload_edit_watch`, `absorb`.
+- **`GistRefresh` owns the whole-list pipeline** (`@src/tui/gist_refresh.rs`): it publishes the base `GistCatalog` as soon as owned/starred/login finish, then publishes fork counts, star counts, and fork metadata as coherent stages. Every result carries a refresh generation; only the latest generation may publish. A failed leg retains that field's last-known-good value, and the pipeline emits one aggregate status after the generation finishes.
+- **`GistCatalog` is the publish/cache unit** (`@src/domain.rs`). Cache writes serialize one complete catalog stage from one generation; do not cache or publish the refresh module's individual legs.
 - **Apply only marks; only the registry spawns** (issue #383). `on_*` handlers are free functions (`fn on_x(state: &mut AppState, ...) -> LoopFlow`) on the screen module that owns the payload they mutate, or on `@src/tui/gist_mutation.rs` when the outcome belongs to no single screen. They set `gist_list_stale` / `revisions_stale`; `Jobs::absorb` consumes those flags immediately after `on_action_outcome` and spawns. Do not spawn from apply. **Revisit** when a third kind of stale need appears: replace the flags with a described follow-up value rather than adding a third field.
 - Action jobs and local scans use **generation supersession** (issue #221).
 - Call sites start work via `Jobs` methods (`spawn_action`, `request_local_scan`, …) or `screens::revisions::request_revisions` — do not own ad-hoc channel fields on `AppState`.

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,7 +1,5 @@
-use crate::domain::GistFile;
+use crate::domain::GistCatalog;
 use anyhow::{Context, Result};
-use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -11,47 +9,14 @@ pub fn cache_path() -> Result<PathBuf> {
     Ok(dir.join("gistui").join("gists.json"))
 }
 
-/// Full startup cache: owned + starred lists and the metadata that powers the gist manager.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub struct GistListCache {
-    #[serde(default)]
-    pub owned: Vec<GistFile>,
-    #[serde(default)]
-    pub starred: Vec<GistFile>,
-    #[serde(default)]
-    pub starred_ids: Vec<String>,
-    #[serde(default)]
-    pub user_login: Option<String>,
-    #[serde(default)]
-    pub comment_counts: HashMap<String, u32>,
-    #[serde(default)]
-    pub fork_counts: HashMap<String, u32>,
-    #[serde(default)]
-    pub star_counts: HashMap<String, u32>,
-}
-
-impl GistListCache {
-    pub fn starred_ids_set(&self) -> HashSet<String> {
-        self.starred_ids.iter().cloned().collect()
-    }
-}
-
-/// Loads the cached gist snapshot. Accepts the legacy bare `[GistFile, …]` format.
-pub fn load_gist_cache(path: &Path) -> Option<GistListCache> {
+/// Loads the cached Gist catalog. Incompatible or corrupt caches are ignored.
+pub fn load_gist_cache(path: &Path) -> Option<GistCatalog> {
     let raw = fs::read_to_string(path).ok()?;
-    if let Ok(cache) = serde_json::from_str::<GistListCache>(&raw) {
-        return Some(cache);
-    }
-    serde_json::from_str::<Vec<GistFile>>(&raw)
-        .ok()
-        .map(|owned| GistListCache {
-            owned,
-            ..GistListCache::default()
-        })
+    serde_json::from_str(&raw).ok()
 }
 
 /// Writes the gist snapshot to the cache, best-effort.
-pub fn save_gist_cache(path: &Path, cache: &GistListCache) {
+pub fn save_gist_cache(path: &Path, cache: &GistCatalog) {
     if let Some(parent) = path.parent() {
         if fs::create_dir_all(parent).is_err() {
             return;
@@ -65,6 +30,7 @@ pub fn save_gist_cache(path: &Path, cache: &GistListCache) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::GistFile;
 
     fn gist(id: &str, filename: &str) -> GistFile {
         GistFile {
@@ -79,10 +45,10 @@ mod tests {
     fn save_then_load_round_trips() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("gistui").join("gists.json");
-        let cache = GistListCache {
+        let cache = GistCatalog {
             owned: vec![gist("a", "one.txt"), gist("b", "two.txt")],
             starred: vec![gist("star1", "x.md")],
-            starred_ids: vec!["star1".into()],
+            starred_ids: ["star1".into()].into(),
             user_login: Some("me".into()),
             comment_counts: [("a".into(), 2)].into(),
             fork_counts: [("a".into(), 1)].into(),
@@ -93,17 +59,6 @@ mod tests {
         let loaded = load_gist_cache(&path).unwrap();
 
         assert_eq!(loaded, cache);
-    }
-
-    #[test]
-    fn load_legacy_bare_array() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("gists.json");
-        let gists = vec![gist("a", "one.txt")];
-        fs::write(&path, serde_json::to_string(&gists).unwrap()).unwrap();
-        let loaded = load_gist_cache(&path).unwrap();
-        assert_eq!(loaded.owned, gists);
-        assert!(loaded.starred.is_empty());
     }
 
     #[test]

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::path::PathBuf;
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PinnedMapping {
@@ -96,6 +99,25 @@ pub struct GistFile {
     /// GraphQL global id from the gist list API (`node_id`), for stargazer counts.
     #[serde(default)]
     pub node_id: Option<String>,
+}
+
+/// Publishable, cacheable owned/starred Gists and their list-level enrichment metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct GistCatalog {
+    #[serde(default)]
+    pub owned: Vec<GistFile>,
+    #[serde(default)]
+    pub starred: Vec<GistFile>,
+    #[serde(default)]
+    pub starred_ids: HashSet<String>,
+    #[serde(default)]
+    pub user_login: Option<String>,
+    #[serde(default)]
+    pub comment_counts: HashMap<String, u32>,
+    #[serde(default)]
+    pub fork_counts: HashMap<String, u32>,
+    #[serde(default)]
+    pub star_counts: HashMap<String, u32>,
 }
 
 /// Image file extensions — the single source of truth for the "image file" classification,

--- a/src/gh/forks.rs
+++ b/src/gh/forks.rs
@@ -195,7 +195,7 @@ pub fn collect_gist_fork_counts(
     owned_raw: Option<&str>,
     starred_raw: Option<&str>,
     gist_ids: impl IntoIterator<Item = String>,
-) -> HashMap<String, u32> {
+) -> crate::gh::CountCollection {
     let mut counts = owned_raw
         .and_then(|raw| parse_gist_fork_counts(raw).ok())
         .unwrap_or_default();
@@ -204,17 +204,20 @@ pub fn collect_gist_fork_counts(
             counts.extend(starred);
         }
     }
+    let mut incomplete = false;
     for id in gist_ids {
         if counts.get(&id).copied().unwrap_or(0) > 0 {
             continue;
         }
-        if let Ok(n) = fetch_gist_fork_count(runner, &id) {
-            if n > 0 {
+        match fetch_gist_fork_count(runner, &id) {
+            Ok(n) if n > 0 => {
                 counts.insert(id, n);
             }
+            Ok(_) => {}
+            Err(_) => incomplete = true,
         }
     }
-    counts
+    crate::gh::CountCollection { counts, incomplete }
 }
 
 #[cfg(test)]
@@ -327,9 +330,10 @@ mod tests {
             None,
             ["abc123".into(), "def456".into()],
         );
-        assert_eq!(counts.get("abc123").copied(), Some(2));
+        assert_eq!(counts.counts.get("abc123").copied(), Some(2));
         // Probe returned empty forks → count stays 0 (from list parse or absent).
-        assert_eq!(counts.get("def456").copied().unwrap_or(0), 0);
+        assert_eq!(counts.counts.get("def456").copied().unwrap_or(0), 0);
+        assert!(!counts.incomplete);
         let calls = runner.calls();
         assert_eq!(calls[0], gist_forks_plan("abc123"));
         assert_eq!(calls[1], gist_forks_plan("def456"));

--- a/src/gh/mod.rs
+++ b/src/gh/mod.rs
@@ -141,3 +141,9 @@ pub use stars::{
     build_stargazer_graphql_query, collect_gist_star_counts, gist_stargazer_graphql_plan,
     parse_stargazer_counts_graphql,
 };
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct CountCollection {
+    pub counts: std::collections::HashMap<String, u32>,
+    pub incomplete: bool,
+}

--- a/src/gh/stars.rs
+++ b/src/gh/stars.rs
@@ -61,20 +61,28 @@ pub fn parse_stargazer_counts_graphql(raw: &str) -> Result<HashMap<String, u32>>
 pub fn collect_gist_star_counts(
     runner: &dyn CommandRunner,
     node_ids: HashMap<String, String>,
-) -> HashMap<String, u32> {
+) -> crate::gh::CountCollection {
     let ids: Vec<String> = node_ids.into_values().collect();
     let mut out = HashMap::new();
+    let mut incomplete = false;
     for chunk in ids.chunks(STARGAZER_GRAPHQL_CHUNK) {
         let query = build_stargazer_graphql_query(chunk);
         let raw = match run_command(runner, &gist_stargazer_graphql_plan(&query)) {
             Ok(raw) => raw,
-            Err(_) => continue,
+            Err(_) => {
+                incomplete = true;
+                continue;
+            }
         };
-        if let Ok(batch) = parse_stargazer_counts_graphql(&raw) {
-            out.extend(batch);
+        match parse_stargazer_counts_graphql(&raw) {
+            Ok(batch) => out.extend(batch),
+            Err(_) => incomplete = true,
         }
     }
-    out
+    crate::gh::CountCollection {
+        counts: out,
+        incomplete,
+    }
 }
 
 #[cfg(test)]

--- a/src/tui/bg.rs
+++ b/src/tui/bg.rs
@@ -8,9 +8,6 @@ use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io;
 use std::path::PathBuf;
 
-/// Owned-fork metadata (gist id → upstream id), or the reason fork detection failed.
-pub(super) type ForkMetaResult = Result<std::collections::HashMap<String, Option<String>>, String>;
-
 pub(super) enum UploadEditWatchEvent {
     /// The temp file's mtime changed — re-read and live-update the diff.
     ContentChanged {
@@ -126,51 +123,10 @@ pub(super) fn fetch_revision_pair_for_restore(
 }
 
 pub(super) fn persist_gist_cache_from_state(state: &AppState) {
-    persist_gist_cache_from_state_fields(
-        &state.gists,
-        &state.starred_gists,
-        &state.starred_gist_ids,
-        &state.current_user_login,
-        &state.gist_comment_counts,
-        &state.gist_fork_counts,
-        &state.gist_star_counts,
-    );
-}
-
-pub(super) fn persist_gist_cache_from_state_fields(
-    owned: &[GistFile],
-    starred: &[GistFile],
-    starred_ids: &std::collections::HashSet<String>,
-    user_login: &Option<String>,
-    comment_counts: &std::collections::HashMap<String, u32>,
-    fork_counts: &std::collections::HashMap<String, u32>,
-    star_counts: &std::collections::HashMap<String, u32>,
-) {
     if let Ok(path) = crate::cache::cache_path() {
-        let cache = crate::cache::GistListCache {
-            owned: owned.to_vec(),
-            starred: starred.to_vec(),
-            starred_ids: starred_ids.iter().cloned().collect(),
-            user_login: user_login.clone(),
-            comment_counts: comment_counts.clone(),
-            fork_counts: fork_counts.clone(),
-            star_counts: star_counts.clone(),
-        };
-        crate::cache::save_gist_cache(&path, &cache);
+        crate::cache::save_gist_cache(&path, &state.gist_catalog);
     }
 }
-
-/// Fetches the gist list on a background thread so startup does not block on `gh`.
-/// Fork counts are fetched separately so the UI can render lists without waiting.
-pub(super) type GistFetchResult = (
-    Vec<GistFile>,
-    Vec<GistFile>,
-    std::collections::HashSet<String>,
-    Option<String>,
-    std::collections::HashMap<String, u32>,
-    Option<String>,
-    Option<String>,
-);
 
 /// Off-thread: ask GitHub for the latest release tag and classify it against the running
 /// version. Network failures map to `Failed` (silent; the loop won't record the throttle).
@@ -181,104 +137,6 @@ pub(super) fn spawn_update_check(
         let outcome =
             crate::update_check::check(&crate::upgrade::UreqClient, env!("CARGO_PKG_VERSION"));
         let _ = tx.send(outcome);
-    });
-    rx
-}
-
-pub(super) fn spawn_gist_fetch() -> std::sync::mpsc::Receiver<GistFetchResult> {
-    let (tx, rx) = std::sync::mpsc::channel();
-    std::thread::spawn(move || {
-        let result = if crate::gh::check_gh_ready(&SystemRunner).is_ok() {
-            // Owned list, starred list, and current-user login are independent network
-            // legs — run them concurrently so large accounts don't pay three sequential
-            // round-trips on cold start (issue #223). Soft-fail each leg independently
-            // (`.ok()`), matching the previous sequential behaviour.
-            let (owned, starred_raw, user_login) = std::thread::scope(|s| {
-                let owned_h = s.spawn(|| crate::gh::fetch_gist_list_json(&SystemRunner).ok());
-                let starred_h =
-                    s.spawn(|| crate::gh::fetch_gist_starred_list_json(&SystemRunner).ok());
-                let user_h = s.spawn(|| crate::gh::fetch_current_user_login(&SystemRunner).ok());
-                (
-                    owned_h.join().unwrap_or(None),
-                    starred_h.join().unwrap_or(None),
-                    user_h.join().unwrap_or(None),
-                )
-            });
-            let (files, mut comment_counts) = owned
-                .as_ref()
-                .map(|raw| {
-                    (
-                        crate::gh::parse_gist_list_json(raw).unwrap_or_default(),
-                        crate::gh::parse_gist_comment_counts(raw).unwrap_or_default(),
-                    )
-                })
-                .unwrap_or_default();
-            if let Some(raw) = starred_raw.as_ref() {
-                if let Ok(starred_comments) = crate::gh::parse_gist_comment_counts(raw) {
-                    comment_counts.extend(starred_comments);
-                }
-            }
-            let starred = starred_raw
-                .as_ref()
-                .map(|raw| crate::gh::parse_gist_list_json(raw).unwrap_or_default())
-                .unwrap_or_default();
-            let starred_ids = starred_raw
-                .as_ref()
-                .and_then(|raw| crate::gh::parse_starred_gist_ids(raw).ok())
-                .unwrap_or_default();
-            (
-                files,
-                starred,
-                starred_ids,
-                user_login,
-                comment_counts,
-                owned,
-                starred_raw,
-            )
-        } else {
-            Default::default()
-        };
-        let _ = tx.send(result);
-    });
-    rx
-}
-
-pub(super) fn spawn_fork_count_fetch(
-    owned_raw: Option<String>,
-    starred_raw: Option<String>,
-    gist_ids: std::collections::HashSet<String>,
-) -> std::sync::mpsc::Receiver<std::collections::HashMap<String, u32>> {
-    let (tx, rx) = std::sync::mpsc::channel();
-    std::thread::spawn(move || {
-        let counts = crate::gh::collect_gist_fork_counts(
-            &SystemRunner,
-            owned_raw.as_deref(),
-            starred_raw.as_deref(),
-            gist_ids,
-        );
-        let _ = tx.send(counts);
-    });
-    rx
-}
-
-pub(super) fn spawn_star_count_fetch(
-    node_ids: std::collections::HashMap<String, String>,
-) -> std::sync::mpsc::Receiver<std::collections::HashMap<String, u32>> {
-    let (tx, rx) = std::sync::mpsc::channel();
-    std::thread::spawn(move || {
-        let counts = crate::gh::collect_gist_star_counts(&SystemRunner, node_ids);
-        let _ = tx.send(counts);
-    });
-    rx
-}
-
-pub(super) fn spawn_fork_metadata_fetch(
-    owned_ids: std::collections::HashSet<String>,
-) -> std::sync::mpsc::Receiver<ForkMetaResult> {
-    let (tx, rx) = std::sync::mpsc::channel();
-    std::thread::spawn(move || {
-        let fork_of = crate::gh::collect_owned_fork_of_ids(&SystemRunner, owned_ids);
-        let _ = tx.send(fork_of);
     });
     rx
 }
@@ -1056,14 +914,10 @@ pub(super) fn unpin_at_pin_index(state: &mut AppState, idx: usize) {
 ///   spawn stamps `AppState::bg_task_generation`. Only matching generations apply;
 ///   cancel bumps the generation and drops the receiver (issue #221).
 /// - **Local scans** ([`Jobs::request_local_scan`]): stamp `AppState::local_scan_generation`.
-/// - **One-shot slots** (gist list, fork/star counts, update check, fork meta): a new
-///   spawn replaces the receiver; there is no multi-generation queue for these.
+/// - **Gist refreshes** own one generation across their base and enrichment jobs.
 pub(super) struct Jobs {
     update: Option<std::sync::mpsc::Receiver<crate::update_check::UpdateCheckOutcome>>,
-    gist: Option<std::sync::mpsc::Receiver<GistFetchResult>>,
-    fork: Option<std::sync::mpsc::Receiver<std::collections::HashMap<String, u32>>>,
-    star: Option<std::sync::mpsc::Receiver<std::collections::HashMap<String, u32>>>,
-    fork_meta: Option<std::sync::mpsc::Receiver<ForkMetaResult>>,
+    gist_refresh: super::gist_refresh::GistRefresh,
     local: LocalScanRx,
     /// Streams `UploadEditWatchEvent`s while a GUI editor has the upload-redact temp file
     /// open (see `spawn_upload_edit_watch`). Unlike one-shot slots, this channel can carry
@@ -1083,13 +937,11 @@ impl Jobs {
     pub(super) fn startup(
         update: Option<std::sync::mpsc::Receiver<crate::update_check::UpdateCheckOutcome>>,
         fetch_gists: bool,
+        catalog: &crate::domain::GistCatalog,
     ) -> Self {
         Self {
             update,
-            gist: fetch_gists.then(spawn_gist_fetch),
-            fork: None,
-            star: None,
-            fork_meta: None,
+            gist_refresh: super::gist_refresh::GistRefresh::new(catalog, fetch_gists),
             local: None,
             upload_edit_watch: None,
             action: None,
@@ -1193,27 +1045,20 @@ impl Jobs {
         self.absorb_inner(state, update_check_path)
     }
 
-    /// Poll each channel in turn and apply ready results to `state`.
-    ///
-    /// **Order matters**: the gist-list section spawns follow-up jobs (fork counts, fork
-    /// metadata, star counts) on success, and those sections poll the very channels it just
-    /// spawned in this same call — so `gist` must run before `fork`/`star`/`fork_meta`.
+    /// Poll each job module in turn and apply ready results to `state`.
     fn absorb_inner(
         &mut self,
         state: &mut AppState,
         update_check_path: &Option<std::path::PathBuf>,
     ) -> Result<LoopFlow> {
-        self.on_gist_list_ready(state);
-        self.on_fork_counts_ready(state);
-        self.on_star_counts_ready(state);
-        self.on_fork_meta_ready(state);
+        self.on_gist_refresh_ready(state);
         self.on_local_scan_ready(state);
         self.on_update_check_ready(state, update_check_path);
         self.on_upload_watch_events(state);
         let flow = self.on_action_outcome(state);
         if std::mem::take(&mut state.gist_list_stale) {
             state.loading = true;
-            self.gist = Some(spawn_gist_fetch());
+            self.gist_refresh.start(&state.gist_catalog);
         }
         if let Some(gist_id) = state.revisions_stale.take() {
             screens::revisions::request_revisions(self, state, gist_id);
@@ -1226,9 +1071,9 @@ impl Jobs {
 /// arrives. A disconnected sender is treated the same as an empty channel (no value yet):
 /// `slot` is left in place and the caller tries again next tick.
 ///
-/// Only covers channels that receive a single unstamped result (`gist`, `fork`, `star`,
-/// `fork_meta`, `update`). The generation-stamped channels (`local`, `action`) and the
-/// multi-message `upload_edit_watch` drain have different shapes and stay hand-rolled.
+/// Only covers channels that receive a single unstamped result (`update`). The
+/// generation-stamped refresh, local, and action channels and the multi-message
+/// `upload_edit_watch` drain have different shapes and stay hand-rolled.
 fn poll_channel<T>(slot: &mut Option<std::sync::mpsc::Receiver<T>>) -> Option<T> {
     let value = slot.as_ref()?.try_recv().ok()?;
     *slot = None;
@@ -1236,34 +1081,16 @@ fn poll_channel<T>(slot: &mut Option<std::sync::mpsc::Receiver<T>>) -> Option<T>
 }
 
 impl Jobs {
-    /// Absorb the background gist list once it arrives, and spawn the follow-up
-    /// fork-count/fork-meta/star-count jobs the freshly-loaded gist list needs.
-    fn on_gist_list_ready(&mut self, state: &mut AppState) {
-        if state.loading {
-            if let Some((
-                gists,
-                starred,
-                starred_ids,
-                user_login,
-                comment_counts,
-                owned_raw,
-                starred_raw,
-            )) = poll_channel(&mut self.gist)
-            {
-                persist_gist_cache_from_state_fields(
-                    &gists,
-                    &starred,
-                    &starred_ids,
-                    &user_login,
-                    &comment_counts,
-                    &state.gist_fork_counts,
-                    &state.gist_star_counts,
-                );
-                state.gists = gists;
-                state.starred_gists = starred;
-                state.starred_gist_ids = starred_ids;
-                state.current_user_login = user_login;
-                state.gist_comment_counts = comment_counts;
+    fn on_gist_refresh_ready(&mut self, state: &mut AppState) {
+        for update in self.gist_refresh.poll() {
+            state.gist_catalog = update.catalog;
+            if update.persist {
+                persist_gist_cache_from_state(state);
+            }
+            if let Some(status) = update.status {
+                state.set_status(status);
+            }
+            if update.base_ready {
                 state.loading = false;
                 if state.gist_index >= state.ranked_gists().len() {
                     state.gist_index = 0;
@@ -1272,52 +1099,6 @@ impl Jobs {
                 if let Some(gm) = state.gist_manager_mut() {
                     gm.cursor.clamp_len(count);
                 }
-                let gist_ids: std::collections::HashSet<String> = state
-                    .gists
-                    .iter()
-                    .chain(state.starred_gists.iter())
-                    .map(|g| g.gist_id.clone())
-                    .collect();
-                self.fork = Some(spawn_fork_count_fetch(
-                    owned_raw,
-                    starred_raw,
-                    gist_ids.clone(),
-                ));
-                self.fork_meta = Some(spawn_fork_metadata_fetch(
-                    state.gists.iter().map(|g| g.gist_id.clone()).collect(),
-                ));
-                let node_ids =
-                    crate::gh::merge_gist_node_id_maps(&state.gists, &state.starred_gists);
-                self.star = Some(spawn_star_count_fetch(node_ids));
-            }
-        }
-    }
-
-    /// Absorb background fork-count results.
-    fn on_fork_counts_ready(&mut self, state: &mut AppState) {
-        if let Some(fork_counts) = poll_channel(&mut self.fork) {
-            state.gist_fork_counts = fork_counts;
-            persist_gist_cache_from_state(state);
-        }
-    }
-
-    /// Absorb background star-count results.
-    fn on_star_counts_ready(&mut self, state: &mut AppState) {
-        if let Some(star_counts) = poll_channel(&mut self.star) {
-            state.gist_star_counts = star_counts;
-            persist_gist_cache_from_state(state);
-        }
-    }
-
-    /// Absorb background fork-metadata (owned-fork upstream ids) results.
-    fn on_fork_meta_ready(&mut self, state: &mut AppState) {
-        if let Some(result) = poll_channel(&mut self.fork_meta) {
-            match result {
-                Ok(fork_of) => {
-                    crate::gh::apply_fork_of_ids(&mut state.gists, &fork_of);
-                    persist_gist_cache_from_state(state);
-                }
-                Err(error) => state.set_status(format!("fork detection unavailable: {error}")),
             }
         }
     }
@@ -1425,6 +1206,8 @@ impl Jobs {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::domain::GistCatalog;
+    use crate::tui::gist_refresh::GistRefresh;
 
     use std::path::PathBuf;
     use std::sync::mpsc;
@@ -1469,114 +1252,11 @@ mod tests {
     fn empty_jobs() -> Jobs {
         Jobs {
             update: None,
-            gist: None,
-            fork: None,
-            star: None,
-            fork_meta: None,
+            gist_refresh: GistRefresh::new(&GistCatalog::default(), false),
             local: None,
             upload_edit_watch: None,
             action: None,
         }
-    }
-
-    // ---- on_gist_list_ready ---------------------------------------------
-
-    #[test]
-    fn on_gist_list_ready_noop_when_not_loading() {
-        let mut state = initial_state();
-        state.loading = false;
-        let (tx, rx) = mpsc::channel::<GistFetchResult>();
-        tx.send(Default::default()).unwrap();
-        let mut jobs = empty_jobs();
-        jobs.gist = Some(rx);
-
-        jobs.on_gist_list_ready(&mut state);
-
-        // Guarded entirely by `state.loading`: the channel is never polled.
-        assert!(jobs.gist.is_some());
-        assert!(state.gists.is_empty());
-    }
-
-    #[test]
-    fn on_gist_list_ready_noop_when_channel_empty() {
-        let mut state = initial_state();
-        state.loading = true;
-        let (_tx, rx) = mpsc::channel::<GistFetchResult>();
-        let mut jobs = empty_jobs();
-        jobs.gist = Some(rx);
-
-        jobs.on_gist_list_ready(&mut state);
-
-        assert!(jobs.gist.is_some());
-        assert!(state.loading);
-        assert!(state.gists.is_empty());
-    }
-
-    // ---- on_fork_counts_ready / on_star_counts_ready ---------------------
-    //
-    // The "value received" branch of both also persists the gist cache to the real
-    // per-OS cache directory (`persist_gist_cache_from_state` — see `bg.rs`), which has
-    // no test seam (unlike `update_check_path`, it isn't threaded through as a
-    // parameter). Exercising that branch here would write to the developer's real
-    // `~/.cache/gistui/gists.json` (or platform equivalent) as a side effect of running
-    // `cargo test`, which the project's "no live gh/network in tests" convention rules
-    // out in spirit. Only the empty-channel guard is covered directly.
-
-    #[test]
-    fn on_fork_counts_ready_noop_when_channel_empty() {
-        let mut state = initial_state();
-        let (_tx, rx) = mpsc::channel();
-        let mut jobs = empty_jobs();
-        jobs.fork = Some(rx);
-
-        jobs.on_fork_counts_ready(&mut state);
-
-        assert!(jobs.fork.is_some());
-        assert!(state.gist_fork_counts.is_empty());
-    }
-
-    #[test]
-    fn on_star_counts_ready_noop_when_channel_empty() {
-        let mut state = initial_state();
-        let (_tx, rx) = mpsc::channel();
-        let mut jobs = empty_jobs();
-        jobs.star = Some(rx);
-
-        jobs.on_star_counts_ready(&mut state);
-
-        assert!(jobs.star.is_some());
-        assert!(state.gist_star_counts.is_empty());
-    }
-
-    // ---- on_fork_meta_ready -----------------------------------------------
-
-    #[test]
-    fn on_fork_meta_ready_noop_when_channel_empty() {
-        let mut state = initial_state();
-        let (_tx, rx) = mpsc::channel();
-        let mut jobs = empty_jobs();
-        jobs.fork_meta = Some(rx);
-
-        jobs.on_fork_meta_ready(&mut state);
-
-        assert!(jobs.fork_meta.is_some());
-    }
-
-    #[test]
-    fn on_fork_meta_ready_sets_status_on_error() {
-        let mut state = initial_state();
-        let (tx, rx) = mpsc::channel();
-        tx.send(Err("boom".to_string())).unwrap();
-        let mut jobs = empty_jobs();
-        jobs.fork_meta = Some(rx);
-
-        jobs.on_fork_meta_ready(&mut state);
-
-        assert!(jobs.fork_meta.is_none());
-        assert_eq!(
-            state.status.as_deref(),
-            Some("fork detection unavailable: boom")
-        );
     }
 
     // ---- on_local_scan_ready ----------------------------------------------
@@ -1782,7 +1462,7 @@ mod tests {
         // Stale outcome dropped without applying — `bg_task_msg` untouched and no
         // follow-up gist fetch spawned.
         assert_eq!(state.bg_task_msg.as_deref(), Some("Deleting gist…"));
-        assert!(jobs.gist.is_none());
+        assert!(!state.gist_list_stale);
         assert!(state.status.is_none());
     }
 

--- a/src/tui/dispatch.rs
+++ b/src/tui/dispatch.rs
@@ -240,7 +240,8 @@ pub(super) fn dispatch_outcome(
             };
 
             let has_same_name = state
-                .gists
+                .gist_catalog
+                .owned
                 .iter()
                 .any(|g| g.gist_id == gist_id && g.filename == filename);
 

--- a/src/tui/gist_mutation.rs
+++ b/src/tui/gist_mutation.rs
@@ -136,10 +136,10 @@ pub(crate) fn on_gist_star_toggle(
 ) -> LoopFlow {
     apply(state, result, "star toggle", |state| {
         if starred {
-            state.starred_gist_ids.insert(gist_id.clone());
+            state.gist_catalog.starred_ids.insert(gist_id.clone());
             format!("starred {gist_id}")
         } else {
-            state.starred_gist_ids.remove(&gist_id);
+            state.gist_catalog.starred_ids.remove(&gist_id);
             format!("unstarred {gist_id}")
         }
     })
@@ -375,7 +375,7 @@ mod tests {
         on_gist_star_toggle(&mut state, Ok(()), "g1".into(), true);
 
         assert!(state.gist_list_stale);
-        assert!(state.starred_gist_ids.contains("g1"));
+        assert!(state.gist_catalog.starred_ids.contains("g1"));
         assert_eq!(state.status.as_deref(), Some("starred g1"));
     }
 

--- a/src/tui/gist_refresh.rs
+++ b/src/tui/gist_refresh.rs
@@ -1,0 +1,465 @@
+//! Whole-list Gist refresh: base catalog fetch, progressive enrichment, and supersession.
+
+use crate::actions::SystemRunner;
+use crate::domain::{GistCatalog, GistFile};
+use std::collections::{HashMap, HashSet};
+use std::sync::mpsc::{self, Receiver};
+
+struct ListLeg {
+    files: Vec<GistFile>,
+    comments: HashMap<String, u32>,
+    raw: String,
+}
+
+struct StarredLeg {
+    list: ListLeg,
+    ids: HashSet<String>,
+}
+
+struct BaseResult {
+    generation: u64,
+    owned: Result<ListLeg, ()>,
+    starred: Result<StarredLeg, ()>,
+    user_login: Result<String, ()>,
+    gh_unavailable: bool,
+}
+
+type CountRx = Option<Receiver<(u64, crate::gh::CountCollection)>>;
+type ForkMetaResult = Result<HashMap<String, Option<String>>, String>;
+type ForkMetaMessage = (u64, ForkMetaResult);
+type ForkMetaRx = Option<Receiver<ForkMetaMessage>>;
+
+#[derive(Debug)]
+pub(super) struct GistRefreshUpdate {
+    pub catalog: GistCatalog,
+    pub base_ready: bool,
+    pub persist: bool,
+    pub status: Option<String>,
+}
+
+pub(super) struct GistRefresh {
+    generation: u64,
+    catalog: GistCatalog,
+    base: Option<Receiver<BaseResult>>,
+    fork_counts: CountRx,
+    star_counts: CountRx,
+    fork_meta: ForkMetaRx,
+    remaining_enrichments: u8,
+    failures: Vec<&'static str>,
+}
+
+impl GistRefresh {
+    pub fn new(catalog: &GistCatalog, start: bool) -> Self {
+        let mut refresh = Self {
+            generation: 0,
+            catalog: catalog.clone(),
+            base: None,
+            fork_counts: None,
+            star_counts: None,
+            fork_meta: None,
+            remaining_enrichments: 0,
+            failures: Vec::new(),
+        };
+        if start {
+            refresh.start(catalog);
+        }
+        refresh
+    }
+
+    pub fn start(&mut self, catalog: &GistCatalog) {
+        self.generation = self.generation.wrapping_add(1);
+        self.catalog = catalog.clone();
+        self.base = Some(spawn_base_fetch(self.generation));
+        self.fork_counts = None;
+        self.star_counts = None;
+        self.fork_meta = None;
+        self.remaining_enrichments = 0;
+        self.failures.clear();
+    }
+
+    pub fn poll(&mut self) -> Vec<GistRefreshUpdate> {
+        let mut updates = Vec::new();
+        if let Some(result) = poll(&mut self.base) {
+            if result.generation == self.generation {
+                self.apply_base(result, &mut updates);
+            }
+        }
+        self.poll_fork_counts(&mut updates);
+        self.poll_star_counts(&mut updates);
+        self.poll_fork_meta(&mut updates);
+        updates
+    }
+
+    fn apply_base(&mut self, result: BaseResult, updates: &mut Vec<GistRefreshUpdate>) {
+        let old_fork_of: HashMap<_, _> = self
+            .catalog
+            .owned
+            .iter()
+            .map(|gist| (gist.gist_id.clone(), gist.fork_of_id.clone()))
+            .collect();
+        let mut owned_raw = None;
+        let mut starred_raw = None;
+        let owned_ok = match result.owned {
+            Ok(mut leg) => {
+                for gist in &mut leg.files {
+                    if let Some(fork_of) = old_fork_of.get(&gist.gist_id) {
+                        gist.fork_of_id = fork_of.clone();
+                    }
+                }
+                self.catalog.owned = leg.files;
+                owned_raw = Some(leg.raw);
+                Some(leg.comments)
+            }
+            Err(()) => {
+                self.failures.push("owned gists");
+                None
+            }
+        };
+        let starred_ok = match result.starred {
+            Ok(leg) => {
+                self.catalog.starred = leg.list.files;
+                self.catalog.starred_ids = leg.ids;
+                starred_raw = Some(leg.list.raw);
+                Some(leg.list.comments)
+            }
+            Err(()) => {
+                self.failures.push("starred gists");
+                None
+            }
+        };
+        if let (Some(mut owned), Some(starred)) = (owned_ok, starred_ok) {
+            owned.extend(starred);
+            self.catalog.comment_counts = owned;
+        }
+        match result.user_login {
+            Ok(login) => self.catalog.user_login = Some(login),
+            Err(()) => self.failures.push("current user"),
+        }
+
+        updates.push(self.update(true, true, None));
+        if result.gh_unavailable {
+            updates.push(self.finish());
+            return;
+        }
+
+        let gist_ids: HashSet<_> = self
+            .catalog
+            .owned
+            .iter()
+            .chain(&self.catalog.starred)
+            .map(|gist| gist.gist_id.clone())
+            .collect();
+        self.fork_counts = Some(spawn_count(self.generation, move || {
+            crate::gh::collect_gist_fork_counts(
+                &SystemRunner,
+                owned_raw.as_deref(),
+                starred_raw.as_deref(),
+                gist_ids,
+            )
+        }));
+        let node_ids =
+            crate::gh::merge_gist_node_id_maps(&self.catalog.owned, &self.catalog.starred);
+        self.star_counts = Some(spawn_count(self.generation, move || {
+            crate::gh::collect_gist_star_counts(&SystemRunner, node_ids)
+        }));
+        let owned_ids = self
+            .catalog
+            .owned
+            .iter()
+            .map(|gist| gist.gist_id.clone())
+            .collect();
+        self.fork_meta = Some(spawn_fork_meta(self.generation, owned_ids));
+        self.remaining_enrichments = 3;
+    }
+
+    fn poll_fork_counts(&mut self, updates: &mut Vec<GistRefreshUpdate>) {
+        let Some((generation, result)) = poll(&mut self.fork_counts) else {
+            return;
+        };
+        if generation != self.generation {
+            return;
+        }
+        if result.incomplete {
+            self.failures.push("fork counts");
+        } else {
+            self.catalog.fork_counts = result.counts;
+            updates.push(self.update(false, true, None));
+        }
+        self.finish_enrichment(updates);
+    }
+
+    fn poll_star_counts(&mut self, updates: &mut Vec<GistRefreshUpdate>) {
+        let Some((generation, result)) = poll(&mut self.star_counts) else {
+            return;
+        };
+        if generation != self.generation {
+            return;
+        }
+        if result.incomplete {
+            self.failures.push("star counts");
+        } else {
+            self.catalog.star_counts = result.counts;
+            updates.push(self.update(false, true, None));
+        }
+        self.finish_enrichment(updates);
+    }
+
+    fn poll_fork_meta(&mut self, updates: &mut Vec<GistRefreshUpdate>) {
+        let Some((generation, result)) = poll(&mut self.fork_meta) else {
+            return;
+        };
+        if generation != self.generation {
+            return;
+        }
+        match result {
+            Ok(fork_of) => {
+                crate::gh::apply_fork_of_ids(&mut self.catalog.owned, &fork_of);
+                updates.push(self.update(false, true, None));
+            }
+            Err(_) => self.failures.push("fork detection"),
+        }
+        self.finish_enrichment(updates);
+    }
+
+    fn finish_enrichment(&mut self, updates: &mut Vec<GistRefreshUpdate>) {
+        self.remaining_enrichments = self.remaining_enrichments.saturating_sub(1);
+        if self.remaining_enrichments == 0 && !self.failures.is_empty() {
+            updates.push(self.finish());
+        }
+    }
+
+    fn finish(&self) -> GistRefreshUpdate {
+        self.update(
+            false,
+            false,
+            Some(format!(
+                "refresh incomplete: {} unavailable",
+                self.failures.join(", ")
+            )),
+        )
+    }
+
+    fn update(&self, base_ready: bool, persist: bool, status: Option<String>) -> GistRefreshUpdate {
+        GistRefreshUpdate {
+            catalog: self.catalog.clone(),
+            base_ready,
+            persist,
+            status,
+        }
+    }
+}
+
+fn spawn_base_fetch(generation: u64) -> Receiver<BaseResult> {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let result = match crate::gh::check_gh_ready(&SystemRunner) {
+            Ok(()) => {
+                let (owned, starred, user_login) = std::thread::scope(|scope| {
+                    let owned = scope.spawn(fetch_owned);
+                    let starred = scope.spawn(fetch_starred);
+                    let user = scope.spawn(|| {
+                        crate::gh::fetch_current_user_login(&SystemRunner).map_err(|_| ())
+                    });
+                    (
+                        owned.join().unwrap_or(Err(())),
+                        starred.join().unwrap_or(Err(())),
+                        user.join().unwrap_or(Err(())),
+                    )
+                });
+                BaseResult {
+                    generation,
+                    owned,
+                    starred,
+                    user_login,
+                    gh_unavailable: false,
+                }
+            }
+            Err(_) => BaseResult {
+                generation,
+                owned: Err(()),
+                starred: Err(()),
+                user_login: Err(()),
+                gh_unavailable: true,
+            },
+        };
+        let _ = tx.send(result);
+    });
+    rx
+}
+
+fn fetch_owned() -> Result<ListLeg, ()> {
+    let raw = crate::gh::fetch_gist_list_json(&SystemRunner).map_err(|_| ())?;
+    Ok(ListLeg {
+        files: crate::gh::parse_gist_list_json(&raw).map_err(|_| ())?,
+        comments: crate::gh::parse_gist_comment_counts(&raw).map_err(|_| ())?,
+        raw,
+    })
+}
+
+fn fetch_starred() -> Result<StarredLeg, ()> {
+    let raw = crate::gh::fetch_gist_starred_list_json(&SystemRunner).map_err(|_| ())?;
+    Ok(StarredLeg {
+        ids: crate::gh::parse_starred_gist_ids(&raw).map_err(|_| ())?,
+        list: ListLeg {
+            files: crate::gh::parse_gist_list_json(&raw).map_err(|_| ())?,
+            comments: crate::gh::parse_gist_comment_counts(&raw).map_err(|_| ())?,
+            raw,
+        },
+    })
+}
+
+fn spawn_count(
+    generation: u64,
+    fetch: impl FnOnce() -> crate::gh::CountCollection + Send + 'static,
+) -> Receiver<(u64, crate::gh::CountCollection)> {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send((generation, fetch()));
+    });
+    rx
+}
+
+fn spawn_fork_meta(generation: u64, owned_ids: HashSet<String>) -> Receiver<ForkMetaMessage> {
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let result = crate::gh::collect_owned_fork_of_ids(&SystemRunner, owned_ids);
+        let _ = tx.send((generation, result));
+    });
+    rx
+}
+
+fn poll<T>(slot: &mut Option<Receiver<T>>) -> Option<T> {
+    let value = slot.as_ref()?.try_recv().ok()?;
+    *slot = None;
+    Some(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gh::CountCollection;
+
+    fn gist(id: &str) -> GistFile {
+        GistFile::fixture(id, format!("{id}.txt"))
+    }
+
+    fn old_catalog() -> GistCatalog {
+        GistCatalog {
+            owned: vec![gist("old-owned")],
+            starred: vec![gist("old-starred")],
+            user_login: Some("octocat".into()),
+            comment_counts: HashMap::from([("old-owned".into(), 4)]),
+            fork_counts: HashMap::from([("old-owned".into(), 2)]),
+            star_counts: HashMap::from([("old-owned".into(), 7)]),
+            ..GistCatalog::default()
+        }
+    }
+
+    #[test]
+    fn partial_base_failure_retains_last_known_good_and_reports_once() {
+        let mut refresh = GistRefresh::new(&old_catalog(), false);
+        refresh.generation = 1;
+        let (tx, rx) = mpsc::channel();
+        tx.send(BaseResult {
+            generation: 1,
+            owned: Err(()),
+            starred: Ok(StarredLeg {
+                list: ListLeg {
+                    files: vec![gist("new-starred")],
+                    comments: HashMap::from([("new-starred".into(), 1)]),
+                    raw: "[]".into(),
+                },
+                ids: HashSet::from(["new-starred".into()]),
+            }),
+            user_login: Err(()),
+            gh_unavailable: true,
+        })
+        .unwrap();
+        refresh.base = Some(rx);
+
+        let updates = refresh.poll();
+
+        assert_eq!(updates.len(), 2);
+        assert!(updates[0].base_ready);
+        assert_eq!(updates[0].catalog.owned[0].gist_id, "old-owned");
+        assert_eq!(updates[0].catalog.starred[0].gist_id, "new-starred");
+        assert_eq!(updates[0].catalog.user_login.as_deref(), Some("octocat"));
+        assert_eq!(updates[0].catalog.comment_counts["old-owned"], 4);
+        assert_eq!(
+            updates[1].status.as_deref(),
+            Some("refresh incomplete: owned gists, current user unavailable")
+        );
+    }
+
+    #[test]
+    fn stale_generation_is_ignored() {
+        let catalog = old_catalog();
+        let mut refresh = GistRefresh::new(&catalog, false);
+        refresh.generation = 2;
+        let (tx, rx) = mpsc::channel();
+        tx.send(BaseResult {
+            generation: 1,
+            owned: Err(()),
+            starred: Err(()),
+            user_login: Err(()),
+            gh_unavailable: true,
+        })
+        .unwrap();
+        refresh.base = Some(rx);
+
+        assert!(refresh.poll().is_empty());
+        assert_eq!(refresh.catalog, catalog);
+    }
+
+    #[test]
+    fn enrichment_publishes_one_coherent_catalog_stage() {
+        let mut refresh = GistRefresh::new(&old_catalog(), false);
+        refresh.generation = 1;
+        refresh.remaining_enrichments = 1;
+        let (tx, rx) = mpsc::channel();
+        tx.send((
+            1,
+            CountCollection {
+                counts: HashMap::from([("old-owned".into(), 9)]),
+                incomplete: false,
+            },
+        ))
+        .unwrap();
+        refresh.fork_counts = Some(rx);
+
+        let updates = refresh.poll();
+
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0].catalog.fork_counts["old-owned"], 9);
+        assert_eq!(updates[0].catalog.star_counts["old-owned"], 7);
+        assert!(updates[0].persist);
+        assert!(updates[0].status.is_none());
+    }
+
+    #[test]
+    fn incomplete_enrichment_retains_cache_and_reports_at_end() {
+        let mut refresh = GistRefresh::new(&old_catalog(), false);
+        refresh.generation = 1;
+        refresh.remaining_enrichments = 1;
+        let (tx, rx) = mpsc::channel();
+        tx.send((
+            1,
+            CountCollection {
+                counts: HashMap::from([("old-owned".into(), 99)]),
+                incomplete: true,
+            },
+        ))
+        .unwrap();
+        refresh.star_counts = Some(rx);
+
+        let updates = refresh.poll();
+
+        assert_eq!(updates.len(), 1);
+        assert_eq!(updates[0].catalog.star_counts["old-owned"], 7);
+        assert!(!updates[0].persist);
+        assert_eq!(
+            updates[0].status.as_deref(),
+            Some("refresh incomplete: star counts unavailable")
+        );
+    }
+}

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -550,7 +550,7 @@ impl AppState {
     /// selected file row. Resets the manager's own filters first so the target is always
     /// visible. No-op (with a status hint) when there are no gists to manage.
     pub(crate) fn open_gist_manager(&mut self) {
-        if self.gists.is_empty() {
+        if self.gist_catalog.owned.is_empty() {
             self.status = Some("no gists to manage".into());
             return;
         }

--- a/src/tui/list_ranking.rs
+++ b/src/tui/list_ranking.rs
@@ -171,7 +171,7 @@ mod tests {
     fn reverse_ranking_orders_locals_by_selected_gist() {
         let mut state = initial_state();
         state.anchor = FocusPane::Gist;
-        state.gists = vec![GistFile {
+        state.gist_catalog.owned = vec![GistFile {
             updated_at: "x".into(),
             created_at: "x".into(),
             ..GistFile::fixture("a", "settings.json")
@@ -257,7 +257,7 @@ mod tests {
         // Regression: eagerly evaluating the cross-pane selection caused the two
         // anchor-driven rankings to recurse into each other.
         let mut state = initial_state();
-        state.gists = vec![GistFile {
+        state.gist_catalog.owned = vec![GistFile {
             updated_at: "x".into(),
             created_at: "x".into(),
             ..GistFile::fixture("a", "f")
@@ -279,7 +279,7 @@ mod tests {
     #[test]
     fn sort_by_name_and_recent_reorders_gists() {
         let mut state = initial_state();
-        state.gists = vec![
+        state.gist_catalog.owned = vec![
             GistFile {
                 public: true,
                 updated_at: "2026-01-01T00:00:00Z".into(),
@@ -307,7 +307,7 @@ mod tests {
     #[test]
     fn gist_type_filter_limits_ranked_gists() {
         let mut state = initial_state();
-        state.gists = vec![
+        state.gist_catalog.owned = vec![
             GistFile {
                 description: "p".into(),
                 public: true,
@@ -344,7 +344,7 @@ mod tests {
     #[test]
     fn no_local_selected_lists_all_gists_unranked() {
         let mut state = initial_state();
-        state.gists = vec![
+        state.gist_catalog.owned = vec![
             GistFile {
                 description: "first".into(),
                 updated_at: "x".into(),
@@ -380,7 +380,7 @@ mod tests {
                 modified: None,
             },
         ];
-        state.gists = vec![
+        state.gist_catalog.owned = vec![
             GistFile {
                 description: "settings".into(),
                 updated_at: "x".into(),
@@ -420,7 +420,7 @@ mod tests {
                 modified: None,
             },
         ];
-        state.gists = vec![
+        state.gist_catalog.owned = vec![
             GistFile {
                 description: "settings".into(),
                 updated_at: "x".into(),
@@ -494,7 +494,7 @@ mod tests {
                 modified: None,
             },
         ];
-        state.gists = vec![
+        state.gist_catalog.owned = vec![
             GistFile {
                 description: "settings".into(),
                 updated_at: "x".into(),
@@ -542,7 +542,7 @@ mod tests {
     #[test]
     fn forked_filter_shows_only_forks() {
         let mut state = initial_state();
-        state.gists = vec![
+        state.gist_catalog.owned = vec![
             GistFile {
                 description: "mine".into(),
                 public: true,
@@ -561,7 +561,7 @@ mod tests {
                 ..GistFile::fixture("forked", "b.txt")
             },
         ];
-        state.current_user_login = Some("me".into());
+        state.gist_catalog.user_login = Some("me".into());
         state.gist_type_filter = GistTypeFilter::Forked;
         let ids: Vec<_> = state
             .ranked_gists()
@@ -576,7 +576,7 @@ mod tests {
         // With the Starred type filter active, ranked_gists must draw from starred_gists, not the
         // owned list — exercises the owned/starred source switch with data on both sides.
         let mut state = initial_state();
-        state.gists = vec![GistFile {
+        state.gist_catalog.owned = vec![GistFile {
             description: "mine".into(),
             public: true,
             updated_at: "x".into(),
@@ -584,7 +584,7 @@ mod tests {
             owner_login: "me".into(),
             ..GistFile::fixture("owned", "a.txt")
         }];
-        state.starred_gists = vec![GistFile {
+        state.gist_catalog.starred = vec![GistFile {
             description: "theirs".into(),
             public: true,
             updated_at: "x".into(),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,6 +1,6 @@
 use crate::domain::{
-    group_gists, GistComment, GistFile, GistFileRef, GistGroup, GistRevision, LocalCandidate,
-    PinnedMapping,
+    group_gists, GistCatalog, GistComment, GistFile, GistFileRef, GistGroup, GistRevision,
+    LocalCandidate, PinnedMapping,
 };
 use crate::ranking::{RankedGistFile, RankedLocal};
 use anyhow::Result;
@@ -15,6 +15,7 @@ use ratatui::{backend::CrosstermBackend, widgets::Clear, Terminal};
 use std::io;
 use std::path::PathBuf;
 
+mod gist_refresh;
 mod mouse;
 pub use mouse::{
     point_in, HitTarget, MouseFrame, MouseSession, PaneHit, PaneTarget, PressKind, RowTarget,
@@ -824,11 +825,7 @@ pub struct DetailState {
 #[derive(Debug, Clone)]
 pub struct AppState {
     pub locals: Vec<LocalCandidate>,
-    pub gists: Vec<GistFile>,
-    /// Starred gists from `GET /gists/starred` (may include others' gists).
-    pub starred_gists: Vec<GistFile>,
-    pub starred_gist_ids: std::collections::HashSet<String>,
-    pub current_user_login: Option<String>,
+    pub gist_catalog: GistCatalog,
     pub pinned: Vec<PinnedMapping>,
     pub focus: FocusPane,
     /// The pane that DRIVES the match ranking, decoupled from `focus`: the anchored pane
@@ -927,14 +924,6 @@ pub struct AppState {
     /// Monotonic tick advanced once per event-loop iteration (~150ms); drives the in-progress
     /// spinner animation. Wraps freely — only its value modulo the frame count is observed.
     pub spinner_frame: usize,
-    /// Per-gist comment counts (`gist_id` → count) from the gist-list fetch, surfaced in the
-    /// gist manager rows. Kept off `GistFile` since the count is a gist-level value, not a
-    /// per-file one; empty until the first live fetch lands (cached startup gists show 0).
-    pub gist_comment_counts: std::collections::HashMap<String, u32>,
-    /// Per-gist fork counts (`gist_id` → how many users forked it), from `/gists/{id}/forks`.
-    pub gist_fork_counts: std::collections::HashMap<String, u32>,
-    /// Per-gist stargazer counts (`gist_id` → count), from GraphQL `stargazerCount`.
-    pub gist_star_counts: std::collections::HashMap<String, u32>,
     /// Active theme selection (persisted to config when toggled with `T`).
     pub theme_choice: crate::config::ThemeChoice,
     /// Resolved colour palette for the current theme choice (from config).
@@ -1407,9 +1396,9 @@ impl AppState {
 
     fn list_gist_source(&self) -> &[GistFile] {
         if self.gist_type_filter.uses_starred_source() {
-            &self.starred_gists
+            &self.gist_catalog.starred
         } else {
-            &self.gists
+            &self.gist_catalog.owned
         }
     }
 
@@ -1418,9 +1407,9 @@ impl AppState {
             .gist_manager()
             .is_some_and(|g| g.type_filter.uses_starred_source());
         if starred {
-            &self.starred_gists
+            &self.gist_catalog.starred
         } else {
-            &self.gists
+            &self.gist_catalog.owned
         }
     }
 
@@ -1431,10 +1420,15 @@ impl AppState {
         // A gist you own *and* starred is fetched by both `/gists` and `/gists/starred`,
         // so it appears in both lists. Owned takes precedence; skip the starred copy to
         // avoid showing each of its files twice in the detail view (issue #188).
-        let owned_ids: std::collections::HashSet<&str> =
-            self.gists.iter().map(|g| g.gist_id.as_str()).collect();
-        self.gists.iter().chain(
-            self.starred_gists
+        let owned_ids: std::collections::HashSet<&str> = self
+            .gist_catalog
+            .owned
+            .iter()
+            .map(|g| g.gist_id.as_str())
+            .collect();
+        self.gist_catalog.owned.iter().chain(
+            self.gist_catalog
+                .starred
                 .iter()
                 .filter(move |g| !owned_ids.contains(g.gist_id.as_str())),
         )
@@ -1473,37 +1467,49 @@ impl AppState {
     }
 
     pub fn gist_is_owned(&self, gist_id: &str) -> bool {
-        if let Some(me) = self.current_user_login.as_deref() {
+        if let Some(me) = self.gist_catalog.user_login.as_deref() {
             self.all_gist_files()
                 .find(|g| g.gist_id == gist_id)
                 .is_some_and(|g| g.is_owned_by(me))
         } else {
-            self.gists.iter().any(|g| g.gist_id == gist_id)
+            self.gist_catalog.owned.iter().any(|g| g.gist_id == gist_id)
         }
     }
 
     pub fn gist_is_starred(&self, gist_id: &str) -> bool {
-        self.starred_gist_ids.contains(gist_id)
+        self.gist_catalog.starred_ids.contains(gist_id)
     }
 
     /// Per-gist comment, stargazer, and fork counts for row/detail labels.
     pub fn gist_counts(&self, gist_id: &str) -> (u32, u32, u32) {
         (
-            self.gist_comment_counts.get(gist_id).copied().unwrap_or(0),
-            self.gist_star_counts.get(gist_id).copied().unwrap_or(0),
-            self.gist_fork_counts.get(gist_id).copied().unwrap_or(0),
+            self.gist_catalog
+                .comment_counts
+                .get(gist_id)
+                .copied()
+                .unwrap_or(0),
+            self.gist_catalog
+                .star_counts
+                .get(gist_id)
+                .copied()
+                .unwrap_or(0),
+            self.gist_catalog
+                .fork_counts
+                .get(gist_id)
+                .copied()
+                .unwrap_or(0),
         )
     }
 
     /// Gists you have starred (unique ids from the starred list fetch).
     pub fn starred_gist_count(&self) -> usize {
-        self.starred_gist_ids.len()
+        self.gist_catalog.starred_ids.len()
     }
 
     /// Owned gists that are forks of an upstream gist.
     pub fn owned_fork_gist_count(&self) -> usize {
         let mut seen = std::collections::HashSet::new();
-        for g in &self.gists {
+        for g in &self.gist_catalog.owned {
             if g.is_fork() {
                 seen.insert(g.gist_id.as_str());
             }
@@ -1527,7 +1533,7 @@ impl AppState {
 
     /// All gists collapsed to one entry each (raw, unfiltered) from the owned list.
     pub fn gist_groups(&self) -> Vec<GistGroup> {
-        group_gists(&self.gists)
+        group_gists(&self.gist_catalog.owned)
     }
 
     /// The gist-level view's rows after the visibility filter, text filter, and sort
@@ -1571,12 +1577,24 @@ impl AppState {
                     unix_now(),
                     sort,
                     (
-                        self.gist_comment_counts.get(&g.id).copied().unwrap_or(0),
-                        self.gist_star_counts.get(&g.id).copied().unwrap_or(0),
-                        self.gist_fork_counts.get(&g.id).copied().unwrap_or(0),
+                        self.gist_catalog
+                            .comment_counts
+                            .get(&g.id)
+                            .copied()
+                            .unwrap_or(0),
+                        self.gist_catalog
+                            .star_counts
+                            .get(&g.id)
+                            .copied()
+                            .unwrap_or(0),
+                        self.gist_catalog
+                            .fork_counts
+                            .get(&g.id)
+                            .copied()
+                            .unwrap_or(0),
                     ),
                     self.gist_is_starred(&g.id),
-                    self.current_user_login.as_deref(),
+                    self.gist_catalog.user_login.as_deref(),
                 )
             })
             .map(|t| hscroll_max_for_text(&t))
@@ -1848,7 +1866,8 @@ impl AppState {
             let gist_id = self.download_gist_id().unwrap_or_default().to_string();
             let raw_url = self.gist_file_raw_url(&gist_id, &local_filename);
             let has_same_name = self
-                .gists
+                .gist_catalog
+                .owned
                 .iter()
                 .any(|g| g.gist_id == gist_id && g.filename == local_filename);
             return if has_same_name {
@@ -1882,7 +1901,8 @@ impl AppState {
         let gist_id = gist.file.gist_id.clone();
         let raw_url = gist.file.raw_url.clone();
         let has_same_name = self
-            .gists
+            .gist_catalog
+            .owned
             .iter()
             .any(|g| g.gist_id == gist_id && g.filename == local_filename);
         if has_same_name {
@@ -2043,10 +2063,7 @@ pub(crate) fn format_file_size(bytes: u64) -> String {
 pub fn initial_state() -> AppState {
     AppState {
         locals: Vec::new(),
-        gists: Vec::new(),
-        starred_gists: Vec::new(),
-        starred_gist_ids: std::collections::HashSet::new(),
-        current_user_login: None,
+        gist_catalog: GistCatalog::default(),
         pinned: Vec::new(),
         focus: FocusPane::Local,
         anchor: FocusPane::Local,
@@ -2100,9 +2117,6 @@ pub fn initial_state() -> AppState {
         upload: UploadState::default(),
         nav_stack: Vec::new(),
         spinner_frame: 0,
-        gist_comment_counts: std::collections::HashMap::new(),
-        gist_fork_counts: std::collections::HashMap::new(),
-        gist_star_counts: std::collections::HashMap::new(),
         theme_choice: crate::config::ThemeChoice::Dark,
         theme: Theme::DARK,
         pin_sync_cache: Vec::new(),
@@ -2162,13 +2176,7 @@ pub fn load_startup_state(no_mouse: bool, no_update_check: bool) -> Result<AppSt
     // Show last-known gists (owned + starred + counts) from cache; background fetch refreshes.
     if let Ok(path) = crate::cache::cache_path() {
         if let Some(cache) = crate::cache::load_gist_cache(&path) {
-            state.starred_gist_ids = cache.starred_ids_set();
-            state.gists = cache.owned;
-            state.starred_gists = cache.starred;
-            state.current_user_login = cache.user_login;
-            state.gist_comment_counts = cache.comment_counts;
-            state.gist_fork_counts = cache.fork_counts;
-            state.gist_star_counts = cache.star_counts;
+            state.gist_catalog = cache;
         }
     }
 
@@ -2271,12 +2279,12 @@ mod tests {
     }
 
     /// Issue #348: the lookup must also cover starred (not just owned) gists — one of the call
-    /// sites this fix replaced only checked `state.gists`, so a starred gist's diff header still
+    /// sites this fix replaced only checked `state.gist_catalog.owned`, so a starred gist's diff header still
     /// showed `(unknown)` even though its age was visible in Pinned Mappings.
     #[test]
     fn gist_file_for_diff_finds_a_starred_gist_too() {
         let mut state = initial_state();
-        state.starred_gists = vec![GistFile {
+        state.gist_catalog.starred = vec![GistFile {
             description: "starred demo".into(),
             public: true,
             updated_at: "2026-06-12T08:00:00Z".into(),
@@ -2336,9 +2344,9 @@ mod tests {
             ..GistFile::fixture("g1", filename)
         };
         let mut state = initial_state();
-        state.gists = vec![make(".zprofile"), make(".zshenv"), make(".zshrc")];
+        state.gist_catalog.owned = vec![make(".zprofile"), make(".zshenv"), make(".zshrc")];
         // Same gist, fetched again from /gists/starred because the owner starred it.
-        state.starred_gists = vec![make(".zprofile"), make(".zshenv"), make(".zshrc")];
+        state.gist_catalog.starred = vec![make(".zprofile"), make(".zshenv"), make(".zshrc")];
 
         assert_eq!(
             state.gist_filenames("g1"),

--- a/src/tui/palette.rs
+++ b/src/tui/palette.rs
@@ -353,7 +353,7 @@ mod tests {
     #[test]
     fn gists_palette_items_enable_selection_actions_when_selected() {
         let mut state = initial_state();
-        state.gists = vec![test_gist("g1", "a.txt")];
+        state.gist_catalog.owned = vec![test_gist("g1", "a.txt")];
         state.screen = Screen::Gists(Box::default());
         let items = menu_items(&state);
         assert!(items.iter().all(|i| i.enabled));
@@ -387,7 +387,7 @@ mod tests {
     #[test]
     fn detail_palette_items_enable_owned_actions_for_owned_previewable_gist() {
         let mut state = initial_state();
-        state.gists = vec![test_gist("g1", "a.txt")];
+        state.gist_catalog.owned = vec![test_gist("g1", "a.txt")];
         state.screen = Screen::GistDetail(Box::new(DetailState {
             gist_id: Some("g1".into()),
             focus: DetailFocus::Files,
@@ -418,8 +418,8 @@ mod tests {
     #[test]
     fn detail_palette_items_gate_fork_on_ownership() {
         let mut state = initial_state();
-        state.gists = vec![test_gist("g1", "a.txt")];
-        state.current_user_login = Some("someone-else".into());
+        state.gist_catalog.owned = vec![test_gist("g1", "a.txt")];
+        state.gist_catalog.user_login = Some("someone-else".into());
         state.screen = Screen::GistDetail(Box::new(DetailState {
             gist_id: Some("g1".into()),
             focus: DetailFocus::Files,
@@ -437,7 +437,7 @@ mod tests {
         // previously showed "Load older comments" enabled even while the Files tab was
         // focused (where `m` is a no-op in `handle_key_detail`).
         let mut state = initial_state();
-        state.gists = vec![test_gist("g1", "a.txt")];
+        state.gist_catalog.owned = vec![test_gist("g1", "a.txt")];
         state.screen = Screen::GistDetail(Box::new(DetailState {
             gist_id: Some("g1".into()),
             focus: DetailFocus::Files,
@@ -461,13 +461,13 @@ mod tests {
         // allows creating a *new* pin on an owned gist — the palette previously enabled "Pin
         // / unpin pair" for any local+gist selection regardless of ownership.
         let mut state = initial_state();
-        state.current_user_login = Some("me".into());
+        state.gist_catalog.user_login = Some("me".into());
         state.locals = vec![LocalCandidate {
             path: PathBuf::from("a.txt"),
             pinned: false,
             modified: None,
         }];
-        state.gists = vec![GistFile {
+        state.gist_catalog.owned = vec![GistFile {
             owner_login: "someone-else".into(),
             ..test_gist("g1", "a.txt")
         }];
@@ -488,7 +488,7 @@ mod tests {
     #[test]
     fn revisions_palette_items_gate_diff_and_restore_on_head_position() {
         let mut state = initial_state();
-        state.gists = vec![test_gist("g1", "a.txt")];
+        state.gist_catalog.owned = vec![test_gist("g1", "a.txt")];
         state.screen = Screen::Revisions(Box::new(RevisionState {
             gist_id: Some("g1".into()),
             target_file: "a.txt".into(),
@@ -579,7 +579,7 @@ mod tests {
         // `entries`. A multi-file gist should show "Cycle target file" enabled even while
         // entries are still `None`.
         let mut state = initial_state();
-        state.gists = vec![test_gist("g1", "a.txt"), test_gist("g1", "b.txt")];
+        state.gist_catalog.owned = vec![test_gist("g1", "a.txt"), test_gist("g1", "b.txt")];
         state.screen = Screen::Revisions(Box::new(RevisionState {
             gist_id: Some("g1".into()),
             target_file: "a.txt".into(),

--- a/src/tui/pin_sync.rs
+++ b/src/tui/pin_sync.rs
@@ -57,7 +57,7 @@ impl AppState {
             // never appear in `self.locals`. Fall back to stat-ing the path so the
             // Pins list and sync status still reflect the real mtime.
             .or_else(|| crate::local::file_mtime_secs(&local_abs));
-        let remote_ts = self.gists.iter().find_map(|g| {
+        let remote_ts = self.gist_catalog.owned.iter().find_map(|g| {
             (g.gist_id == m.gist_id && g.filename == m.gist_filename)
                 .then(|| crate::domain::parse_rfc3339_to_unix(&g.updated_at))
                 .flatten()
@@ -177,7 +177,7 @@ mod tests {
             direction: None,
             last_seen_hash: None,
         }];
-        state.gists = vec![GistFile {
+        state.gist_catalog.owned = vec![GistFile {
             updated_at: "2026-01-01T00:00:00Z".into(),
             ..GistFile::fixture("g1", "settings.json")
         }];
@@ -213,7 +213,7 @@ mod tests {
             direction: None,
             last_seen_hash: Some(hash),
         }];
-        state.gists = vec![GistFile {
+        state.gist_catalog.owned = vec![GistFile {
             // Far in the past, so the just-written local file (mtime ~ now) reads as newer —
             // sync_status(Some(local_ts), Some(remote_ts)) would normally resolve to Push.
             updated_at: "2020-01-01T00:00:00Z".into(),
@@ -247,7 +247,7 @@ mod tests {
             direction: None,
             last_seen_hash: Some("does-not-match-anything".into()),
         }];
-        state.gists = vec![GistFile {
+        state.gist_catalog.owned = vec![GistFile {
             updated_at: "2020-01-01T00:00:00Z".into(),
             ..GistFile::fixture("g1", "settings.json")
         }];
@@ -279,7 +279,7 @@ mod tests {
             direction: None,
             last_seen_hash: None,
         }];
-        state.gists = vec![GistFile {
+        state.gist_catalog.owned = vec![GistFile {
             updated_at: "2020-01-01T00:00:00Z".into(),
             ..GistFile::fixture("g1", "settings.json")
         }];

--- a/src/tui/render/mod.rs
+++ b/src/tui/render/mod.rs
@@ -313,7 +313,7 @@ mod tests {
     #[test]
     fn render_screen_vm_list_row_marks_clipped_description() {
         let mut state = initial_state();
-        state.gists = vec![gist_file(
+        state.gist_catalog.owned = vec![gist_file(
             "MicrosoftDateTimeJsonConverter.cs",
             "System.Text.Json deserialize legacy JSON data TAILMARKER",
         )];
@@ -332,7 +332,7 @@ mod tests {
     #[test]
     fn render_screen_vm_list_row_does_not_split_a_wide_character() {
         let mut state = initial_state();
-        state.gists = vec![gist_file(
+        state.gist_catalog.owned = vec![gist_file(
             "日本語テストファイル名前がとても長いです.txt",
             "desc",
         )];
@@ -347,7 +347,7 @@ mod tests {
     #[test]
     fn render_screen_vm_list_row_leaves_a_fitting_label_untouched() {
         let mut state = initial_state();
-        state.gists = vec![gist_file("a.txt", "short")];
+        state.gist_catalog.owned = vec![gist_file("a.txt", "short")];
         let text = render_state_size(&state, 137, 20);
         assert!(
             text.contains("a.txt — short"),
@@ -360,7 +360,7 @@ mod tests {
     fn render_screen_vm_gists_row_marks_clipped_description() {
         let mut state = initial_state();
         state.screen = Screen::Gists(Box::default());
-        state.gists = vec![gist_file(
+        state.gist_catalog.owned = vec![gist_file(
             "file.txt",
             "a very long gist description that must not survive a narrow manager row TAILMARKER",
         )];
@@ -417,13 +417,16 @@ mod tests {
     fn render_gist_detail_metadata_fits_at_eighty_columns() {
         let mut state = initial_state();
         state.screen = Screen::GistDetail(Box::default());
-        state.gists = vec![crate::domain::GistFile {
+        state.gist_catalog.owned = vec![crate::domain::GistFile {
             content_type: Some("text/plain".into()),
             size: 1_536,
             ..gist_file("notes.txt", "metadata")
         }];
         state.detail_mut().unwrap().gist_id = Some("abc123def".into());
-        state.gist_comment_counts.insert("abc123def".into(), 3);
+        state
+            .gist_catalog
+            .comment_counts
+            .insert("abc123def".into(), 3);
 
         let text = render_state_size(&state, 80, 24);
         assert!(text.contains("notes.txt · 1.5 KiB · text/plain"), "{text}");
@@ -574,7 +577,7 @@ mod tests {
     fn render_comments_keep_hanging_indent_at_eighty_columns() {
         let mut state = initial_state();
         state.screen = Screen::GistDetail(Box::default());
-        state.gists = vec![crate::domain::GistFile::fixture("g1", "a.txt")];
+        state.gist_catalog.owned = vec![crate::domain::GistFile::fixture("g1", "a.txt")];
         if let Some(d) = state.detail_mut() {
             d.gist_id = Some("g1".into());
             d.focus = DetailFocus::Comments;

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -38,7 +38,7 @@ pub(super) fn run_loop(
             update_rx = Some(spawn_update_check());
         }
     }
-    let mut jobs = Jobs::startup(update_rx, true);
+    let mut jobs = Jobs::startup(update_rx, true, &state.gist_catalog);
     // Pins presentation cache: refresh on enter/return to Pins (or Pins-as-palette-bg) and
     // whenever the dirty flag is set — never every frame while already on Pins (#241).
     let mut pin_sync_screen_active = false;

--- a/src/tui/screens/confirm.rs
+++ b/src/tui/screens/confirm.rs
@@ -390,7 +390,7 @@ mod tests {
     #[test]
     fn stage_upload_preview_falls_back_to_list_raw_url() {
         let mut state = state_with_gists();
-        state.gists[0].raw_url = Some("https://example.test/a.txt".into());
+        state.gist_catalog.owned[0].raw_url = Some("https://example.test/a.txt".into());
         let file = gist_file_ref("g1", "a.txt");
 
         let (file, local_label, gist_label) =

--- a/src/tui/screens/detail.rs
+++ b/src/tui/screens/detail.rs
@@ -567,7 +567,7 @@ pub(crate) fn build_gist_detail_vm(state: &AppState) -> GistDetailVm {
     let info_line = crate::tui::render::gist_info_line(
         &group,
         crate::tui::render::unix_now(),
-        state.current_user_login.as_deref(),
+        state.gist_catalog.user_login.as_deref(),
         state.gist_is_starred(gist_id),
         state.gist_counts(gist_id),
     );
@@ -1046,7 +1046,7 @@ mod tests {
 
     fn state_with_many_files(n: usize) -> AppState {
         let mut state = initial_state();
-        state.gists = (0..n)
+        state.gist_catalog.owned = (0..n)
             .map(|i| GistFile {
                 description: "demo".into(),
                 updated_at: "2026-06-10T00:00:00Z".into(),
@@ -1319,10 +1319,10 @@ mod tests {
     #[test]
     fn fork_key_returns_fork_intent_for_foreign_gist_in_detail() {
         let mut state = initial_state();
-        state.current_user_login = Some("me".into());
+        state.gist_catalog.user_login = Some("me".into());
         state.screen = Screen::GistDetail(Box::default());
         detail_mut(&mut state).gist_id = Some("foreign".into());
-        state.starred_gists = vec![GistFile {
+        state.gist_catalog.starred = vec![GistFile {
             description: "x".into(),
             public: true,
             updated_at: "x".into(),
@@ -1339,10 +1339,10 @@ mod tests {
     #[test]
     fn fork_key_blocked_for_owned_gist_in_detail() {
         let mut state = initial_state();
-        state.current_user_login = Some("me".into());
+        state.gist_catalog.user_login = Some("me".into());
         state.screen = Screen::GistDetail(Box::default());
         detail_mut(&mut state).gist_id = Some("mine".into());
-        state.gists = vec![GistFile {
+        state.gist_catalog.owned = vec![GistFile {
             description: "x".into(),
             public: true,
             updated_at: "x".into(),
@@ -1357,10 +1357,10 @@ mod tests {
     #[test]
     fn foreign_detail_mutate_keys_are_silent_noop() {
         let mut state = initial_state();
-        state.current_user_login = Some("me".into());
+        state.gist_catalog.user_login = Some("me".into());
         state.screen = Screen::GistDetail(Box::default());
         detail_mut(&mut state).gist_id = Some("foreign".into());
-        state.starred_gists = vec![GistFile {
+        state.gist_catalog.starred = vec![GistFile {
             description: "x".into(),
             public: true,
             updated_at: "x".into(),
@@ -1473,7 +1473,7 @@ mod tests {
         let mut state = initial_state();
         state.screen = Screen::GistDetail(Box::default());
         detail_mut(&mut state).gist_id = Some("g1".into());
-        state.gists = vec![GistFile::fixture("g1", "a.txt")];
+        state.gist_catalog.owned = vec![GistFile::fixture("g1", "a.txt")];
         detail_mut(&mut state).comments = Some(comments);
         detail_mut(&mut state).comments_loaded_oldest_page = 1;
         let detail = build_gist_detail_vm(&state);

--- a/src/tui/screens/diff.rs
+++ b/src/tui/screens/diff.rs
@@ -545,7 +545,7 @@ mod tests {
             pinned: false,
             modified: None,
         }];
-        state.gists = vec![GistFile {
+        state.gist_catalog.owned = vec![GistFile {
             description: "x".into(),
             updated_at: "x".into(),
             created_at: "x".into(),

--- a/src/tui/screens/gists.rs
+++ b/src/tui/screens/gists.rs
@@ -181,12 +181,27 @@ pub(crate) fn build_gists_vm(state: &AppState) -> GistsVm {
                     now,
                     gm.sort,
                     (
-                        state.gist_comment_counts.get(&g.id).copied().unwrap_or(0),
-                        state.gist_star_counts.get(&g.id).copied().unwrap_or(0),
-                        state.gist_fork_counts.get(&g.id).copied().unwrap_or(0),
+                        state
+                            .gist_catalog
+                            .comment_counts
+                            .get(&g.id)
+                            .copied()
+                            .unwrap_or(0),
+                        state
+                            .gist_catalog
+                            .star_counts
+                            .get(&g.id)
+                            .copied()
+                            .unwrap_or(0),
+                        state
+                            .gist_catalog
+                            .fork_counts
+                            .get(&g.id)
+                            .copied()
+                            .unwrap_or(0),
                     ),
                     state.gist_is_starred(&g.id),
-                    state.current_user_login.as_deref(),
+                    state.gist_catalog.user_login.as_deref(),
                 ),
             })
             .collect();
@@ -419,7 +434,7 @@ mod tests {
     fn gist_view_s_cycles_sort_updated_then_created() {
         let mut state = initial_state();
         state.screen = Screen::Gists(Box::default());
-        state.gists = vec![
+        state.gist_catalog.owned = vec![
             GistFile {
                 description: "x".into(),
                 updated_at: "2026-01-01T00:00:00Z".into(),
@@ -458,7 +473,7 @@ mod tests {
 
     fn gists_screen_state() -> AppState {
         let mut state = initial_state();
-        state.gists = vec![
+        state.gist_catalog.owned = vec![
             GistFile {
                 description: "alpha".into(),
                 updated_at: "2026-06-10T00:00:00Z".into(),
@@ -515,7 +530,7 @@ mod tests {
     fn gists_page_keys_jump_selection() {
         let mut state = initial_state();
         state.screen = Screen::Gists(Box::default());
-        state.gists = (0..12)
+        state.gist_catalog.owned = (0..12)
             .map(|i| GistFile {
                 description: format!("gist {i}"),
                 public: true,
@@ -533,8 +548,8 @@ mod tests {
     #[test]
     fn fork_key_ignored_on_list_and_gist_manager() {
         let mut state = initial_state();
-        state.current_user_login = Some("me".into());
-        state.starred_gists = vec![GistFile {
+        state.gist_catalog.user_login = Some("me".into());
+        state.gist_catalog.starred = vec![GistFile {
             description: "x".into(),
             public: true,
             updated_at: "x".into(),

--- a/src/tui/screens/list.rs
+++ b/src/tui/screens/list.rs
@@ -121,7 +121,7 @@ pub(crate) fn list_guard(state: &AppState, code: KeyCode) -> bool {
         // handler's (looser, tested) condition instead of narrowing the handler to match the
         // palette, since the palette's extra restriction wasn't guarding against a real bug.
         KeyCode::Char('S') => has_local && has_gist,
-        KeyCode::Char('g') => !state.gists.is_empty(),
+        KeyCode::Char('g') => !state.gist_catalog.owned.is_empty(),
         KeyCode::Char('X') => {
             has_gist
                 && owned
@@ -697,7 +697,7 @@ pub(crate) fn build_list_vm(state: &AppState) -> ListVm {
     let gist_head = |name: &str| {
         format!(
             "[2] {name}{}{}",
-            crate::tui::render::count_label(ranked.len(), state.gists.len()),
+            crate::tui::render::count_label(ranked.len(), state.gist_catalog.owned.len()),
             anchor_marker(state, FocusPane::Gist)
         )
     };
@@ -1099,7 +1099,7 @@ mod tests {
     fn x_on_a_gists_only_file_is_blocked() {
         let mut state = initial_state();
         state.focus = FocusPane::Gist;
-        state.gists = vec![GistFile {
+        state.gist_catalog.owned = vec![GistFile {
             updated_at: "2026-01-01T00:00:00Z".into(),
             created_at: "2026-01-01T00:00:00Z".into(),
             ..GistFile::fixture("abc123", "notes.md")
@@ -1213,7 +1213,7 @@ mod tests {
     #[test]
     fn list_click_selects_and_focuses_local_pane() {
         let mut state = state_with_local_paths(&["a.rs", "b.rs", "c.rs"]);
-        state.gists = vec![];
+        state.gist_catalog.owned = vec![];
         state.screen = Screen::List;
         state.focus = FocusPane::Gist;
         state.local_hscroll = 5;
@@ -1579,8 +1579,8 @@ mod tests {
     #[test]
     fn space_blocks_preview_for_image_gist_file() {
         let mut state = state_with_two_gists();
-        state.gists[0].filename = "logo.png".into();
-        state.gists[0].content_type = Some("image/png".into());
+        state.gist_catalog.owned[0].filename = "logo.png".into();
+        state.gist_catalog.owned[0].content_type = Some("image/png".into());
         assert_eq!(state.handle_key(KeyCode::Char(' ')), KeyOutcome::None);
         assert!(state
             .status
@@ -1591,8 +1591,8 @@ mod tests {
     #[test]
     fn enter_blocks_diff_for_image_gist_file() {
         let mut state = state_with_two_gists();
-        state.gists[0].filename = "photo.jpg".into();
-        state.gists[0].content_type = Some("image/jpeg".into());
+        state.gist_catalog.owned[0].filename = "photo.jpg".into();
+        state.gist_catalog.owned[0].content_type = Some("image/jpeg".into());
         assert_eq!(state.handle_key(KeyCode::Enter), KeyOutcome::None);
         assert!(state
             .status
@@ -1609,7 +1609,7 @@ mod tests {
     #[test]
     fn left_right_scrolls_focused_gist_pane() {
         let mut state = initial_state();
-        state.gists = vec![GistFile {
+        state.gist_catalog.owned = vec![GistFile {
             description: "a fairly long description for scrolling".into(),
             updated_at: "x".into(),
             created_at: "x".into(),
@@ -1629,7 +1629,7 @@ mod tests {
     #[test]
     fn gist_hscroll_caps_at_painted_row() {
         let mut state = initial_state();
-        state.gists = vec![GistFile {
+        state.gist_catalog.owned = vec![GistFile {
             description: "tiny".into(),
             updated_at: "x".into(),
             created_at: "x".into(),
@@ -1654,7 +1654,7 @@ mod tests {
     fn gist_hscroll_follows_the_selected_row() {
         let mut state = initial_state();
         state.gist_sort = GistSort::Name;
-        state.gists = vec![
+        state.gist_catalog.owned = vec![
             GistFile {
                 description: "ab".into(),
                 updated_at: "x".into(),
@@ -1739,13 +1739,13 @@ mod tests {
     #[test]
     fn gist_hscroll_caps_include_star_prefix() {
         let mut state = initial_state();
-        state.gists = vec![GistFile {
+        state.gist_catalog.owned = vec![GistFile {
             description: "tiny".into(),
             updated_at: "x".into(),
             created_at: "x".into(),
             ..GistFile::fixture("starred-id", "f")
         }];
-        state.starred_gist_ids.insert("starred-id".into());
+        state.gist_catalog.starred_ids.insert("starred-id".into());
         state.focus = FocusPane::Gist;
 
         let ranked = state.ranked_gists();
@@ -1779,7 +1779,7 @@ mod tests {
     #[test]
     fn moving_gist_selection_resets_hscroll() {
         let mut state = initial_state();
-        state.gists = vec![
+        state.gist_catalog.owned = vec![
             GistFile {
                 description: "first long description here".into(),
                 updated_at: "x".into(),
@@ -1803,7 +1803,7 @@ mod tests {
     #[test]
     fn enter_with_no_local_but_gist_selected_returns_preview() {
         let mut state = initial_state();
-        state.gists = vec![GistFile {
+        state.gist_catalog.owned = vec![GistFile {
             description: "first".into(),
             updated_at: "x".into(),
             created_at: "x".into(),
@@ -1959,7 +1959,7 @@ mod tests {
             pinned: false,
             modified: None,
         }];
-        state.gists = vec![GistFile {
+        state.gist_catalog.owned = vec![GistFile {
             description: "x".into(),
             updated_at: "x".into(),
             created_at: "x".into(),
@@ -1980,7 +1980,7 @@ mod tests {
             pinned: false,
             modified: None,
         }];
-        state.gists = vec![GistFile {
+        state.gist_catalog.owned = vec![GistFile {
             description: "x".into(),
             updated_at: "x".into(),
             created_at: "x".into(),
@@ -2041,7 +2041,7 @@ mod tests {
     fn x_removes_selected_file_from_a_multifile_gist() {
         let mut state = initial_state();
         state.focus = FocusPane::Gist;
-        state.gists = vec![
+        state.gist_catalog.owned = vec![
             GistFile {
                 description: "my notes".into(),
                 updated_at: "2026-01-01T00:00:00Z".into(),
@@ -2076,7 +2076,7 @@ mod tests {
             pinned: true,
             modified: None,
         }];
-        state.gists = vec![GistFile::fixture("g1", "a.txt")];
+        state.gist_catalog.owned = vec![GistFile::fixture("g1", "a.txt")];
         let KeyOutcome::SyncSelectedPair { entry, .. } = state.handle_key(KeyCode::Char('S'))
         else {
             panic!("expected deferred pair sync");
@@ -2233,13 +2233,13 @@ mod tests {
     #[test]
     fn foreign_gist_blocks_pin() {
         let mut state = initial_state();
-        state.current_user_login = Some("me".into());
+        state.gist_catalog.user_login = Some("me".into());
         state.locals = vec![LocalCandidate {
             path: PathBuf::from("/cwd/a.txt"),
             pinned: false,
             modified: None,
         }];
-        state.gists = vec![GistFile {
+        state.gist_catalog.owned = vec![GistFile {
             description: "x".into(),
             public: true,
             updated_at: "x".into(),
@@ -2256,7 +2256,7 @@ mod tests {
     #[test]
     fn star_key_returns_toggle_intent() {
         let mut state = initial_state();
-        state.gists = vec![GistFile {
+        state.gist_catalog.owned = vec![GistFile {
             description: "x".into(),
             public: true,
             updated_at: "x".into(),

--- a/src/tui/screens/preview.rs
+++ b/src/tui/screens/preview.rs
@@ -270,7 +270,7 @@ mod tests {
     #[test]
     fn stage_preview_content_miss_falls_back_to_raw_url_and_returns_title() {
         let mut state = state_with_gists();
-        state.gists[0].raw_url = Some("https://example.test/a.txt".into());
+        state.gist_catalog.owned[0].raw_url = Some("https://example.test/a.txt".into());
 
         let (file, title) =
             stage_preview_content(&mut state, gist_file_ref("g1", "a.txt")).expect("spawn");
@@ -282,7 +282,7 @@ mod tests {
     #[test]
     fn stage_refresh_preview_drops_cache_and_returns_fetch_payload() {
         let mut state = state_with_gists();
-        state.gists[0].raw_url = Some("https://example.test/a.txt".into());
+        state.gist_catalog.owned[0].raw_url = Some("https://example.test/a.txt".into());
         let file = gist_file_ref("g1", "a.txt");
         state
             .gist_content_cache

--- a/src/tui/screens/revisions.rs
+++ b/src/tui/screens/revisions.rs
@@ -684,7 +684,7 @@ mod tests {
     #[test]
     fn revisions_capital_f_on_single_file_gist_shows_status() {
         let mut state = initial_state();
-        state.gists = vec![GistFile {
+        state.gist_catalog.owned = vec![GistFile {
             description: "solo".into(),
             updated_at: "x".into(),
             created_at: "x".into(),

--- a/src/tui/test_support.rs
+++ b/src/tui/test_support.rs
@@ -104,7 +104,7 @@ pub(super) fn set_diff_scroll(state: &mut AppState, scroll: u16) {
 
 pub(super) fn state_with_gists() -> AppState {
     let mut state = initial_state();
-    state.gists = vec![
+    state.gist_catalog.owned = vec![
         GistFile {
             description: "demo".into(),
             updated_at: "2026-06-10T00:00:00Z".into(),
@@ -150,7 +150,7 @@ pub(super) fn list_state_with_matches() -> AppState {
             modified: None,
         },
     ];
-    state.gists = vec![
+    state.gist_catalog.owned = vec![
         GistFile {
             description: "Zed".into(),
             public: true,
@@ -173,7 +173,7 @@ pub(super) fn list_state_with_matches() -> AppState {
 
 pub(super) fn state_with_two_gists() -> AppState {
     let mut state = initial_state();
-    state.gists = vec![
+    state.gist_catalog.owned = vec![
         GistFile {
             description: "My Ghostty config".into(),
             public: true,
@@ -199,7 +199,7 @@ pub(super) fn state_with_selection() -> AppState {
         pinned: false,
         modified: None,
     }];
-    state.gists = vec![GistFile {
+    state.gist_catalog.owned = vec![GistFile {
         description: "settings".into(),
         updated_at: "x".into(),
         created_at: "x".into(),

--- a/src/tui/view_model.rs
+++ b/src/tui/view_model.rs
@@ -415,7 +415,7 @@ pub(crate) fn build_compact_gist_bg_vm(state: &AppState, gist_id: &str) -> Optio
         info_line: gist_info_line(
             &group,
             unix_now(),
-            state.current_user_login.as_deref(),
+            state.gist_catalog.user_login.as_deref(),
             state.gist_is_starred(gist_id),
             state.gist_counts(gist_id),
         ),
@@ -731,11 +731,11 @@ mod tests {
             pinned: true,
             modified: None,
         }];
-        state.gists = vec![GistFile {
+        state.gist_catalog.owned = vec![GistFile {
             description: "demo notes".into(),
             ..GistFile::fixture("g1", "notes.txt")
         }];
-        state.starred_gist_ids.insert("g1".into());
+        state.gist_catalog.starred_ids.insert("g1".into());
         state.pinned = vec![PinnedMapping {
             local_path: PathBuf::from("notes.txt"),
             gist_id: "g1".into(),
@@ -856,7 +856,7 @@ mod tests {
             other => panic!("expected Gists, got {other:?}"),
         }
 
-        state.gists = vec![
+        state.gist_catalog.owned = vec![
             GistFile {
                 description: "alpha".into(),
                 ..GistFile::fixture("g1", "a.txt")
@@ -866,8 +866,8 @@ mod tests {
                 ..GistFile::fixture("g2", "b.txt")
             },
         ];
-        state.starred_gist_ids.insert("g1".into());
-        state.gist_comment_counts.insert("g1".into(), 2);
+        state.gist_catalog.starred_ids.insert("g1".into());
+        state.gist_catalog.comment_counts.insert("g1".into(), 2);
         match build_view_model(&state).screen {
             ScreenVm::Gists(g) => {
                 assert_eq!(g.pane.empty, ListPaneEmpty::HasRows);
@@ -895,7 +895,7 @@ mod tests {
 
         let mut state = initial_state();
         state.screen = Screen::Gists(Box::default());
-        state.gists = vec![GistFile::fixture("g1", "a.txt")];
+        state.gist_catalog.owned = vec![GistFile::fixture("g1", "a.txt")];
         if let Some(gm) = state.gist_manager_mut() {
             gm.filter_query = crate::tui::TextInput::from("zzz-nope");
         }
@@ -936,7 +936,7 @@ mod tests {
 
         let mut state = initial_state();
         state.screen = Screen::GistDetail(Box::default());
-        state.gists = vec![
+        state.gist_catalog.owned = vec![
             GistFile {
                 description: "demo".into(),
                 content_type: Some("text/plain".into()),
@@ -950,7 +950,7 @@ mod tests {
             d.focus = DetailFocus::Files;
             d.file_cursor = 1;
         }
-        state.gist_comment_counts.insert("g1".into(), 3);
+        state.gist_catalog.comment_counts.insert("g1".into(), 3);
 
         match build_view_model(&state).screen {
             ScreenVm::GistDetail(d) => {
@@ -1024,7 +1024,7 @@ mod tests {
         if let Some(r) = state.revision_mut() {
             r.gist_id = Some("g1".into());
         }
-        state.gists = vec![GistFile {
+        state.gist_catalog.owned = vec![GistFile {
             description: "hist".into(),
             ..GistFile::fixture("g1", "a.txt")
         }];
@@ -1187,7 +1187,7 @@ mod tests {
         use crate::domain::GistFile;
 
         let mut state = initial_state();
-        state.gists = vec![GistFile {
+        state.gist_catalog.owned = vec![GistFile {
             description: "pack".into(),
             ..GistFile::fixture("g1", "a.txt")
         }];


### PR DESCRIPTION
## Summary

- introduce a domain `GistCatalog` as the live and cached whole-list read model
- move base fetch, progressive enrichment, generation supersession, and failure aggregation into one `GistRefresh` module
- retain last-known-good catalog fields on partial GitHub failures and persist only coherent stages

## Verification

- `mise run check`
- Standards review: clean
- Spec review: clean

Closes #402