### PR TITLE
fix(tui): centralize runtime settings persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Settings now reliably remember the "Show full diff" choice alongside the other preferences.
 - Gist refreshes now keep the last usable list and counts when one GitHub request fails, and a
   superseded refresh can no longer overwrite newer results.
 - Mouse double-clicks now respect close buttons, repository links, and top-bar shortcuts instead

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -6,10 +6,16 @@ Index: [`AGENTS.md`](../../AGENTS.md). Source of truth for types lives in the mo
 
 | Kind | Modules | Testing |
 | --- | --- | --- |
-| **Pure** (unit-tested) | `domain`, `config`, `ranking`, `local`, `diff`, actions **plan/guard**, `tui::view_model`, `tui::list_ranking` | In-crate unit tests |
+| **Pure** (unit-tested) | `domain`, `config`, `ranking`, `local`, `diff`, actions **plan/guard**, `tui::view_model`, `tui::list_ranking`, `tui::settings` | In-crate unit tests |
 | **Impure** (thin IO) | `gh`, actions **execute**, `tui::run_loop` / `tui::bg` / `tui::gist_refresh` / `tui::pin_sync` | No live `gh`. Spawn/absorb is thin IO; action-job `on_*` apply handlers (screen modules / `gist_mutation.rs`) are unit-tested (#298, #383) |
 
 `build_view_model` (`@src/tui/view_model.rs`): `AppState` + pin-sync cache → presentation facts. Paint helpers apply theme/layout only — no business rules, FS, or network.
+
+## Runtime settings (`@src/tui/settings.rs`, issue #404)
+
+- `RuntimeSettings` is the only runtime owner of the seven Settings-screen preferences and the `--no-mouse` / `--no-update-check` session overrides. Effective mouse and update-check values are derived; `Theme` is derived from `ThemeChoice`.
+- Settings-screen edits, global theme toggle, and Diff context toggle all call `RuntimeSettings::adjust`. Only a mouse change returns `SettingsEffect::SyncMouseCapture`; dispatch owns that terminal IO.
+- Persistence loads the current `AppConfig`, calls `apply_to_config`, then saves. That projection updates every runtime-owned field and leaves pins, skip directories, and other config data intact.
 
 ## GistFile construction (`@src/domain.rs`, issue #379)
 

--- a/src/tui/bg.rs
+++ b/src/tui/bg.rs
@@ -455,7 +455,7 @@ pub(super) fn edit_local_path(
         return Ok(());
     };
 
-    if state.mouse_enabled {
+    if state.settings.mouse_enabled() {
         execute!(terminal.backend_mut(), DisableMouseCapture)?;
     }
     disable_raw_mode()?;
@@ -466,7 +466,7 @@ pub(super) fn edit_local_path(
         .status();
     enable_raw_mode()?;
     execute!(terminal.backend_mut(), EnterAlternateScreen)?;
-    if state.mouse_enabled {
+    if state.settings.mouse_enabled() {
         execute!(terminal.backend_mut(), EnableMouseCapture)?;
     }
     terminal.clear()?;
@@ -609,7 +609,7 @@ pub(super) fn edit_upload_buffer(
         return Ok(());
     }
 
-    if state.mouse_enabled {
+    if state.settings.mouse_enabled() {
         execute!(terminal.backend_mut(), DisableMouseCapture)?;
     }
     disable_raw_mode()?;
@@ -620,7 +620,7 @@ pub(super) fn edit_upload_buffer(
         .status();
     enable_raw_mode()?;
     execute!(terminal.backend_mut(), EnterAlternateScreen)?;
-    if state.mouse_enabled {
+    if state.settings.mouse_enabled() {
         execute!(terminal.backend_mut(), EnableMouseCapture)?;
     }
     terminal.clear()?;
@@ -732,7 +732,7 @@ pub(super) fn refresh_locals(
         &state.pinned,
         matches!(scan_mode, LocalScanMode::Active) && state.local_recursive,
         &state.skip_dirs,
-        state.scan_depth,
+        state.settings.scan_depth(),
     ) {
         state.locals = locals;
         state.local_index = selected
@@ -745,65 +745,17 @@ pub(super) fn refresh_locals(
     }
 }
 
-/// Persist the diff-context toggle (`diff_show_full`) to the config file, leaving the
-/// configured `diff_context` radius untouched. IO boundary, called from `run_loop`.
-pub(super) fn persist_theme(state: &mut AppState) {
-    let result = crate::config::config_path().and_then(|path| {
-        let mut config = crate::config::load_config(&path)?;
-        config.theme = state.theme_choice;
-        crate::config::save_config(&path, &config)?;
-        Ok(())
-    });
-    let name = match state.theme_choice {
-        crate::config::ThemeChoice::Dark => "dark",
-        crate::config::ThemeChoice::Light => "light",
-    };
-    match result {
-        Ok(()) => state.set_status(format!("Theme: {name}")),
-        Err(error) => state.set_status(format!("save config failed: {error}")),
-    }
-}
-
-pub(super) fn persist_diff_context(state: &mut AppState) {
-    let result = crate::config::config_path().and_then(|path| {
-        let mut config = crate::config::load_config(&path)?;
-        config.diff_show_full = state.diff_show_full;
-        crate::config::save_config(&path, &config)?;
-        Ok(())
-    });
-    match result {
-        Ok(()) if state.diff_show_full => state.set_status("Diff context: full file"),
-        Ok(()) => state.set_status(format!("Diff context: {} lines", state.diff_context)),
-        Err(error) => state.set_status(format!("save config failed: {error}")),
-    }
-}
-
 /// Persist Settings-screen fields after a user change (issue #227). Creates config.toml
 /// only when a value actually changed (opening Config never calls this).
-pub(super) fn persist_settings(state: &mut AppState) {
+pub(super) fn persist_settings(state: &mut AppState, success_message: String) {
     let result = crate::config::config_path().and_then(|path| {
         let mut config = crate::config::load_config(&path)?;
-        config.theme = state.theme_choice;
-        config.mouse = state.config_mouse;
-        config.check_updates = state.config_check_updates;
-        config.ignore_trailing_newline = state.ignore_trailing_newline;
-        config.scan_depth = state.scan_depth;
-        config.diff_context = state.diff_context;
+        state.settings.apply_to_config(&mut config);
         crate::config::save_config(&path, &config)?;
         Ok(())
     });
     match result {
-        Ok(()) => {
-            let field = ConfigField::ALL
-                .get(state.config().map(|c| c.index).unwrap_or(0))
-                .copied()
-                .unwrap_or(ConfigField::Theme);
-            state.set_status(format!(
-                "{}: {}",
-                field.label(),
-                state.config_field_value(field)
-            ));
-        }
+        Ok(()) => state.set_status(success_message),
         Err(error) => state.set_status(format!("save config failed: {error}")),
     }
 }
@@ -846,7 +798,6 @@ pub(super) fn pin_paths(
         Ok(config) => {
             state.pinned = config.pinned;
             state.skip_dirs = config.skip_dirs;
-            state.scan_depth = config.scan_depth;
             state.mark_pin_sync_cache_dirty();
             state.set_status(format!("Pinned {} <-> {}", local_path.display(), filename));
         }
@@ -863,7 +814,6 @@ pub(super) fn unpin_path(state: &mut AppState, local_path: &std::path::Path) {
         Ok(config) => {
             state.pinned = config.pinned;
             state.skip_dirs = config.skip_dirs;
-            state.scan_depth = config.scan_depth;
             state.mark_pin_sync_cache_dirty();
             state.set_status(format!(
                 "Unpinned {}",
@@ -888,7 +838,6 @@ pub(super) fn unpin_at_pin_index(state: &mut AppState, idx: usize) {
         Ok(config) => {
             state.pinned = config.pinned;
             state.skip_dirs = config.skip_dirs;
-            state.scan_depth = config.scan_depth;
             state.mark_pin_sync_cache_dirty();
             let len = state.visible_pin_indices().len();
             if let Some(pins) = state.pins_mut() {
@@ -1025,7 +974,7 @@ impl Jobs {
             state.pinned.clone(),
             state.local_recursive,
             state.skip_dirs.clone(),
-            state.scan_depth,
+            state.settings.scan_depth(),
         ));
     }
 

--- a/src/tui/dispatch.rs
+++ b/src/tui/dispatch.rs
@@ -452,12 +452,15 @@ pub(super) fn dispatch_outcome(
                 spawn_pin_diff(state, jobs, &m, entry);
             }
         }
-        KeyOutcome::PersistDiffContext => persist_diff_context(state),
-        KeyOutcome::PersistSettings => {
-            persist_settings(state);
-            sync_mouse_capture(terminal, state.mouse_enabled)?;
+        KeyOutcome::PersistSettings {
+            effect,
+            success_message,
+        } => {
+            persist_settings(state, success_message);
+            if effect == Some(SettingsEffect::SyncMouseCapture) {
+                sync_mouse_capture(terminal, state.settings.mouse_enabled())?;
+            }
         }
-        KeyOutcome::ThemeToggle => persist_theme(state),
         KeyOutcome::FetchRevisions { gist_id } => {
             screens::revisions::request_revisions(jobs, state, gist_id);
         }

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -92,12 +92,14 @@ impl AppState {
             && !self.is_any_filtering()
             && !self.editing_description
         {
-            self.theme_choice = match self.theme_choice {
-                crate::config::ThemeChoice::Dark => crate::config::ThemeChoice::Light,
-                crate::config::ThemeChoice::Light => crate::config::ThemeChoice::Dark,
+            let change = self.settings.adjust(ConfigField::Theme, true).unwrap();
+            return KeyOutcome::PersistSettings {
+                effect: change.effect,
+                success_message: format!(
+                    "Theme: {}",
+                    self.settings.field_value(ConfigField::Theme)
+                ),
             };
-            self.theme = Theme::for_choice(self.theme_choice);
-            return KeyOutcome::ThemeToggle;
         }
         if let Some(action) = nav_action(code, modifiers) {
             if self.apply_navigation(action) {
@@ -135,36 +137,7 @@ impl AppState {
 
     /// Value string shown for a Config field row.
     pub(crate) fn config_field_value(&self, field: ConfigField) -> String {
-        match field {
-            ConfigField::Theme => match self.theme_choice {
-                crate::config::ThemeChoice::Dark => "dark".into(),
-                crate::config::ThemeChoice::Light => "light".into(),
-            },
-            ConfigField::Mouse => {
-                if self.config_mouse {
-                    "on".into()
-                } else {
-                    "off".into()
-                }
-            }
-            ConfigField::CheckUpdates => {
-                if self.config_check_updates {
-                    "on".into()
-                } else {
-                    "off".into()
-                }
-            }
-            ConfigField::DiffShowFull => if self.diff_show_full { "on" } else { "off" }.into(),
-            ConfigField::IgnoreTrailingNewline => {
-                if self.ignore_trailing_newline {
-                    "on".into()
-                } else {
-                    "off".into()
-                }
-            }
-            ConfigField::ScanDepth => self.scan_depth.to_string(),
-            ConfigField::DiffContext => self.diff_context.to_string(),
-        }
+        self.settings.field_value(field)
     }
 
     /// Arrow / hjkl / Ctrl+b/f navigation. Returns true when the key was consumed.
@@ -732,10 +705,22 @@ mod tests {
     fn shift_t_toggles_theme() {
         use crossterm::event::KeyModifiers;
         let mut state = initial_state();
-        assert_eq!(state.theme_choice, crate::config::ThemeChoice::Dark);
+        assert_eq!(
+            state.settings.theme_choice(),
+            crate::config::ThemeChoice::Dark
+        );
         let outcome = state.handle_key_with(KeyCode::Char('T'), KeyModifiers::SHIFT);
-        assert_eq!(outcome, KeyOutcome::ThemeToggle);
-        assert_eq!(state.theme_choice, crate::config::ThemeChoice::Light);
+        assert_eq!(
+            outcome,
+            KeyOutcome::PersistSettings {
+                effect: None,
+                success_message: "Theme: light".into(),
+            }
+        );
+        assert_eq!(
+            state.settings.theme_choice(),
+            crate::config::ThemeChoice::Light
+        );
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -139,58 +139,6 @@ impl Screen {
     );
 }
 
-/// Fields shown on [`Screen::Config`] in order (issue #227).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ConfigField {
-    Theme,
-    Mouse,
-    CheckUpdates,
-    DiffShowFull,
-    IgnoreTrailingNewline,
-    ScanDepth,
-    DiffContext,
-}
-
-impl ConfigField {
-    pub const ALL: [ConfigField; 7] = [
-        ConfigField::Theme,
-        ConfigField::Mouse,
-        ConfigField::CheckUpdates,
-        ConfigField::DiffShowFull,
-        ConfigField::IgnoreTrailingNewline,
-        ConfigField::ScanDepth,
-        ConfigField::DiffContext,
-    ];
-
-    pub fn label(self) -> &'static str {
-        match self {
-            ConfigField::Theme => "Theme",
-            ConfigField::Mouse => "Mouse support",
-            ConfigField::CheckUpdates => "Check for updates",
-            ConfigField::DiffShowFull => "Show full diff",
-            ConfigField::IgnoreTrailingNewline => "Ignore trailing newline",
-            ConfigField::ScanDepth => "Recursive scan depth",
-            ConfigField::DiffContext => "Diff context lines",
-        }
-    }
-
-    pub fn is_numeric(self) -> bool {
-        matches!(self, ConfigField::ScanDepth | ConfigField::DiffContext)
-    }
-
-    pub fn description(self) -> &'static str {
-        match self {
-            ConfigField::Theme => "terminal colours",
-            ConfigField::Mouse => "click and wheel input",
-            ConfigField::CheckUpdates => "daily GitHub version check",
-            ConfigField::DiffShowFull => "open Diff expanded",
-            ConfigField::IgnoreTrailingNewline => "hide newline-only diffs",
-            ConfigField::ScanDepth => "directory levels to scan",
-            ConfigField::DiffContext => "unchanged lines around edits",
-        }
-    }
-}
-
 /// Settings-screen state — carried on [`Screen::Config`] (issue #242).
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ConfigState {
@@ -589,13 +537,14 @@ pub enum KeyOutcome {
         entry: DeferredEntry,
         index: usize,
     },
-    PersistDiffContext,
     CopyGistUrl {
         gist_id: String,
     },
     CopyPreviewContent,
-    ThemeToggle,
-    PersistSettings,
+    PersistSettings {
+        effect: Option<SettingsEffect>,
+        success_message: String,
+    },
     FetchRevisions {
         gist_id: String,
     },
@@ -856,14 +805,7 @@ pub struct AppState {
     /// Soft-wrap long lines in the diff view instead of horizontal scrolling (`w` toggles;
     /// session-scoped, mirrors `preview_wrap`).
     pub diff_wrap: bool,
-    /// Unchanged context lines kept around each change in the diff view (from config).
-    pub diff_context: u32,
-    /// When true the diff view shows the full file; when false it collapses to
-    /// `diff_context` lines. Toggled with `c` and persisted to config.
-    pub diff_show_full: bool,
-    /// Treat a file-final-newline-only delta as no change in the diff view and the
-    /// overwrite-confirm gate (from config; default `true`).
-    pub ignore_trailing_newline: bool,
+    pub settings: RuntimeSettings,
     pub cwd: PathBuf,
     pub status: Option<String>,
     pub loading: bool,
@@ -878,20 +820,6 @@ pub struct AppState {
     /// Syntax-highlight file content in the preview and diff-context lines (issue #69).
     /// Defaults on; `load_startup_state` turns it off when `NO_COLOR` is set in the environment.
     pub syntax_highlight: bool,
-    /// Config preference for mouse (before CLI force-off). Edited on [`Screen::Config`].
-    pub config_mouse: bool,
-    /// Whether mouse capture is active this session (config `mouse` AND-NOT `--no-mouse`).
-    /// Gates the `Event::Mouse` branch and the close-button rendering.
-    pub mouse_enabled: bool,
-    /// CLI `--no-mouse` for the process (re-applied when config mouse toggles).
-    pub no_mouse_cli: bool,
-    /// Config preference for daily update checks. Edited on [`Screen::Config`].
-    pub config_check_updates: bool,
-    /// Whether the startup update check runs this session (config `check_updates` AND-NOT
-    /// `--no-update-check`).
-    pub update_check_enabled: bool,
-    /// CLI `--no-update-check` for the process.
-    pub no_update_check_cli: bool,
     /// Newer release version found by the background check, if any (footer hint on the List).
     pub update_available: Option<String>,
     /// How this binary was installed — resolved once at startup so the update hint can show
@@ -900,7 +828,6 @@ pub struct AppState {
     pub(crate) gist_content_cache: crate::lru::LruCache<(String, String), String>,
     pub local_recursive: bool,
     pub skip_dirs: Vec<String>,
-    pub scan_depth: u32,
     pub local_scanning: bool,
     /// Generation token for the in-flight local scan. Bumped on each
     /// [`Self::begin_local_scan`]; absorb ignores results with a mismatched id so a
@@ -924,11 +851,6 @@ pub struct AppState {
     /// Monotonic tick advanced once per event-loop iteration (~150ms); drives the in-progress
     /// spinner animation. Wraps freely — only its value modulo the frame count is observed.
     pub spinner_frame: usize,
-    /// Active theme selection (persisted to config when toggled with `T`).
-    pub theme_choice: crate::config::ThemeChoice,
-    /// Resolved colour palette for the current theme choice (from config).
-    pub theme: Theme,
-
     /// Presentation cache for the Pins list: sync status + mtimes, filled by
     /// [`Self::refresh_pin_sync_cache`] (impure). The pure view-model builder and Pins paint
     /// read only this cache — never `fs::read` / hash on the draw path (issue #241).
@@ -1254,7 +1176,7 @@ impl AppState {
             &remote,
             &local_label,
             &local_content,
-            self.ignore_trailing_newline,
+            self.settings.ignore_trailing_newline(),
         );
         if let Some(body) = self.scroll_body_mut() {
             body.text = diff;
@@ -2044,11 +1966,7 @@ impl AppState {
     /// Context radius to render the diff with: `None` shows the full file, `Some(n)`
     /// collapses unchanged regions to `n` lines around each change.
     pub fn effective_diff_context(&self) -> Option<usize> {
-        if self.diff_show_full {
-            None
-        } else {
-            Some(self.diff_context as usize)
-        }
+        self.settings.effective_diff_context()
     }
 }
 
@@ -2082,9 +2000,7 @@ pub fn initial_state() -> AppState {
         filter_query: TextInput::default(),
         local_filter_query: TextInput::default(),
         diff_wrap: false,
-        diff_context: 3,
-        diff_show_full: false,
-        ignore_trailing_newline: true,
+        settings: RuntimeSettings::default(),
         cwd: PathBuf::from("."),
         status: None,
         loading: false,
@@ -2092,12 +2008,6 @@ pub fn initial_state() -> AppState {
         revisions_stale: None,
         preview_wrap: false,
         syntax_highlight: true,
-        config_mouse: true,
-        mouse_enabled: true,
-        no_mouse_cli: false,
-        config_check_updates: true,
-        update_check_enabled: true,
-        no_update_check_cli: false,
         update_available: None,
         install_method: crate::upgrade::InstallMethod::Standalone,
         // Bound the in-memory preview cache so browsing many/large gists can't grow unbounded;
@@ -2105,7 +2015,6 @@ pub fn initial_state() -> AppState {
         gist_content_cache: crate::lru::LruCache::new(64),
         local_recursive: false,
         skip_dirs: crate::config::AppConfig::default().skip_dirs,
-        scan_depth: crate::config::AppConfig::default().scan_depth,
         local_scanning: false,
         local_scan_generation: 0,
 
@@ -2117,8 +2026,6 @@ pub fn initial_state() -> AppState {
         upload: UploadState::default(),
         nav_stack: Vec::new(),
         spinner_frame: 0,
-        theme_choice: crate::config::ThemeChoice::Dark,
-        theme: Theme::DARK,
         pin_sync_cache: Vec::new(),
         pin_sync_cache_dirty: true,
     }
@@ -2130,27 +2037,15 @@ pub fn load_startup_state(no_mouse: bool, no_update_check: bool) -> Result<AppSt
     let config = crate::config::load_config(&config_path)?;
     let cwd = std::env::current_dir()?;
 
+    state.settings = RuntimeSettings::from_config(&config, no_mouse, no_update_check);
     state.pinned = config.pinned;
     state.mark_pin_sync_cache_dirty();
     state.skip_dirs = config.skip_dirs;
-    state.scan_depth = config.scan_depth;
-    state.diff_context = config.diff_context;
-    state.diff_show_full = config.diff_show_full;
-    state.ignore_trailing_newline = config.ignore_trailing_newline;
-    state.theme_choice = config.theme;
-    state.theme = Theme::for_choice(config.theme);
     // Honour NO_COLOR for the syntax-highlight feature only (existing semantic colours stay).
     state.syntax_highlight = std::env::var_os("NO_COLOR").is_none();
-    state.config_mouse = config.mouse;
-    state.no_mouse_cli = no_mouse;
-    // `--no-mouse` / `--no-update-check` force off; no flag forces on (edit config instead).
-    state.mouse_enabled = config.mouse && !no_mouse;
-    state.config_check_updates = config.check_updates;
-    state.no_update_check_cli = no_update_check;
-    state.update_check_enabled = config.check_updates && !no_update_check;
     // Surface a previously-seen newer release immediately (even when the daily check is
     // throttled), so the hint persists across launches without re-hitting the network.
-    if state.update_check_enabled {
+    if state.settings.update_check_enabled() {
         if let Ok(exe) = std::env::current_exe() {
             state.install_method = crate::upgrade::detect_install_method(&exe);
         }
@@ -2165,7 +2060,7 @@ pub fn load_startup_state(no_mouse: bool, no_update_check: bool) -> Result<AppSt
         &state.pinned,
         false,
         &state.skip_dirs,
-        state.scan_depth,
+        state.settings.scan_depth(),
     )?;
     state.cwd = cwd;
     // Start focused on the gist pane: the common flow is to pick a gist and pull it
@@ -2235,6 +2130,8 @@ mod run_loop;
 use run_loop::run_loop;
 mod text_input;
 pub use text_input::{EditResult, TextInput};
+mod settings;
+pub use settings::{ConfigField, RuntimeSettings, SettingsEffect};
 mod theme;
 pub use theme::Theme;
 mod view_model;
@@ -2396,7 +2293,7 @@ mod tests {
 
     #[test]
     fn initial_state_enables_mouse_by_default() {
-        assert!(super::initial_state().mouse_enabled);
+        assert!(super::initial_state().settings.mouse_enabled());
     }
 
     #[test]

--- a/src/tui/render/mod.rs
+++ b/src/tui/render/mod.rs
@@ -42,7 +42,7 @@ pub(super) fn render(
     // Paint the full canvas so every unfilled cell uses the theme background (no-op for dark
     // theme where bg=Reset, effective for light theme which sets a grey canvas).
     frame.render_widget(
-        Block::default().style(state.theme.base_style()),
+        Block::default().style(state.settings.theme().base_style()),
         frame.area(),
     );
     // Pure presentation seam (issues #241 / #250): every screen paints from the view model.
@@ -50,7 +50,7 @@ pub(super) fn render(
     let vm = super::build_view_model(state);
     render_screen_vm_with_feedback(frame, state, &vm.screen, &vm.chrome, layout, feedback);
     if let Some(ref msg) = vm.chrome.bg_task_msg {
-        render_loading_overlay(frame, msg, vm.chrome.spinner_frame, &state.theme);
+        render_loading_overlay(frame, msg, vm.chrome.spinner_frame, &state.settings.theme());
     }
 }
 

--- a/src/tui/run_loop.rs
+++ b/src/tui/run_loop.rs
@@ -15,7 +15,7 @@ pub(super) fn run_loop(
     no_update_check: bool,
 ) -> Result<()> {
     let mut state = load_startup_state(no_mouse, no_update_check)?;
-    if state.mouse_enabled {
+    if state.settings.mouse_enabled() {
         execute!(terminal.backend_mut(), EnableMouseCapture)?;
     }
     let mut mouse_layout = MouseFrame::default();
@@ -27,7 +27,7 @@ pub(super) fn run_loop(
     let update_check_path = crate::update_check::state_path().ok();
     let mut update_rx: Option<std::sync::mpsc::Receiver<crate::update_check::UpdateCheckOutcome>> =
         None;
-    if state.update_check_enabled {
+    if state.settings.update_check_enabled() {
         let due = update_check_path.as_ref().is_none_or(|path| {
             crate::update_check::should_check(
                 crate::update_check::load_state(path).last_check,
@@ -95,7 +95,7 @@ pub(super) fn run_loop(
                 }
                 state.handle_key_with(key.code, key.modifiers)
             }
-            Event::Mouse(m) if state.mouse_enabled => {
+            Event::Mouse(m) if state.settings.mouse_enabled() => {
                 if state.bg_task_msg.is_some() {
                     continue; // ignore mouse while a background task overlay is up, mirroring keys
                 }

--- a/src/tui/screens/config.rs
+++ b/src/tui/screens/config.rs
@@ -5,7 +5,7 @@ use crate::tui::keys::{point_in, NavAction};
 use crate::tui::view_model::{ChromeVm, ConfigVm};
 use crate::tui::{
     AppState, ConfigField, HelpTopic, HitTarget, KeyOutcome, MouseFrame, PaneHit, PaneTarget,
-    Screen, Theme,
+    Screen,
 };
 use crossterm::event::KeyCode;
 use ratatui::{
@@ -46,13 +46,13 @@ impl AppState {
                 }
             }
             KeyCode::Enter | KeyCode::Char(' ') | KeyCode::Right | KeyCode::Char('l') => {
-                if self.adjust_config_field(true) {
-                    return KeyOutcome::PersistSettings;
+                if let Some(outcome) = self.adjust_config_field(true) {
+                    return outcome;
                 }
             }
             KeyCode::Left | KeyCode::Char('h') => {
-                if self.adjust_config_field(false) {
-                    return KeyOutcome::PersistSettings;
+                if let Some(outcome) = self.adjust_config_field(false) {
+                    return outcome;
                 }
             }
             KeyCode::Char('?') => self.open_help(),
@@ -61,66 +61,18 @@ impl AppState {
         KeyOutcome::None
     }
 
-    /// Toggle or nudge the selected Config field. Returns true when a value changed
-    /// (caller should persist). Pure aside from mutating `self`.
-    pub(crate) fn adjust_config_field(&mut self, forward: bool) -> bool {
+    /// Toggle or nudge the selected Config field and describe the persistence work.
+    pub(crate) fn adjust_config_field(&mut self, forward: bool) -> Option<KeyOutcome> {
         let index = self.config().map(|c| c.index).unwrap_or(0);
         let field = ConfigField::ALL
             .get(index)
             .copied()
             .unwrap_or(ConfigField::Theme);
-        match field {
-            ConfigField::Theme => {
-                self.theme_choice = match self.theme_choice {
-                    crate::config::ThemeChoice::Dark => crate::config::ThemeChoice::Light,
-                    crate::config::ThemeChoice::Light => crate::config::ThemeChoice::Dark,
-                };
-                self.theme = Theme::for_choice(self.theme_choice);
-                true
-            }
-            ConfigField::Mouse => {
-                self.config_mouse = !self.config_mouse;
-                self.mouse_enabled = self.config_mouse && !self.no_mouse_cli;
-                true
-            }
-            ConfigField::CheckUpdates => {
-                self.config_check_updates = !self.config_check_updates;
-                self.update_check_enabled = self.config_check_updates && !self.no_update_check_cli;
-                true
-            }
-            ConfigField::DiffShowFull => {
-                self.diff_show_full = !self.diff_show_full;
-                true
-            }
-            ConfigField::IgnoreTrailingNewline => {
-                self.ignore_trailing_newline = !self.ignore_trailing_newline;
-                true
-            }
-            ConfigField::ScanDepth => {
-                let next = if forward {
-                    self.scan_depth.saturating_add(1).min(20)
-                } else {
-                    self.scan_depth.saturating_sub(1)
-                };
-                if next == self.scan_depth {
-                    return false;
-                }
-                self.scan_depth = next;
-                true
-            }
-            ConfigField::DiffContext => {
-                let next = if forward {
-                    self.diff_context.saturating_add(1).min(50)
-                } else {
-                    self.diff_context.saturating_sub(1)
-                };
-                if next == self.diff_context {
-                    return false;
-                }
-                self.diff_context = next;
-                true
-            }
-        }
+        let change = self.settings.adjust(field, forward)?;
+        Some(KeyOutcome::PersistSettings {
+            effect: change.effect,
+            success_message: format!("{}: {}", field.label(), self.settings.field_value(field)),
+        })
     }
 
     /// Arrow key navigation for `Screen::Config`: moves the field-index selection. Left/Right
@@ -195,7 +147,13 @@ pub(crate) fn render_config_vm(
     layout: &mut MouseFrame,
 ) {
     let area = frame.area();
-    let area = crate::tui::render_top_bar(frame, area, &state.theme, chrome.mouse_enabled, layout);
+    let area = crate::tui::render_top_bar(
+        frame,
+        area,
+        &state.settings.theme(),
+        chrome.mouse_enabled,
+        layout,
+    );
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -220,20 +178,20 @@ pub(crate) fn render_config_vm(
         .title_bottom(Line::from(
             " Esc close · Enter/←/→ change · saved on change ",
         ))
-        .style(state.theme.base_style())
-        .border_style(Style::default().fg(state.theme.accent));
+        .style(state.settings.theme().base_style())
+        .border_style(Style::default().fg(state.settings.theme().accent));
     let list = List::new(items)
         .block(block)
         .highlight_style(
             Style::default()
-                .bg(state.theme.accent)
-                .fg(state.theme.fg_on_accent)
+                .bg(state.settings.theme().accent)
+                .fg(state.settings.theme().fg_on_accent)
                 .add_modifier(Modifier::BOLD),
         )
         .highlight_symbol("▸ ");
     frame.render_stateful_widget(list, chunks[0], &mut list_state);
     if chrome.mouse_enabled {
-        let close = crate::tui::render_close_button(frame, chunks[0], &state.theme);
+        let close = crate::tui::render_close_button(frame, chunks[0], &state.settings.theme());
         layout.register(HitTarget::Close, close);
         layout.register_pane(
             PaneTarget::List,
@@ -246,7 +204,8 @@ pub(crate) fn render_config_vm(
     }
     if let Some(ref status) = config.status {
         frame.render_widget(
-            Paragraph::new(status.as_str()).style(Style::default().fg(state.theme.accent)),
+            Paragraph::new(status.as_str())
+                .style(Style::default().fg(state.settings.theme().accent)),
             chunks[1],
         );
     }
@@ -254,7 +213,7 @@ pub(crate) fn render_config_vm(
         Paragraph::new(
             " File-only: skip_dirs · ~/.config/gistui/config.toml (or $XDG_CONFIG_HOME)",
         )
-        .style(Style::default().fg(state.theme.dim)),
+        .style(Style::default().fg(state.settings.theme().dim)),
         chunks[2],
     );
 }
@@ -272,62 +231,25 @@ mod tests {
     }
 
     #[test]
-    fn adjust_config_mouse_updates_mouse_enabled_respecting_cli() {
-        let mut state = initial_state();
-        state.open_config();
-        config_mut(&mut state).index = ConfigField::ALL
-            .iter()
-            .position(|f| *f == ConfigField::Mouse)
-            .unwrap();
-        state.no_mouse_cli = false;
-        state.config_mouse = false;
-        state.mouse_enabled = false;
-
-        assert!(state.adjust_config_field(true));
-        assert!(state.config_mouse);
-        assert!(
-            state.mouse_enabled,
-            "toggling mouse on must enable session mouse when CLI does not force off"
-        );
-
-        // CLI --no-mouse still wins for the effective session flag.
-        state.no_mouse_cli = true;
-        state.config_mouse = false;
-        state.mouse_enabled = false;
-        assert!(state.adjust_config_field(true));
-        assert!(state.config_mouse);
-        assert!(
-            !state.mouse_enabled,
-            "--no-mouse must keep mouse_enabled false even when config prefers on"
-        );
-    }
-
-    #[test]
     fn config_adjust_theme_returns_persist_settings() {
         let mut state = initial_state();
         state.open_config();
-        // Theme is index 0
-        config_mut(&mut state).index = 0;
-        assert_eq!(state.theme_choice, crate::config::ThemeChoice::Dark);
-        assert!(state.adjust_config_field(true));
-        assert_eq!(state.theme_choice, crate::config::ThemeChoice::Light);
-        // Space on config screen yields PersistSettings
+        assert_eq!(
+            state.settings.theme_choice(),
+            crate::config::ThemeChoice::Dark
+        );
         let outcome = state.handle_key(KeyCode::Char(' '));
-        assert_eq!(outcome, KeyOutcome::PersistSettings);
-    }
-
-    #[test]
-    fn config_adjust_scan_depth_clamps_and_reports_change() {
-        let mut state = initial_state();
-        state.open_config();
-        config_mut(&mut state).index = ConfigField::ALL
-            .iter()
-            .position(|f| *f == ConfigField::ScanDepth)
-            .unwrap();
-        state.scan_depth = 0;
-        assert!(!state.adjust_config_field(false)); // already min
-        assert!(state.adjust_config_field(true));
-        assert_eq!(state.scan_depth, 1);
+        assert_eq!(
+            outcome,
+            KeyOutcome::PersistSettings {
+                effect: None,
+                success_message: "Theme: light".into(),
+            }
+        );
+        assert_eq!(
+            state.settings.theme_choice(),
+            crate::config::ThemeChoice::Light
+        );
     }
 
     #[test]
@@ -338,59 +260,14 @@ mod tests {
             .iter()
             .position(|field| *field == ConfigField::DiffShowFull)
             .unwrap();
-        assert!(!state.diff_show_full);
-        assert!(state.adjust_config_field(true));
-        assert!(state.diff_show_full);
-    }
-
-    #[test]
-    fn config_field_values_round_trip_via_save_config() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("config.toml");
-        let mut state = initial_state();
-        state.theme_choice = crate::config::ThemeChoice::Light;
-        state.config_mouse = false;
-        state.config_check_updates = false;
-        state.ignore_trailing_newline = false;
-        state.scan_depth = 5;
-        state.diff_context = 7;
-        // Simulate persist_settings write path using shipped save/load.
-        let config = crate::config::AppConfig {
-            theme: state.theme_choice,
-            mouse: state.config_mouse,
-            check_updates: state.config_check_updates,
-            ignore_trailing_newline: state.ignore_trailing_newline,
-            scan_depth: state.scan_depth,
-            diff_context: state.diff_context,
-            ..crate::config::AppConfig::default()
-        };
-        crate::config::save_config(&path, &config).unwrap();
-        assert!(path.exists());
-        let loaded = crate::config::load_config(&path).unwrap();
-        assert_eq!(loaded.theme, crate::config::ThemeChoice::Light);
-        assert!(!loaded.mouse);
-        assert!(!loaded.check_updates);
-        assert!(!loaded.ignore_trailing_newline);
-        assert_eq!(loaded.scan_depth, 5);
-        assert_eq!(loaded.diff_context, 7);
-    }
-
-    #[test]
-    fn persist_settings_dispatch_path_syncs_mouse_capture() {
-        // Structural: PersistSettings arm must call sync_mouse_capture after save so a
-        // Settings mouse toggle takes effect without restart (skeptic fix).
-        let src = include_str!("../dispatch.rs");
-        let persist_idx = src
-            .find("KeyOutcome::PersistSettings")
-            .expect("PersistSettings arm");
-        let arm = &src[persist_idx..persist_idx + 280];
-        assert!(
-            arm.contains("sync_mouse_capture"),
-            "PersistSettings must sync terminal mouse capture: {arm}"
+        assert!(!state.settings.diff_show_full());
+        assert_eq!(
+            state.adjust_config_field(true),
+            Some(KeyOutcome::PersistSettings {
+                effect: None,
+                success_message: "Show full diff: on".into(),
+            })
         );
-        assert!(
-            arm.contains("mouse_enabled"),
-            "must pass current mouse_enabled into sync: {arm}"
-        );
+        assert!(state.settings.diff_show_full());
     }
 }

--- a/src/tui/screens/confirm.rs
+++ b/src/tui/screens/confirm.rs
@@ -178,7 +178,7 @@ pub(crate) fn build_confirm_vm(state: &AppState) -> ConfirmVm {
 /// theme's `del_color` so the stakes read at a glance; non-destructive writes use the neutral
 /// `notice_color` prompt.
 pub(crate) fn confirm_modal_style(state: &AppState) -> (&'static str, Color) {
-    let theme = &state.theme;
+    let theme = &state.settings.theme();
     match state.pending_action() {
         Some(PendingAction::Create { .. }) if state.editing_description => {
             ("Description", theme.accent)
@@ -207,10 +207,20 @@ pub(crate) fn render_confirm_vm(
 ) {
     match &confirm.background {
         ConfirmBackgroundVm::CompactGist(bg) => {
-            crate::tui::render::render_compact_gist_bg_vm(frame, frame.area(), bg, &state.theme);
+            crate::tui::render::render_compact_gist_bg_vm(
+                frame,
+                frame.area(),
+                bg,
+                &state.settings.theme(),
+            );
         }
         ConfirmBackgroundVm::Diff(diff) => {
-            crate::tui::render::render_diff_pane_vm(frame, frame.area(), diff, &state.theme);
+            crate::tui::render::render_diff_pane_vm(
+                frame,
+                frame.area(),
+                diff,
+                &state.settings.theme(),
+            );
         }
         ConfirmBackgroundVm::Empty => {}
     }
@@ -226,19 +236,19 @@ pub(crate) fn render_confirm_vm(
             input,
             suffix,
             confirm.border,
-            &state.theme,
+            &state.settings.theme(),
         ),
         ConfirmModalKind::Prompt { text } => crate::tui::render::render_centered_modal(
             frame,
             confirm.title,
             text,
             confirm.border,
-            &state.theme,
+            &state.settings.theme(),
         ),
     };
     if chrome.mouse_enabled {
         // Put the close button on the modal box itself, not the full-screen corner.
-        let close = crate::tui::render::render_close_button(frame, modal, &state.theme);
+        let close = crate::tui::render::render_close_button(frame, modal, &state.settings.theme());
         layout.register(HitTarget::Close, close);
     }
 }
@@ -351,7 +361,7 @@ pub(crate) fn on_restore_revision_ready(
                 &revision_content,
                 &new_label,
                 &current_content,
-                state.ignore_trailing_newline,
+                state.settings.ignore_trailing_newline(),
             );
             state.open_deferred(
                 entry,

--- a/src/tui/screens/detail.rs
+++ b/src/tui/screens/detail.rs
@@ -677,7 +677,13 @@ pub(crate) fn render_gist_detail_vm(
     feedback: &mut crate::tui::render::RenderFeedback,
 ) {
     let area = frame.area();
-    let area = crate::tui::render_top_bar(frame, area, &state.theme, chrome.mouse_enabled, layout);
+    let area = crate::tui::render_top_bar(
+        frame,
+        area,
+        &state.settings.theme(),
+        chrome.mouse_enabled,
+        layout,
+    );
     // Fixed 4-row header (borders + basic-info line + focus tabs); the active tab — the file
     // list or the comments, never both — fills the rest above the footer.
     let chunks = ratatui::layout::Layout::default()
@@ -694,16 +700,28 @@ pub(crate) fn render_gist_detail_vm(
         ])
         .split(area);
     if !detail.missing {
-        render_detail_header_vm(frame, chunks[0], detail, chrome, &state.theme, layout);
+        render_detail_header_vm(
+            frame,
+            chunks[0],
+            detail,
+            chrome,
+            &state.settings.theme(),
+            layout,
+        );
         match detail.focus {
-            DetailFocus::Files => {
-                render_gist_file_list_vm(frame, chunks[1], detail, chrome, &state.theme, layout)
-            }
+            DetailFocus::Files => render_gist_file_list_vm(
+                frame,
+                chunks[1],
+                detail,
+                chrome,
+                &state.settings.theme(),
+                layout,
+            ),
             DetailFocus::Comments => render_gist_comments_vm(
                 frame,
                 chunks[1],
                 &detail.comments,
-                &state.theme,
+                &state.settings.theme(),
                 layout,
                 feedback,
             ),
@@ -716,7 +734,7 @@ pub(crate) fn render_gist_detail_vm(
         &detail.footer,
         detail.footer_colored,
         crate::tui::keymap::for_screen(&state.screen),
-        &state.theme,
+        &state.settings.theme(),
     );
 
     let edit_modal = if let Some(input) = &detail.description_input {
@@ -729,8 +747,8 @@ pub(crate) fn render_gist_detail_vm(
             "",
             input,
             "",
-            state.theme.accent,
-            &state.theme,
+            state.settings.theme().accent,
+            &state.settings.theme(),
         ))
     } else {
         None
@@ -738,8 +756,11 @@ pub(crate) fn render_gist_detail_vm(
     if chrome.mouse_enabled {
         // When the edit-description modal is open, the close button belongs on it;
         // otherwise it sits on the full-screen detail view's top-right corner.
-        let close =
-            crate::tui::render_close_button(frame, edit_modal.unwrap_or(area), &state.theme);
+        let close = crate::tui::render_close_button(
+            frame,
+            edit_modal.unwrap_or(area),
+            &state.settings.theme(),
+        );
         layout.register(HitTarget::Close, close);
     }
 }

--- a/src/tui/screens/diff.rs
+++ b/src/tui/screens/diff.rs
@@ -4,7 +4,7 @@
 use crate::tui::bg::{record_pin_sync, refresh_locals, LocalScanMode, LoopFlow};
 use crate::tui::render::{diff_labels, preview_diff_text};
 use crate::tui::view_model::{ChromeVm, DiffVm};
-use crate::tui::{AppState, HelpTopic, HitTarget, KeyOutcome, PendingAction};
+use crate::tui::{AppState, ConfigField, HelpTopic, HitTarget, KeyOutcome, PendingAction};
 use crossterm::event::KeyCode;
 use ratatui::{
     layout::{Constraint, Direction, Layout},
@@ -85,11 +85,21 @@ impl AppState {
             // Toggle between the configured context radius and the full file; the line
             // count changes, so reset the vertical scroll. The choice is persisted.
             KeyCode::Char('c') => {
-                self.diff_show_full = !self.diff_show_full;
+                let change = self
+                    .settings
+                    .adjust(ConfigField::DiffShowFull, true)
+                    .unwrap();
                 if let Some(body) = self.scroll_body_mut() {
                     body.scroll = 0;
                 }
-                return KeyOutcome::PersistDiffContext;
+                return KeyOutcome::PersistSettings {
+                    effect: change.effect,
+                    success_message: if self.settings.diff_show_full() {
+                        "Diff context: full file".into()
+                    } else {
+                        format!("Diff context: {} lines", self.settings.diff_context())
+                    },
+                };
             }
             // Soft-wrap long lines instead of horizontal scrolling; reset the now-meaningless
             // horizontal offset so wrapped lines start at column 0.
@@ -155,10 +165,10 @@ pub(crate) fn diff_title(state: &AppState) -> String {
 /// on those destination screens (which read `state.status`), so no status is set while on Diff.
 /// Footer hints for `Screen::Diff` (pure for tests).
 pub(crate) fn diff_footer(state: &AppState) -> String {
-    let context = if state.diff_show_full {
+    let context = if state.settings.diff_show_full() {
         "c context [full]".to_string()
     } else {
-        format!("c context [{}]", state.diff_context)
+        format!("c context [{}]", state.settings.diff_context())
     };
     // When wrapping, horizontal scroll (←→) is meaningless — drop it from the hint.
     let scroll = if state.diff_wrap {
@@ -222,7 +232,13 @@ pub(crate) fn render_diff_vm(
     layout: &mut crate::tui::MouseFrame,
 ) {
     let area = frame.area();
-    let area = crate::tui::render_top_bar(frame, area, &state.theme, chrome.mouse_enabled, layout);
+    let area = crate::tui::render_top_bar(
+        frame,
+        area,
+        &state.settings.theme(),
+        chrome.mouse_enabled,
+        layout,
+    );
     // Hint lines are trimmed to one row (#342); they never wrap.
     let footer_lines = 1;
     let chunks = Layout::default()
@@ -230,7 +246,7 @@ pub(crate) fn render_diff_vm(
         .constraints([Constraint::Min(5), Constraint::Length(footer_lines)])
         .split(area);
 
-    crate::tui::render_diff_pane_vm(frame, chunks[0], diff, &state.theme);
+    crate::tui::render_diff_pane_vm(frame, chunks[0], diff, &state.settings.theme());
 
     crate::tui::render_footer(
         frame,
@@ -239,10 +255,10 @@ pub(crate) fn render_diff_vm(
         &diff.footer,
         true,
         crate::tui::keymap::for_screen(&state.screen),
-        &state.theme,
+        &state.settings.theme(),
     );
     if chrome.mouse_enabled {
-        let close = crate::tui::render_close_button(frame, area, &state.theme);
+        let close = crate::tui::render_close_button(frame, area, &state.settings.theme());
         layout.register(HitTarget::Close, close);
     }
 }
@@ -277,12 +293,12 @@ pub(crate) fn on_preview_diff(
                         &local_content,
                         &gist_label,
                         &remote,
-                        state.ignore_trailing_newline,
+                        state.settings.ignore_trailing_newline(),
                     );
                     let identical = crate::diff::content_eq(
                         &local_content,
                         &remote,
-                        state.ignore_trailing_newline,
+                        state.settings.ignore_trailing_newline(),
                     );
                     state.open_deferred(
                         entry,
@@ -349,12 +365,12 @@ pub(crate) fn on_download_selected(
                             &local_content,
                             &gist_label,
                             &remote,
-                            state.ignore_trailing_newline,
+                            state.settings.ignore_trailing_newline(),
                         );
                         let identical = crate::diff::content_eq(
                             &local_content,
                             &remote,
-                            state.ignore_trailing_newline,
+                            state.settings.ignore_trailing_newline(),
                         );
                         state.open_deferred(
                             entry,
@@ -423,7 +439,7 @@ pub(crate) fn on_revision_diff(
                 &old_content,
                 &new_label,
                 &new_content,
-                state.ignore_trailing_newline,
+                state.settings.ignore_trailing_newline(),
             );
             let identical = old_content == new_content;
             // `enter_diff` (via `enter`) parks the live Revisions screen so Esc
@@ -519,21 +535,26 @@ mod tests {
     #[test]
     fn diff_context_toggle_flips_effective_radius() {
         let mut state = initial_state();
-        state.diff_context = 3;
         assert_eq!(state.effective_diff_context(), Some(3));
 
         // Pressing `c` in the diff view flips to full view and resets the scroll.
         state.screen = Screen::Diff(Box::default());
         set_diff_scroll(&mut state, 12);
         let outcome = state.handle_key(KeyCode::Char('c'));
-        assert_eq!(outcome, KeyOutcome::PersistDiffContext);
-        assert!(state.diff_show_full);
+        assert_eq!(
+            outcome,
+            KeyOutcome::PersistSettings {
+                effect: None,
+                success_message: "Diff context: full file".into(),
+            }
+        );
+        assert!(state.settings.diff_show_full());
         assert_eq!(state.scroll_body().expect("Diff ScrollBody").scroll, 0);
         assert_eq!(state.effective_diff_context(), None);
 
         // Pressing it again returns to the configured radius.
         state.handle_key(KeyCode::Char('c'));
-        assert!(!state.diff_show_full);
+        assert!(!state.settings.diff_show_full());
         assert_eq!(state.effective_diff_context(), Some(3));
     }
 

--- a/src/tui/screens/gists.rs
+++ b/src/tui/screens/gists.rs
@@ -247,7 +247,13 @@ pub(crate) fn render_gists_vm(
     layout: &mut MouseFrame,
 ) {
     let area = frame.area();
-    let area = crate::tui::render_top_bar(frame, area, &state.theme, chrome.mouse_enabled, layout);
+    let area = crate::tui::render_top_bar(
+        frame,
+        area,
+        &state.settings.theme(),
+        chrome.mouse_enabled,
+        layout,
+    );
     // Footer: filter input while filtering, else status or hints (see #72 / #250).
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -266,7 +272,7 @@ pub(crate) fn render_gists_vm(
         frame,
         chunks[0],
         &gists.pane,
-        &state.theme,
+        &state.settings.theme(),
         chrome.mouse_enabled,
         layout,
         PaneTarget::List,
@@ -278,7 +284,7 @@ pub(crate) fn render_gists_vm(
             chunks[1],
             &gists.footer_title,
             crate::tui::render::input_line("/", &gists.filter_query, ""),
-            &state.theme,
+            &state.settings.theme(),
             layout,
         );
     } else {
@@ -289,11 +295,11 @@ pub(crate) fn render_gists_vm(
             &gists.footer,
             gists.footer_colored,
             crate::tui::keymap::for_screen(&state.screen),
-            &state.theme,
+            &state.settings.theme(),
         );
     }
     if chrome.mouse_enabled {
-        let close = crate::tui::render_close_button(frame, area, &state.theme);
+        let close = crate::tui::render_close_button(frame, area, &state.settings.theme());
         layout.register(HitTarget::Close, close);
     }
 }

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -438,7 +438,13 @@ pub(crate) fn render_help_vm(
     layout: &mut MouseFrame,
 ) {
     let area = frame.area();
-    let area = crate::tui::render_top_bar(frame, area, &state.theme, chrome.mouse_enabled, layout);
+    let area = crate::tui::render_top_bar(
+        frame,
+        area,
+        &state.settings.theme(),
+        chrome.mouse_enabled,
+        layout,
+    );
     match &help.mode {
         HelpModeVm::Index { items, selected } => {
             let list_items: Vec<ListItem> = items
@@ -454,14 +460,14 @@ pub(crate) fn render_help_vm(
                         ))
                         .borders(Borders::ALL)
                         .border_type(BorderType::Rounded)
-                        .style(state.theme.base_style())
+                        .style(state.settings.theme().base_style())
                         .padding(Padding::horizontal(1)),
                 )
-                .style(state.theme.base_style())
+                .style(state.settings.theme().base_style())
                 .highlight_style(
                     Style::default()
-                        .bg(state.theme.accent)
-                        .fg(state.theme.fg_on_accent)
+                        .bg(state.settings.theme().accent)
+                        .fg(state.settings.theme().fg_on_accent)
                         .add_modifier(Modifier::BOLD),
                 )
                 .highlight_symbol(crate::tui::render::list_pane::LIST_HIGHLIGHT_SYMBOL);
@@ -505,7 +511,7 @@ pub(crate) fn render_help_vm(
                                     Span::styled(
                                         repo.to_string(),
                                         Style::default()
-                                            .fg(state.theme.fg)
+                                            .fg(state.settings.theme().fg)
                                             .add_modifier(Modifier::UNDERLINED),
                                     ),
                                 ])
@@ -517,14 +523,14 @@ pub(crate) fn render_help_vm(
                 .collect();
             frame.render_widget(
                 Paragraph::new(Text::from(body_lines))
-                    .style(state.theme.base_style())
+                    .style(state.settings.theme().base_style())
                     .scroll((*scroll, 0))
                     .block(
                         Block::default()
                             .title(crate::tui::render::fit_block_title(title, area.width))
                             .borders(Borders::ALL)
                             .border_type(BorderType::Rounded)
-                            .style(state.theme.base_style())
+                            .style(state.settings.theme().base_style())
                             .padding(Padding::horizontal(1)),
                     ),
                 area,
@@ -547,7 +553,7 @@ pub(crate) fn render_help_vm(
         }
     }
     if chrome.mouse_enabled {
-        let close = crate::tui::render_close_button(frame, area, &state.theme);
+        let close = crate::tui::render_close_button(frame, area, &state.settings.theme());
         layout.register(HitTarget::Close, close);
     }
 }

--- a/src/tui/screens/list.rs
+++ b/src/tui/screens/list.rs
@@ -771,7 +771,13 @@ pub(crate) fn render_list_vm(
     layout: &mut MouseFrame,
 ) {
     let area = frame.area();
-    let area = crate::tui::render_top_bar(frame, area, &state.theme, chrome.mouse_enabled, layout);
+    let area = crate::tui::render_top_bar(
+        frame,
+        area,
+        &state.settings.theme(),
+        chrome.mouse_enabled,
+        layout,
+    );
     let footer_body = match &list.footer {
         ListFooterVm::Hints { text } | ListFooterVm::Status { text } => text.clone(),
         ListFooterVm::Filtering { focus, query } => {
@@ -813,7 +819,7 @@ pub(crate) fn render_list_vm(
         frame,
         columns[0],
         &list.local,
-        &state.theme,
+        &state.settings.theme(),
         chrome.mouse_enabled,
         layout,
         PaneTarget::Local,
@@ -822,7 +828,7 @@ pub(crate) fn render_list_vm(
         frame,
         columns[1],
         &list.gist,
-        &state.theme,
+        &state.settings.theme(),
         chrome.mouse_enabled,
         layout,
         PaneTarget::Gist,
@@ -830,7 +836,7 @@ pub(crate) fn render_list_vm(
 
     let divider_x = columns[0].right().saturating_sub(1);
     if list.split_dragging {
-        highlight_pane_divider(frame, chunks[0], divider_x, state.theme.accent);
+        highlight_pane_divider(frame, chunks[0], divider_x, state.settings.theme().accent);
     }
     if chrome.mouse_enabled {
         let split = SplitHit {
@@ -856,7 +862,7 @@ pub(crate) fn render_list_vm(
                 chunks[1],
                 "",
                 line,
-                &state.theme,
+                &state.settings.theme(),
                 layout,
             );
         }
@@ -868,7 +874,7 @@ pub(crate) fn render_list_vm(
                 &footer_body,
                 footer_is_command,
                 crate::tui::keymap::for_screen(&state.screen),
-                &state.theme,
+                &state.settings.theme(),
             );
         }
     }

--- a/src/tui/screens/palette.rs
+++ b/src/tui/screens/palette.rs
@@ -4,7 +4,9 @@
 use crate::tui::palette::{CrossAction, PaletteExec, PaletteMode};
 use crate::tui::view_model::{ChromeVm, PaletteVm};
 use crate::tui::EditResult;
-use crate::tui::{AppState, HelpTopic, HitTarget, KeyOutcome, MouseFrame, RowTarget, Screen};
+use crate::tui::{
+    AppState, ConfigField, HelpTopic, HitTarget, KeyOutcome, MouseFrame, RowTarget, Screen,
+};
 use crossterm::event::{KeyCode, KeyModifiers};
 use ratatui::{
     layout::{Margin, Rect},
@@ -129,12 +131,14 @@ impl AppState {
                 KeyOutcome::None
             }
             PaletteExec::Cross(CrossAction::ToggleTheme) => {
-                self.theme_choice = match self.theme_choice {
-                    crate::config::ThemeChoice::Dark => crate::config::ThemeChoice::Light,
-                    crate::config::ThemeChoice::Light => crate::config::ThemeChoice::Dark,
-                };
-                self.theme = crate::tui::Theme::for_choice(self.theme_choice);
-                KeyOutcome::ThemeToggle
+                let change = self.settings.adjust(ConfigField::Theme, true).unwrap();
+                KeyOutcome::PersistSettings {
+                    effect: change.effect,
+                    success_message: format!(
+                        "Theme: {}",
+                        self.settings.field_value(ConfigField::Theme)
+                    ),
+                }
             }
             PaletteExec::Cross(CrossAction::Quit) => KeyOutcome::Quit,
         }
@@ -239,10 +243,10 @@ pub(crate) fn render_palette_vm(
     frame.render_widget(Clear, rect);
 
     layout.intercept_all();
-    let dim = Style::default().fg(state.theme.dim);
+    let dim = Style::default().fg(state.settings.theme().dim);
     let active = Style::default()
-        .fg(state.theme.fg_on_accent)
-        .bg(state.theme.accent)
+        .fg(state.settings.theme().fg_on_accent)
+        .bg(state.settings.theme().accent)
         .add_modifier(Modifier::BOLD);
     let mut lines: Vec<Line<'static>> = Vec::new();
     if palette.has_query {
@@ -255,32 +259,34 @@ pub(crate) fn render_palette_vm(
             let row_style = if i == palette.selected {
                 active
             } else if item.enabled {
-                state.theme.base_style()
+                state.settings.theme().base_style()
             } else {
-                Style::default().fg(state.theme.dim)
+                Style::default().fg(state.settings.theme().dim)
             };
             lines.push(crate::tui::render::palette_row_spans(
                 &item.key_hint,
                 &item.label,
                 item.category,
                 palette.key_width,
-                &state.theme,
+                &state.settings.theme(),
                 row_style,
             ));
         }
     }
     frame.render_widget(
-        Paragraph::new(lines).style(state.theme.base_style()).block(
-            Block::default()
-                .title(crate::tui::render::fit_block_title(
-                    palette.title,
-                    rect.width,
-                ))
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded)
-                .border_style(Style::default().fg(state.theme.accent))
-                .style(state.theme.base_style()),
-        ),
+        Paragraph::new(lines)
+            .style(state.settings.theme().base_style())
+            .block(
+                Block::default()
+                    .title(crate::tui::render::fit_block_title(
+                        palette.title,
+                        rect.width,
+                    ))
+                    .borders(Borders::ALL)
+                    .border_type(BorderType::Rounded)
+                    .border_style(Style::default().fg(state.settings.theme().accent))
+                    .style(state.settings.theme().base_style()),
+            ),
         rect,
     );
 
@@ -299,7 +305,7 @@ pub(crate) fn render_palette_vm(
         y = y.saturating_add(1);
     }
     if chrome.mouse_enabled {
-        let close = crate::tui::render::render_close_button(frame, rect, &state.theme);
+        let close = crate::tui::render::render_close_button(frame, rect, &state.settings.theme());
         layout.register(HitTarget::PaletteClose, close);
     }
 }
@@ -359,7 +365,16 @@ mod tests {
 
         let outcome = state.palette_click(col, row, &mouse);
 
-        assert_eq!(outcome, KeyOutcome::ThemeToggle);
-        assert_eq!(state.theme_choice, crate::config::ThemeChoice::Light);
+        assert_eq!(
+            outcome,
+            KeyOutcome::PersistSettings {
+                effect: None,
+                success_message: "Theme: light".into(),
+            }
+        );
+        assert_eq!(
+            state.settings.theme_choice(),
+            crate::config::ThemeChoice::Light
+        );
     }
 }

--- a/src/tui/screens/pins.rs
+++ b/src/tui/screens/pins.rs
@@ -303,7 +303,13 @@ pub(crate) fn render_pins_vm(
     layout: &mut MouseFrame,
 ) {
     let area = frame.area();
-    let area = crate::tui::render_top_bar(frame, area, &state.theme, chrome.mouse_enabled, layout);
+    let area = crate::tui::render_top_bar(
+        frame,
+        area,
+        &state.settings.theme(),
+        chrome.mouse_enabled,
+        layout,
+    );
     // Sync feedback (e.g. "already in sync") is carried in the Pins VM footer (see #72 / #241).
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -322,7 +328,7 @@ pub(crate) fn render_pins_vm(
         frame,
         chunks[0],
         &pins.pane,
-        &state.theme,
+        &state.settings.theme(),
         chrome.mouse_enabled,
         layout,
         PaneTarget::List,
@@ -334,7 +340,7 @@ pub(crate) fn render_pins_vm(
             chunks[1],
             &pins.footer_title,
             crate::tui::render::input_line("/", &pins.filter_query, ""),
-            &state.theme,
+            &state.settings.theme(),
             layout,
         );
     } else {
@@ -345,11 +351,11 @@ pub(crate) fn render_pins_vm(
             &pins.footer,
             pins.footer_colored,
             crate::tui::keymap::for_screen(&state.screen),
-            &state.theme,
+            &state.settings.theme(),
         );
     }
     if chrome.mouse_enabled {
-        let close = crate::tui::render_close_button(frame, area, &state.theme);
+        let close = crate::tui::render_close_button(frame, area, &state.settings.theme());
         layout.register(HitTarget::Close, close);
     }
 }

--- a/src/tui/screens/preview.rs
+++ b/src/tui/screens/preview.rs
@@ -145,7 +145,13 @@ pub(crate) fn render_preview_vm(
     layout: &mut MouseFrame,
 ) {
     let area = frame.area();
-    let area = crate::tui::render_top_bar(frame, area, &state.theme, chrome.mouse_enabled, layout);
+    let area = crate::tui::render_top_bar(
+        frame,
+        area,
+        &state.settings.theme(),
+        chrome.mouse_enabled,
+        layout,
+    );
     let footer_lines = if preview.footer_colored {
         1
     } else {
@@ -165,20 +171,20 @@ pub(crate) fn render_preview_vm(
         ))
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .style(state.theme.base_style())
+        .style(state.settings.theme().base_style())
         .padding(Padding::horizontal(1));
     let line_spans = preview_line_spans(
         &preview.body,
         preview.syntax_highlight,
         preview.ext.as_deref(),
-        &state.theme,
+        &state.settings.theme(),
     );
     let total_lines = line_spans.len();
     let paragraph = if preview.wrap {
         // Wrapping needs the full line set; vertical scroll goes through Paragraph (no hscroll).
         let body = Text::from(line_spans.into_iter().map(Line::from).collect::<Vec<_>>());
         Paragraph::new(body)
-            .style(state.theme.base_style())
+            .style(state.settings.theme().base_style())
             .scroll((preview.scroll, 0))
             .wrap(Wrap { trim: false })
             .block(block)
@@ -191,7 +197,7 @@ pub(crate) fn render_preview_vm(
             .skip(preview.scroll as usize)
             .collect();
         Paragraph::new(Text::from(visible))
-            .style(state.theme.base_style())
+            .style(state.settings.theme().base_style())
             .block(block)
     };
     frame.render_widget(paragraph, chunks[0]);
@@ -207,10 +213,10 @@ pub(crate) fn render_preview_vm(
         &preview.footer,
         preview.footer_colored,
         crate::tui::keymap::for_screen(&state.screen),
-        &state.theme,
+        &state.settings.theme(),
     );
     if chrome.mouse_enabled {
-        let close = crate::tui::render_close_button(frame, area, &state.theme);
+        let close = crate::tui::render_close_button(frame, area, &state.settings.theme());
         layout.register(HitTarget::Close, close);
     }
 }

--- a/src/tui/screens/revisions.rs
+++ b/src/tui/screens/revisions.rs
@@ -417,7 +417,13 @@ pub(crate) fn render_revisions_vm(
     layout: &mut MouseFrame,
 ) {
     let area = frame.area();
-    let area = crate::tui::render_top_bar(frame, area, &state.theme, chrome.mouse_enabled, layout);
+    let area = crate::tui::render_top_bar(
+        frame,
+        area,
+        &state.settings.theme(),
+        chrome.mouse_enabled,
+        layout,
+    );
     let footer_lines =
         crate::tui::render::wrap_line_count(&revs.footer, area.width.saturating_sub(2)).max(1);
     let chunks = Layout::default()
@@ -429,7 +435,7 @@ pub(crate) fn render_revisions_vm(
         frame,
         chunks[0],
         &revs.pane,
-        &state.theme,
+        &state.settings.theme(),
         chrome.mouse_enabled,
         layout,
         PaneTarget::List,
@@ -441,10 +447,10 @@ pub(crate) fn render_revisions_vm(
         &revs.footer,
         revs.footer_colored,
         crate::tui::keymap::for_screen(&state.screen),
-        &state.theme,
+        &state.settings.theme(),
     );
     if chrome.mouse_enabled {
-        let close = crate::tui::render_close_button(frame, area, &state.theme);
+        let close = crate::tui::render_close_button(frame, area, &state.settings.theme());
         layout.register(HitTarget::Close, close);
     }
 }

--- a/src/tui/settings.rs
+++ b/src/tui/settings.rs
@@ -1,0 +1,289 @@
+//! Runtime ownership for persisted TUI settings and CLI force-off overrides.
+
+use super::Theme;
+use crate::config::{AppConfig, ThemeChoice};
+
+/// Fields shown on the Settings screen, in display order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigField {
+    Theme,
+    Mouse,
+    CheckUpdates,
+    DiffShowFull,
+    IgnoreTrailingNewline,
+    ScanDepth,
+    DiffContext,
+}
+
+impl ConfigField {
+    pub const ALL: [Self; 7] = [
+        Self::Theme,
+        Self::Mouse,
+        Self::CheckUpdates,
+        Self::DiffShowFull,
+        Self::IgnoreTrailingNewline,
+        Self::ScanDepth,
+        Self::DiffContext,
+    ];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Theme => "Theme",
+            Self::Mouse => "Mouse support",
+            Self::CheckUpdates => "Check for updates",
+            Self::DiffShowFull => "Show full diff",
+            Self::IgnoreTrailingNewline => "Ignore trailing newline",
+            Self::ScanDepth => "Recursive scan depth",
+            Self::DiffContext => "Diff context lines",
+        }
+    }
+
+    pub fn is_numeric(self) -> bool {
+        matches!(self, Self::ScanDepth | Self::DiffContext)
+    }
+
+    pub fn description(self) -> &'static str {
+        match self {
+            Self::Theme => "terminal colours",
+            Self::Mouse => "click and wheel input",
+            Self::CheckUpdates => "daily GitHub version check",
+            Self::DiffShowFull => "open Diff expanded",
+            Self::IgnoreTrailingNewline => "hide newline-only diffs",
+            Self::ScanDepth => "directory levels to scan",
+            Self::DiffContext => "unchanged lines around edits",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingsEffect {
+    SyncMouseCapture,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SettingsChange {
+    pub effect: Option<SettingsEffect>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeSettings {
+    theme_choice: ThemeChoice,
+    mouse: bool,
+    check_updates: bool,
+    diff_show_full: bool,
+    ignore_trailing_newline: bool,
+    scan_depth: u32,
+    diff_context: u32,
+    no_mouse: bool,
+    no_update_check: bool,
+}
+
+impl RuntimeSettings {
+    pub fn from_config(config: &AppConfig, no_mouse: bool, no_update_check: bool) -> Self {
+        Self {
+            theme_choice: config.theme,
+            mouse: config.mouse,
+            check_updates: config.check_updates,
+            diff_show_full: config.diff_show_full,
+            ignore_trailing_newline: config.ignore_trailing_newline,
+            scan_depth: config.scan_depth,
+            diff_context: config.diff_context,
+            no_mouse,
+            no_update_check,
+        }
+    }
+
+    pub fn adjust(&mut self, field: ConfigField, forward: bool) -> Option<SettingsChange> {
+        let effect = match field {
+            ConfigField::Theme => {
+                self.theme_choice = match self.theme_choice {
+                    ThemeChoice::Dark => ThemeChoice::Light,
+                    ThemeChoice::Light => ThemeChoice::Dark,
+                };
+                None
+            }
+            ConfigField::Mouse => {
+                self.mouse = !self.mouse;
+                Some(SettingsEffect::SyncMouseCapture)
+            }
+            ConfigField::CheckUpdates => {
+                self.check_updates = !self.check_updates;
+                None
+            }
+            ConfigField::DiffShowFull => {
+                self.diff_show_full = !self.diff_show_full;
+                None
+            }
+            ConfigField::IgnoreTrailingNewline => {
+                self.ignore_trailing_newline = !self.ignore_trailing_newline;
+                None
+            }
+            ConfigField::ScanDepth => {
+                let next = if forward {
+                    self.scan_depth.saturating_add(1).min(20)
+                } else {
+                    self.scan_depth.saturating_sub(1)
+                };
+                if next == self.scan_depth {
+                    return None;
+                }
+                self.scan_depth = next;
+                None
+            }
+            ConfigField::DiffContext => {
+                let next = if forward {
+                    self.diff_context.saturating_add(1).min(50)
+                } else {
+                    self.diff_context.saturating_sub(1)
+                };
+                if next == self.diff_context {
+                    return None;
+                }
+                self.diff_context = next;
+                None
+            }
+        };
+        Some(SettingsChange { effect })
+    }
+
+    pub fn apply_to_config(&self, config: &mut AppConfig) {
+        config.theme = self.theme_choice;
+        config.mouse = self.mouse;
+        config.check_updates = self.check_updates;
+        config.diff_show_full = self.diff_show_full;
+        config.ignore_trailing_newline = self.ignore_trailing_newline;
+        config.scan_depth = self.scan_depth;
+        config.diff_context = self.diff_context;
+    }
+
+    pub fn field_value(&self, field: ConfigField) -> String {
+        match field {
+            ConfigField::Theme => match self.theme_choice {
+                ThemeChoice::Dark => "dark",
+                ThemeChoice::Light => "light",
+            }
+            .into(),
+            ConfigField::Mouse => if self.mouse { "on" } else { "off" }.into(),
+            ConfigField::CheckUpdates => if self.check_updates { "on" } else { "off" }.into(),
+            ConfigField::DiffShowFull => if self.diff_show_full { "on" } else { "off" }.into(),
+            ConfigField::IgnoreTrailingNewline => if self.ignore_trailing_newline {
+                "on"
+            } else {
+                "off"
+            }
+            .into(),
+            ConfigField::ScanDepth => self.scan_depth.to_string(),
+            ConfigField::DiffContext => self.diff_context.to_string(),
+        }
+    }
+
+    pub fn theme_choice(&self) -> ThemeChoice {
+        self.theme_choice
+    }
+    pub fn theme(&self) -> Theme {
+        Theme::for_choice(self.theme_choice)
+    }
+    pub fn mouse_enabled(&self) -> bool {
+        self.mouse && !self.no_mouse
+    }
+    pub fn update_check_enabled(&self) -> bool {
+        self.check_updates && !self.no_update_check
+    }
+    pub fn diff_show_full(&self) -> bool {
+        self.diff_show_full
+    }
+    pub fn ignore_trailing_newline(&self) -> bool {
+        self.ignore_trailing_newline
+    }
+    pub fn scan_depth(&self) -> u32 {
+        self.scan_depth
+    }
+    pub fn diff_context(&self) -> u32 {
+        self.diff_context
+    }
+
+    pub fn effective_diff_context(&self) -> Option<usize> {
+        (!self.diff_show_full).then_some(self.diff_context as usize)
+    }
+}
+
+impl Default for RuntimeSettings {
+    fn default() -> Self {
+        Self::from_config(&AppConfig::default(), false, false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cli_overrides_force_effective_values_off_without_changing_preferences() {
+        let config = AppConfig::default();
+        let settings = RuntimeSettings::from_config(&config, true, true);
+        assert!(!settings.mouse_enabled());
+        assert!(!settings.update_check_enabled());
+        let mut saved = AppConfig::default();
+        settings.apply_to_config(&mut saved);
+        assert!(saved.mouse);
+        assert!(saved.check_updates);
+    }
+
+    #[test]
+    fn numeric_adjustments_clamp_and_report_no_change_at_bounds() {
+        let mut config = AppConfig {
+            scan_depth: 20,
+            diff_context: 0,
+            ..AppConfig::default()
+        };
+        let mut settings = RuntimeSettings::from_config(&config, false, false);
+        assert!(settings.adjust(ConfigField::ScanDepth, true).is_none());
+        assert!(settings.adjust(ConfigField::DiffContext, false).is_none());
+        assert!(settings.adjust(ConfigField::ScanDepth, false).is_some());
+        assert_eq!(settings.scan_depth(), 19);
+        settings.apply_to_config(&mut config);
+        assert_eq!(config.diff_context, 0);
+    }
+
+    #[test]
+    fn only_mouse_adjustment_requests_external_effect() {
+        let mut settings = RuntimeSettings::default();
+        let change = settings.adjust(ConfigField::Mouse, true).unwrap();
+        assert_eq!(change.effect, Some(SettingsEffect::SyncMouseCapture));
+        let change = settings.adjust(ConfigField::Theme, true).unwrap();
+        assert_eq!(change.effect, None);
+    }
+
+    #[test]
+    fn projection_updates_every_owned_field_and_preserves_the_rest() {
+        let source = AppConfig {
+            theme: ThemeChoice::Light,
+            mouse: false,
+            check_updates: false,
+            diff_show_full: true,
+            ignore_trailing_newline: false,
+            scan_depth: 5,
+            diff_context: 7,
+            ..AppConfig::default()
+        };
+        let settings = RuntimeSettings::from_config(&source, false, false);
+        let mut target = AppConfig::default();
+        target.pinned.push(crate::domain::PinnedMapping {
+            local_path: "/tmp/keep".into(),
+            gist_id: "g1".into(),
+            gist_filename: "a.txt".into(),
+            direction: None,
+            last_seen_hash: None,
+        });
+        target.skip_dirs = vec!["keep-me".into()];
+        settings.apply_to_config(&mut target);
+        assert_eq!(
+            target,
+            AppConfig {
+                pinned: target.pinned.clone(),
+                skip_dirs: vec!["keep-me".into()],
+                ..source
+            }
+        );
+    }
+}

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -46,7 +46,7 @@ impl SyntaxPalette {
 }
 
 /// Semantic colour palette for the TUI. All render code uses these fields rather than
-/// hard-coded `Color::*` values so that swapping themes only requires changing `AppState::theme`.
+/// hard-coded `Color::*` values; `RuntimeSettings` derives one from the selected theme.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Theme {
     /// Canvas background — `Color::Reset` for dark (terminal native), `Color::White` for light.

--- a/src/tui/view_model.rs
+++ b/src/tui/view_model.rs
@@ -370,7 +370,7 @@ pub struct HelpIndexItemVm {
 /// Pure chrome facts shared across screens (and palette backgrounds).
 pub(crate) fn build_chrome(state: &AppState) -> ChromeVm {
     ChromeVm {
-        mouse_enabled: state.mouse_enabled,
+        mouse_enabled: state.settings.mouse_enabled(),
         bg_task_msg: state.bg_task_msg.clone(),
         spinner_frame: state.spinner_frame,
     }


### PR DESCRIPTION
## Summary

- make `RuntimeSettings` the single owner of persisted TUI preferences, CLI overrides, effective values, and field adjustment rules
- route Settings, global theme, and Diff context mutations through one persistence projection while preserving their existing status messages
- persist `diff_show_full` correctly and retain pins, skip directories, and other non-UI config values

## Verification

- `mise run check`
- Standards review: clean
- Spec review: clean

Closes #404