### PR TITLE
fix(tui): centralize Gist content cache policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Deleting a Gist no longer leaves its files available through the preview cache, and a failed
+  preview refresh keeps the last usable cached content for the next preview.
 - Settings now reliably remember the "Show full diff" choice alongside the other preferences.
 - Gist refreshes now keep the last usable list and counts when one GitHub request fails, and a
   superseded refresh can no longer overwrite newer results.

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -6,7 +6,7 @@ Index: [`AGENTS.md`](../../AGENTS.md). Source of truth for types lives in the mo
 
 | Kind | Modules | Testing |
 | --- | --- | --- |
-| **Pure** (unit-tested) | `domain`, `config`, `ranking`, `local`, `diff`, actions **plan/guard**, `tui::view_model`, `tui::list_ranking`, `tui::settings` | In-crate unit tests |
+| **Pure** (unit-tested) | `domain`, `config`, `ranking`, `local`, `diff`, actions **plan/guard**, `tui::view_model`, `tui::list_ranking`, `tui::settings`, `tui::gist_content` | In-crate unit tests |
 | **Impure** (thin IO) | `gh`, actions **execute**, `tui::run_loop` / `tui::bg` / `tui::gist_refresh` / `tui::pin_sync` | No live `gh`. Spawn/absorb is thin IO; action-job `on_*` apply handlers (screen modules / `gist_mutation.rs`) are unit-tested (#298, #383) |
 
 `build_view_model` (`@src/tui/view_model.rs`): `AppState` + pin-sync cache → presentation facts. Paint helpers apply theme/layout only — no business rules, FS, or network.
@@ -16,6 +16,17 @@ Index: [`AGENTS.md`](../../AGENTS.md). Source of truth for types lives in the mo
 - `RuntimeSettings` is the only runtime owner of the seven Settings-screen preferences and the `--no-mouse` / `--no-update-check` session overrides. Effective mouse and update-check values are derived; `Theme` is derived from `ThemeChoice`.
 - Settings-screen edits, global theme toggle, and Diff context toggle all call `RuntimeSettings::adjust`. Only a mouse change returns `SettingsEffect::SyncMouseCapture`; dispatch owns that terminal IO.
 - Persistence loads the current `AppConfig`, calls `apply_to_config`, then saves. That projection updates every runtime-owned field and leaves pins, skip directories, and other config data intact.
+
+## Gist content store (`@src/tui/gist_content.rs`, issue #406)
+
+- `GistContentStore` is the only owner of the 64-entry in-memory content LRU. Callers request
+  `PreferCache` for Preview or `Refresh` for every explicit/fresh fetch; both miss paths hydrate
+  a missing raw URL from `GistCatalog` before IO starts.
+- `Refresh` bypasses but does not evict last-known-good content. Only a successful Preview fetch
+  inserts its result. Failed, cancelled, or superseded work therefore leaves the store unchanged.
+- Successful file-content mutations invalidate that file after upload, remove, or revision
+  restore. Successful Gist deletion invalidates every file for the Gist. Metadata-only mutations
+  (description, compact, star, fork) do not invalidate content.
 
 ## GistFile construction (`@src/domain.rs`, issue #379)
 

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -364,11 +364,6 @@ impl GistFileRef {
             self.raw_url.clone(),
         )
     }
-
-    /// Key for the gist content LRU: `(gist_id, filename)` only.
-    pub fn cache_key(&self) -> (String, String) {
-        (self.gist_id.clone(), self.filename.clone())
-    }
 }
 
 /// One entry from `gh api /gists/{id}/commits` — a gist revision (newest-first in the API).
@@ -542,13 +537,6 @@ mod tests {
                 ..GistFile::fixture("g1", "a.txt")
             }
         );
-    }
-
-    #[test]
-    fn gist_file_ref_cache_key_is_id_and_filename() {
-        let r = GistFileRef::new("g1", "f.toml", Some("https://raw".into()));
-        assert_eq!(r.cache_key(), ("g1".into(), "f.toml".into()));
-        assert_eq!(GistFileRef::id_name("g1", "f.toml").raw_url, None);
     }
 
     #[test]

--- a/src/lru.rs
+++ b/src/lru.rs
@@ -66,6 +66,19 @@ impl<K: Clone + Eq + Hash, V> LruCache<K, V> {
         self.map.remove(key)
     }
 
+    /// Remove every entry whose key matches `predicate`.
+    pub(crate) fn remove_where(&mut self, mut predicate: impl FnMut(&K) -> bool) {
+        let keys: Vec<K> = self
+            .order
+            .iter()
+            .filter(|key| predicate(key))
+            .cloned()
+            .collect();
+        for key in keys {
+            self.remove(&key);
+        }
+    }
+
     /// Move an existing key to the most-recently-used (back) position.
     fn touch(&mut self, key: &K) {
         if let Some(pos) = self.order.iter().position(|k| k == key) {
@@ -136,5 +149,16 @@ mod tests {
 
         assert_eq!(cache.len(), 1);
         assert_eq!(cache.get(&"b"), Some(&2));
+    }
+
+    #[test]
+    fn remove_where_drops_every_matching_entry() {
+        let mut cache = LruCache::new(3);
+        cache.insert(("g1", "a"), 1);
+        cache.insert(("g2", "b"), 2);
+        cache.insert(("g1", "c"), 3);
+        cache.remove_where(|(gist_id, _)| *gist_id == "g1");
+        assert_eq!(cache.len(), 1);
+        assert_eq!(cache.get(&("g2", "b")), Some(&2));
     }
 }

--- a/src/tui/gist_content.rs
+++ b/src/tui/gist_content.rs
@@ -1,0 +1,146 @@
+//! In-memory Gist content lookup, request hydration, and invalidation policy.
+
+use crate::domain::{GistCatalog, GistFileRef};
+
+type ContentKey = (String, String);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum FetchPolicy {
+    PreferCache,
+    Refresh,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum ContentLookup {
+    Hit(String),
+    Miss(GistFileRef),
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct GistContentStore {
+    cache: crate::lru::LruCache<ContentKey, String>,
+}
+
+impl GistContentStore {
+    pub fn lookup(
+        &mut self,
+        catalog: &GistCatalog,
+        mut file: GistFileRef,
+        policy: FetchPolicy,
+    ) -> ContentLookup {
+        let key = key(&file);
+        if policy == FetchPolicy::PreferCache {
+            if let Some(content) = self.cache.get(&key).cloned() {
+                return ContentLookup::Hit(content);
+            }
+        }
+        if file.raw_url.is_none() {
+            file.raw_url = catalog
+                .owned
+                .iter()
+                .chain(&catalog.starred)
+                .find(|gist| gist.gist_id == file.gist_id && gist.filename == file.filename)
+                .and_then(|gist| gist.raw_url.clone());
+        }
+        ContentLookup::Miss(file)
+    }
+
+    pub fn insert(&mut self, file: &GistFileRef, content: String) {
+        self.cache.insert(key(file), content);
+    }
+
+    pub fn invalidate_file(&mut self, file: &GistFileRef) {
+        self.cache.remove(&key(file));
+    }
+
+    pub fn invalidate_gist(&mut self, gist_id: &str) {
+        self.cache.remove_where(|(id, _)| id == gist_id);
+    }
+}
+
+impl Default for GistContentStore {
+    fn default() -> Self {
+        Self {
+            cache: crate::lru::LruCache::new(64),
+        }
+    }
+}
+
+fn key(file: &GistFileRef) -> ContentKey {
+    (file.gist_id.clone(), file.filename.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::GistFile;
+
+    fn catalog() -> GistCatalog {
+        GistCatalog {
+            owned: vec![GistFile {
+                raw_url: Some("https://example.test/a.txt".into()),
+                ..GistFile::fixture("g1", "a.txt")
+            }],
+            ..GistCatalog::default()
+        }
+    }
+
+    #[test]
+    fn prefer_cache_hits_while_refresh_returns_a_hydrated_request() {
+        let file = GistFileRef::id_name("g1", "a.txt");
+        let mut store = GistContentStore::default();
+        store.insert(&file, "cached".into());
+        assert_eq!(
+            store.lookup(&catalog(), file.clone(), FetchPolicy::PreferCache),
+            ContentLookup::Hit("cached".into())
+        );
+        assert_eq!(
+            store.lookup(&catalog(), file, FetchPolicy::Refresh),
+            ContentLookup::Miss(GistFileRef::new(
+                "g1",
+                "a.txt",
+                Some("https://example.test/a.txt".into())
+            ))
+        );
+    }
+
+    #[test]
+    fn refresh_keeps_last_known_good_until_insert() {
+        let file = GistFileRef::id_name("g1", "a.txt");
+        let mut store = GistContentStore::default();
+        store.insert(&file, "old".into());
+        assert!(matches!(
+            store.lookup(&catalog(), file.clone(), FetchPolicy::Refresh),
+            ContentLookup::Miss(_)
+        ));
+        assert_eq!(
+            store.lookup(&catalog(), file, FetchPolicy::PreferCache),
+            ContentLookup::Hit("old".into())
+        );
+    }
+
+    #[test]
+    fn invalidation_can_target_one_file_or_a_whole_gist() {
+        let a = GistFileRef::id_name("g1", "a.txt");
+        let b = GistFileRef::id_name("g1", "b.txt");
+        let c = GistFileRef::id_name("g2", "c.txt");
+        let mut store = GistContentStore::default();
+        for file in [&a, &b, &c] {
+            store.insert(file, file.filename.clone());
+        }
+        store.invalidate_file(&a);
+        assert!(matches!(
+            store.lookup(&catalog(), a, FetchPolicy::PreferCache),
+            ContentLookup::Miss(_)
+        ));
+        store.invalidate_gist("g1");
+        assert!(matches!(
+            store.lookup(&catalog(), b, FetchPolicy::PreferCache),
+            ContentLookup::Miss(_)
+        ));
+        assert_eq!(
+            store.lookup(&catalog(), c, FetchPolicy::PreferCache),
+            ContentLookup::Hit("c.txt".into())
+        );
+    }
+}

--- a/src/tui/gist_mutation.rs
+++ b/src/tui/gist_mutation.rs
@@ -31,7 +31,7 @@ pub(crate) fn on_upload_replace(
     file: crate::domain::GistFileRef,
 ) -> LoopFlow {
     apply(state, result, "upload", |state| {
-        state.gist_content_cache.remove(&file.cache_key());
+        state.gist_content_store.invalidate_file(&file);
         if let Some(local_path) = state.upload_local_path() {
             let content = state.content_to_upload();
             record_pin_sync(
@@ -84,7 +84,8 @@ pub(crate) fn on_delete_gist(
     result: Result<(), String>,
     gist_id: String,
 ) -> LoopFlow {
-    apply(state, result, "delete", |_| {
+    apply(state, result, "delete", |state| {
+        state.gist_content_store.invalidate_gist(&gist_id);
         format!("Deleted gist {gist_id}")
     })
 }
@@ -98,8 +99,11 @@ pub(crate) fn on_remove_file(
 ) -> LoopFlow {
     apply(state, result, "remove", |state| {
         state
-            .gist_content_cache
-            .remove(&(gist_id.clone(), filename.clone()));
+            .gist_content_store
+            .invalidate_file(&crate::domain::GistFileRef::id_name(
+                gist_id.clone(),
+                filename.clone(),
+            ));
         format!("Removed {filename} from gist {gist_id}")
     })
 }
@@ -199,9 +203,8 @@ mod tests {
         let mut state = initial_state();
         state.cwd = dir.path().to_path_buf();
         state.pinned = vec![mapping];
-        state
-            .gist_content_cache
-            .insert(("g1".into(), "a.txt".into()), "stale".into());
+        let file = crate::domain::GistFileRef::id_name("g1", "a.txt");
+        state.gist_content_store.insert(&file, "stale".into());
         state.enter_confirm(
             PendingAction::Upload {
                 gist_id: "g1".into(),
@@ -216,10 +219,14 @@ mod tests {
 
         assert!(state.gist_list_stale);
         assert_eq!(state.status.as_deref(), Some("Uploaded a.txt to gist g1"));
-        assert!(state
-            .gist_content_cache
-            .get(&("g1".into(), "a.txt".into()))
-            .is_none());
+        assert!(matches!(
+            state.gist_content_store.lookup(
+                &state.gist_catalog,
+                file,
+                crate::tui::gist_content::FetchPolicy::PreferCache
+            ),
+            crate::tui::gist_content::ContentLookup::Miss(_)
+        ));
         assert_eq!(state.pinned[0].direction, Some(SyncDirection::Upload));
         assert_eq!(
             state.pinned[0].last_seen_hash.as_deref(),
@@ -265,21 +272,53 @@ mod tests {
     #[test]
     fn on_delete_gist_err_sets_status() {
         let mut state = initial_state();
+        let file = crate::domain::GistFileRef::id_name("g1", "a.txt");
+        state.gist_content_store.insert(&file, "body".into());
 
         on_delete_gist(&mut state, Err("boom".into()), "g1".into());
 
         assert_eq!(state.status.as_deref(), Some("delete failed: boom"));
         assert!(!state.gist_list_stale);
+        assert!(matches!(
+            state.gist_content_store.lookup(
+                &state.gist_catalog,
+                file,
+                crate::tui::gist_content::FetchPolicy::PreferCache
+            ),
+            crate::tui::gist_content::ContentLookup::Hit(_)
+        ));
     }
 
     #[test]
     fn on_delete_gist_ok_marks_list_stale() {
         let mut state = initial_state();
+        let deleted = crate::domain::GistFileRef::id_name("g1", "a.txt");
+        let retained = crate::domain::GistFileRef::id_name("g2", "b.txt");
+        state.gist_content_store.insert(&deleted, "deleted".into());
+        state
+            .gist_content_store
+            .insert(&retained, "retained".into());
 
         on_delete_gist(&mut state, Ok(()), "g1".into());
 
         assert!(state.gist_list_stale);
         assert_eq!(state.status.as_deref(), Some("Deleted gist g1"));
+        assert!(matches!(
+            state.gist_content_store.lookup(
+                &state.gist_catalog,
+                deleted,
+                crate::tui::gist_content::FetchPolicy::PreferCache
+            ),
+            crate::tui::gist_content::ContentLookup::Miss(_)
+        ));
+        assert!(matches!(
+            state.gist_content_store.lookup(
+                &state.gist_catalog,
+                retained,
+                crate::tui::gist_content::FetchPolicy::PreferCache
+            ),
+            crate::tui::gist_content::ContentLookup::Hit(_)
+        ));
     }
 
     #[test]
@@ -295,18 +334,21 @@ mod tests {
     #[test]
     fn on_remove_file_ok_drops_cache_and_marks_list_stale() {
         let mut state = initial_state();
-        state
-            .gist_content_cache
-            .insert(("g1".into(), "a.txt".into()), "body".into());
+        let file = crate::domain::GistFileRef::id_name("g1", "a.txt");
+        state.gist_content_store.insert(&file, "body".into());
 
         on_remove_file(&mut state, Ok(()), "g1".into(), "a.txt".into());
 
         assert!(state.gist_list_stale);
         assert_eq!(state.status.as_deref(), Some("Removed a.txt from gist g1"));
-        assert!(state
-            .gist_content_cache
-            .get(&("g1".into(), "a.txt".into()))
-            .is_none());
+        assert!(matches!(
+            state.gist_content_store.lookup(
+                &state.gist_catalog,
+                file,
+                crate::tui::gist_content::FetchPolicy::PreferCache
+            ),
+            crate::tui::gist_content::ContentLookup::Miss(_)
+        ));
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -15,6 +15,7 @@ use ratatui::{backend::CrosstermBackend, widgets::Clear, Terminal};
 use std::io;
 use std::path::PathBuf;
 
+mod gist_content;
 mod gist_refresh;
 mod mouse;
 pub use mouse::{
@@ -688,8 +689,8 @@ pub struct PinsState {
 pub struct PreviewState {
     pub title: String,
     pub body: ScrollBody,
-    /// `(gist_id, filename)` for refresh / copy-url context.
-    pub gist_key: Option<(String, String)>,
+    /// Gist file identity for refresh / copy-url context.
+    pub gist_file: Option<GistFileRef>,
 }
 
 /// Unified-diff view — carried on [`Screen::Diff`] (issue #242).
@@ -825,7 +826,7 @@ pub struct AppState {
     /// How this binary was installed — resolved once at startup so the update hint can show
     /// the right upgrade command without per-frame IO.
     pub install_method: crate::upgrade::InstallMethod,
-    pub(crate) gist_content_cache: crate::lru::LruCache<(String, String), String>,
+    gist_content_store: gist_content::GistContentStore,
     pub local_recursive: bool,
     pub skip_dirs: Vec<String>,
     pub local_scanning: bool,
@@ -1030,12 +1031,7 @@ impl AppState {
     }
 
     /// Enter full-screen content preview with the given body and gist identity.
-    pub fn enter_preview(
-        &mut self,
-        title: String,
-        text: String,
-        gist_key: Option<(String, String)>,
-    ) {
+    pub fn enter_preview(&mut self, title: String, text: String, gist_file: Option<GistFileRef>) {
         self.status = None;
         self.enter(Screen::Preview(Box::new(PreviewState {
             title,
@@ -1043,7 +1039,7 @@ impl AppState {
                 text,
                 ..ScrollBody::default()
             },
-            gist_key,
+            gist_file,
         })));
     }
 
@@ -2010,9 +2006,7 @@ pub fn initial_state() -> AppState {
         syntax_highlight: true,
         update_available: None,
         install_method: crate::upgrade::InstallMethod::Standalone,
-        // Bound the in-memory preview cache so browsing many/large gists can't grow unbounded;
-        // evicted entries are simply re-fetched on demand.
-        gist_content_cache: crate::lru::LruCache::new(64),
+        gist_content_store: gist_content::GistContentStore::default(),
         local_recursive: false,
         skip_dirs: crate::config::AppConfig::default().skip_dirs,
         local_scanning: false,

--- a/src/tui/screens/confirm.rs
+++ b/src/tui/screens/confirm.rs
@@ -2,6 +2,7 @@
 //! one file (issue #287, Phase 2; issue #383).
 
 use crate::tui::bg::LoopFlow;
+use crate::tui::gist_content::{ContentLookup, FetchPolicy};
 use crate::tui::view_model::{ConfirmBackgroundVm, ConfirmModalKind, ConfirmVm};
 use crate::tui::{AppState, HelpTopic, HitTarget, KeyOutcome, MouseFrame, PendingAction, Screen};
 use crossterm::event::KeyCode;
@@ -22,13 +23,17 @@ pub(crate) fn wheel_step() -> usize {
 pub(crate) fn stage_upload_preview(
     state: &mut AppState,
     local_path: PathBuf,
-    mut file: crate::domain::GistFileRef,
+    file: crate::domain::GistFileRef,
 ) -> (crate::domain::GistFileRef, String, String) {
     let gist_file = state.gist_file_for_diff(&file);
     let (local_label, gist_label) = crate::tui::render::diff_labels(Some(&local_path), &gist_file);
-    if file.raw_url.is_none() {
-        file.raw_url = gist_file.raw_url;
-    }
+    let ContentLookup::Miss(file) =
+        state
+            .gist_content_store
+            .lookup(&state.gist_catalog, file, FetchPolicy::Refresh)
+    else {
+        unreachable!("fresh fetch always bypasses cached content")
+    };
     (file, local_label, gist_label)
 }
 

--- a/src/tui/screens/diff.rs
+++ b/src/tui/screens/diff.rs
@@ -2,6 +2,7 @@
 //! colocated in one file (issue #287, Phase 2; issue #383).
 
 use crate::tui::bg::{record_pin_sync, refresh_locals, LocalScanMode, LoopFlow};
+use crate::tui::gist_content::{ContentLookup, FetchPolicy};
 use crate::tui::render::{diff_labels, preview_diff_text};
 use crate::tui::view_model::{ChromeVm, DiffVm};
 use crate::tui::{AppState, ConfigField, HelpTopic, HitTarget, KeyOutcome, PendingAction};
@@ -41,14 +42,18 @@ pub(crate) fn stage_download_gist(
 }
 
 fn stage_gist_diff_fetch(
-    state: &AppState,
+    state: &mut AppState,
     local_path: Option<&std::path::Path>,
-    mut file: crate::domain::GistFileRef,
+    file: crate::domain::GistFileRef,
 ) -> (crate::domain::GistFileRef, String, String) {
     let gist = state.gist_file_for_diff(&file);
-    if file.raw_url.is_none() {
-        file.raw_url = gist.raw_url.clone();
-    }
+    let ContentLookup::Miss(file) =
+        state
+            .gist_content_store
+            .lookup(&state.gist_catalog, file, FetchPolicy::Refresh)
+    else {
+        unreachable!("fresh fetch always bypasses cached content")
+    };
     let (local_label, gist_label) = diff_labels(local_path, &gist);
     (file, local_label, gist_label)
 }

--- a/src/tui/screens/list.rs
+++ b/src/tui/screens/list.rs
@@ -967,7 +967,7 @@ mod tests {
         state.enter_preview(
             "Preview: a / x".into(),
             "raw content".into(),
-            Some(("a".into(), "x".into())),
+            Some(crate::domain::GistFileRef::id_name("a", "x")),
         );
         assert_eq!(state.handle_key(KeyCode::Esc), KeyOutcome::None);
         assert_eq!(state.screen, Screen::List);

--- a/src/tui/screens/preview.rs
+++ b/src/tui/screens/preview.rs
@@ -2,6 +2,7 @@
 //! colocated in one file (issue #287, Phase 2; issue #383).
 
 use crate::tui::bg::LoopFlow;
+use crate::tui::gist_content::{ContentLookup, FetchPolicy};
 use crate::tui::view_model::{ChromeVm, PreviewVm};
 use crate::tui::{AppState, HelpTopic, HitTarget, KeyOutcome, MouseFrame};
 use crossterm::event::KeyCode;
@@ -25,30 +26,37 @@ pub(crate) fn wheel_step() -> usize {
 /// Stage a content preview. A cache hit enters Preview immediately; a miss returns fetch data.
 pub(crate) fn stage_preview_content(
     state: &mut AppState,
-    mut file: crate::domain::GistFileRef,
+    file: crate::domain::GistFileRef,
 ) -> Option<(crate::domain::GistFileRef, String)> {
-    let key = file.cache_key();
-    if let Some(content) = state.gist_content_cache.get(&key).cloned() {
-        let title = state.preview_title(&file.gist_id, &file.filename);
-        state.enter_preview(title, content, Some(key));
-        return None;
+    match state.gist_content_store.lookup(
+        &state.gist_catalog,
+        file.clone(),
+        FetchPolicy::PreferCache,
+    ) {
+        ContentLookup::Hit(content) => {
+            let title = state.preview_title(&file.gist_id, &file.filename);
+            state.enter_preview(title, content, Some(file));
+            None
+        }
+        ContentLookup::Miss(file) => {
+            let title = state.preview_title(&file.gist_id, &file.filename);
+            Some((file, title))
+        }
     }
-    if file.raw_url.is_none() {
-        file.raw_url = state.gist_file_raw_url(&file.gist_id, &file.filename);
-    }
-    let title = state.preview_title(&file.gist_id, &file.filename);
-    Some((file, title))
 }
 
-/// Invalidate cached content and build the fetch payload for refreshing a preview.
+/// Bypass cached content and build the fetch payload for refreshing a preview.
 pub(crate) fn stage_refresh_preview(
     state: &mut AppState,
-    mut file: crate::domain::GistFileRef,
+    file: crate::domain::GistFileRef,
 ) -> (crate::domain::GistFileRef, String) {
-    state.gist_content_cache.remove(&file.cache_key());
-    if file.raw_url.is_none() {
-        file.raw_url = state.gist_file_raw_url(&file.gist_id, &file.filename);
-    }
+    let ContentLookup::Miss(file) =
+        state
+            .gist_content_store
+            .lookup(&state.gist_catalog, file, FetchPolicy::Refresh)
+    else {
+        unreachable!("refresh always bypasses cached content")
+    };
     let title = state.preview_title(&file.gist_id, &file.filename);
     (file, title)
 }
@@ -68,21 +76,21 @@ impl AppState {
                 let Some(p) = self.preview() else {
                     return KeyOutcome::None;
                 };
-                let Some((gist_id, filename)) = p.gist_key.clone() else {
+                let Some(file) = p.gist_file.clone() else {
                     return KeyOutcome::None;
                 };
                 return KeyOutcome::RefreshPreview {
                     entry: self
                         .defer_replacement()
                         .unwrap_or_else(|| self.defer_entry()),
-                    file: crate::domain::GistFileRef::id_name(gist_id, filename),
+                    file,
                 };
             }
             KeyCode::Char('w') => self.preview_wrap = !self.preview_wrap,
             KeyCode::Char('y') => {
                 let gist_id = self
                     .preview()
-                    .and_then(|p| p.gist_key.as_ref().map(|(id, _)| id.clone()))
+                    .and_then(|p| p.gist_file.as_ref().map(|file| file.gist_id.clone()))
                     .or_else(|| self.context_gist_id());
                 let Some(gist_id) = gist_id else {
                     return KeyOutcome::None;
@@ -106,9 +114,9 @@ pub(crate) fn build_preview_vm(state: &AppState) -> PreviewVm {
     };
     let (footer, footer_colored) = crate::tui::footer_with_status(state.status.as_deref(), hints);
     let ext = p
-        .gist_key
+        .gist_file
         .as_ref()
-        .and_then(|(_, filename)| crate::tui::view_model::file_ext(filename));
+        .and_then(|file| crate::tui::view_model::file_ext(&file.filename));
     PreviewVm {
         title: p.title,
         body: p.body.text,
@@ -231,10 +239,7 @@ pub(crate) fn on_preview_content(
 ) -> LoopFlow {
     match result {
         Ok(content) => {
-            let key = file.cache_key();
-            state
-                .gist_content_cache
-                .insert(key.clone(), content.clone());
+            state.gist_content_store.insert(&file, content.clone());
             state.open_deferred(
                 entry,
                 crate::tui::Screen::Preview(Box::new(crate::tui::PreviewState {
@@ -243,7 +248,7 @@ pub(crate) fn on_preview_content(
                         text: content,
                         ..crate::tui::ScrollBody::default()
                     },
-                    gist_key: Some(key),
+                    gist_file: Some(file),
                 })),
             );
         }
@@ -264,9 +269,7 @@ mod tests {
     fn stage_preview_content_cache_hit_enters_preview_without_spawn_payload() {
         let mut state = state_with_gists();
         let file = gist_file_ref("g1", "a.txt");
-        state
-            .gist_content_cache
-            .insert(file.cache_key(), "cached".into());
+        state.gist_content_store.insert(&file, "cached".into());
 
         assert!(stage_preview_content(&mut state, file).is_none());
 
@@ -286,20 +289,25 @@ mod tests {
     }
 
     #[test]
-    fn stage_refresh_preview_drops_cache_and_returns_fetch_payload() {
+    fn stage_refresh_preview_keeps_cache_and_returns_fetch_payload() {
         let mut state = state_with_gists();
         state.gist_catalog.owned[0].raw_url = Some("https://example.test/a.txt".into());
         let file = gist_file_ref("g1", "a.txt");
-        state
-            .gist_content_cache
-            .insert(file.cache_key(), "cached".into());
-        state.enter_preview("a.txt".into(), "cached".into(), Some(file.cache_key()));
+        state.gist_content_store.insert(&file, "cached".into());
+        state.enter_preview("a.txt".into(), "cached".into(), Some(file.clone()));
 
         let entry = state.defer_replacement().unwrap();
         let (file, title) = stage_refresh_preview(&mut state, file);
 
         assert!(entry.return_to.is_gists());
-        assert!(state.gist_content_cache.get(&file.cache_key()).is_none());
+        assert!(matches!(
+            state.gist_content_store.lookup(
+                &state.gist_catalog,
+                file.clone(),
+                FetchPolicy::PreferCache
+            ),
+            ContentLookup::Hit(ref content) if content == "cached"
+        ));
         assert_eq!(file.raw_url.as_deref(), Some("https://example.test/a.txt"));
         assert!(title.contains("a.txt"));
     }
@@ -460,10 +468,14 @@ mod tests {
             "a.txt".into(),
         );
 
-        assert_eq!(
-            state.gist_content_cache.get(&file.cache_key()),
-            Some(&"body".to_string())
-        );
+        assert!(matches!(
+            state.gist_content_store.lookup(
+                &state.gist_catalog,
+                file.clone(),
+                FetchPolicy::PreferCache
+            ),
+            ContentLookup::Hit(ref content) if content == "body"
+        ));
         let preview = state.preview().expect("expected Screen::Preview");
         assert_eq!(preview.body.text, "body");
     }

--- a/src/tui/screens/revisions.rs
+++ b/src/tui/screens/revisions.rs
@@ -515,8 +515,11 @@ pub(crate) fn on_restore_revision_done(
     match result {
         Ok(()) => {
             state
-                .gist_content_cache
-                .remove(&(gist_id.clone(), filename.clone()));
+                .gist_content_store
+                .invalidate_file(&crate::domain::GistFileRef::id_name(
+                    gist_id.clone(),
+                    filename.clone(),
+                ));
             state.set_status(format!(
                 "Restored {filename} from old revision (new revision created)"
             ));
@@ -865,9 +868,8 @@ mod tests {
             },
             String::new(),
         );
-        state
-            .gist_content_cache
-            .insert(("g1".into(), "a.txt".into()), "stale".into());
+        let file = crate::domain::GistFileRef::id_name("g1", "a.txt");
+        state.gist_content_store.insert(&file, "stale".into());
 
         on_restore_revision_done(&mut state, Ok(()), "g1".into(), "a.txt".into());
 
@@ -882,9 +884,13 @@ mod tests {
             state.status.as_deref(),
             Some("Restored a.txt from old revision (new revision created)")
         );
-        assert!(state
-            .gist_content_cache
-            .get(&("g1".into(), "a.txt".into()))
-            .is_none());
+        assert!(matches!(
+            state.gist_content_store.lookup(
+                &state.gist_catalog,
+                file,
+                crate::tui::gist_content::FetchPolicy::PreferCache
+            ),
+            crate::tui::gist_content::ContentLookup::Miss(_)
+        ));
     }
 }

--- a/src/tui/view_model.rs
+++ b/src/tui/view_model.rs
@@ -1110,7 +1110,7 @@ mod tests {
         state.enter_preview(
             "gist: notes.txt".into(),
             "hello preview\n".into(),
-            Some(("g1".into(), "notes.rs".into())),
+            Some(crate::domain::GistFileRef::id_name("g1", "notes.rs")),
         );
         state.status = Some("refresh failed".into());
         match build_view_model(&state).screen {


### PR DESCRIPTION
## Summary

- centralize preview cache lookup, raw URL hydration, and invalidation in `GistContentStore`
- keep last-known-good preview content across explicit refresh failures
- invalidate cached content after successful file mutations and whole-Gist deletion

## Verification

- `mise run check`
- standards review: clean
- spec review: clean

Closes #406