### PR TITLE
fix(tui): deepen selectable-list interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of falling through to the row underneath.
 - Command-palette mouse clicks now execute the row under the pointer when disabled commands are
   visible above it.
+- Revision history now scrolls like every other list: moving the selection resets the horizontal
+  scroll, and scrolling right stops at the selected row's own text instead of running unbounded.
 
 ## [0.18.0] — 2026-08-21
 

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -129,8 +129,19 @@ Help topics and `README.md` stay hand-written — the List topic is fifty lines 
   `is_dragging()`.
 - Non-mouse render output belongs in `RenderFeedback`. In particular, comments scroll-to-bottom
   is consumed only after the comments renderer supplies `comments_max_scroll`.
+- `MouseFrame::resolve_pane` is the seam `ScreenLookup::click_select` consumes (issue #408):
+  it walks only `register_pane` hits and returns a resolved `RowTarget::Pane { pane, index }`,
+  never raw `(col, row)`. It deliberately ignores `Divider`/other whole-body `Rect` hits —
+  `HitTarget::Divider` registers over the List screen's *entire* body (feeding `MouseFrame::split`,
+  which just returns the most recently registered `SplitHit` regardless of point containment), far
+  wider than its visual grab zone, and would otherwise mask every pane row underneath it if
+  `resolve` (the priority-ordered `Rect` resolver used for top-bar/tab targets) were reused here.
+  Per-screen `click_select_*` functions match on `pane`/`index` only — List routes Local vs. Gist
+  focus and anchor re-ranking; Pins/Gists/Revisions/Help/Config select on their single `PaneTarget::List`;
+  GistDetail focuses Files on any hit in `PaneTarget::DetailFiles`, moving `file_cursor` only when
+  `index` is `Some`.
 
-List-row horizontal scroll (issue #341) is **per selected row**, not pane-wide: `row_hscroll` applies the pane offset only to the highlighted index; `focused_hscroll_max` / Pins / Gists caps are that row's painted string. A non-zero offset prefixes `…` in `visible_list_row` (then `truncate_end` may still mark a clipped tail). Unselected rows stay at column 0.
+List-row horizontal scroll (issue #341) is **per selected row**, not pane-wide: `row_hscroll` applies the pane offset only to the highlighted index; `focused_hscroll_max` / Pins / Gists / Revisions caps are that row's painted string. A non-zero offset prefixes `…` in `visible_list_row` (then `truncate_end` may still mark a clipped tail). Unselected rows stay at column 0. `RevisionState.cursor` is a `ListCursor` like Pins/Gists (issue #408): vertical/page moves and row clicks reset `hscroll`, and Right clamps to `revisions_hscroll_max` (the selected row's rendered label) instead of growing unbounded.
 
 List-row budget: inner pane width minus borders+padding (`LIST_CHROME_CELLS`) minus `LIST_HIGHLIGHT_SYMBOL`. ratatui's default `HighlightSpacing::WhenSelected` indents **every** row once any row is selected — these lists always `select(...)` when they have rows, so unselected rows still pay the `▶ ` indent. Keep the widget's `highlight_symbol` and the budget on `LIST_HIGHLIGHT_SYMBOL` so they cannot drift.
 

--- a/src/tui/keys.rs
+++ b/src/tui/keys.rs
@@ -36,7 +36,7 @@ fn nav_action(code: KeyCode, modifiers: KeyModifiers) -> Option<NavAction> {
 /// keeps paging predictable without threading terminal size into the key logic.
 pub(crate) const PAGE_SCROLL: u16 = 10;
 
-/// Dispatch [`NavAction`] onto a Pins/Gists [`ListCursor`] (step from [`PAGE_SCROLL`]).
+/// Dispatch [`NavAction`] onto a Pins/Gists/Revisions [`ListCursor`] (step from [`PAGE_SCROLL`]).
 pub(crate) fn apply_list_cursor_nav(
     cursor: &mut ListCursor,
     action: NavAction,
@@ -182,9 +182,13 @@ impl AppState {
     /// Select the clicked list row on the current screen, focusing its pane/list. Returns
     /// `true` when a row was hit (so a double-click should "open" it). A click in a pane's
     /// blank area or border focuses it but selects nothing (returns `false`); a click off
-    /// every list returns `false`.
+    /// every list returns `false`. Resolves the pane/index target once here (issue #408) —
+    /// per-screen handlers consume the resolved `RowTarget`, never raw coordinates.
     fn click_select(&mut self, col: u16, row: u16, layout: &MouseFrame) -> bool {
-        (super::screens::lookup(&self.screen).click_select)(self, col, row, layout)
+        let Some(target) = layout.resolve_pane(col, row) else {
+            return false;
+        };
+        (super::screens::lookup(&self.screen).click_select)(self, target)
     }
 
     /// Open/activate the currently selected row on the current screen (the double-click
@@ -558,11 +562,6 @@ impl AppState {
         let starring = !self.gist_is_starred(&gist_id);
         KeyOutcome::ToggleGistStar { gist_id, starring }
     }
-}
-
-/// Whether a column/row position lands inside a `Rect`.
-pub(crate) fn point_in(rect: ratatui::layout::Rect, col: u16, row: u16) -> bool {
-    col >= rect.x && col < rect.right() && row >= rect.y && row < rect.bottom()
 }
 
 #[cfg(test)]

--- a/src/tui/list_cursor.rs
+++ b/src/tui/list_cursor.rs
@@ -1,11 +1,11 @@
-//! Shared list selection + horizontal scroll for Pins and Gists manager screens.
+//! Shared list selection + horizontal scroll for Pins, Gists manager, and Revisions.
 //!
 //! Bounds (`len`, `hmax`, page `step`) are computed by the caller with `&AppState`
 //! *before* taking `&mut` on the payload, so navigation never fights the borrow
 //! checker (issue #274).
 
 /// Index + horizontal scroll for a single-column list that resets hscroll when the
-/// selection moves vertically (Pins / Gists policy).
+/// selection moves vertically (Pins / Gists / Revisions policy).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct ListCursor {
     pub index: usize,

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -651,11 +651,9 @@ pub struct RevisionState {
     pub gist_id: Option<String>,
     /// Fetched revision rows (`None` while the initial list fetch is in flight).
     pub entries: Option<Vec<GistRevision>>,
-    /// Cursor into `entries` (0 = current head).
-    /// Not a [`ListCursor`]: Revisions does not reset hscroll on vertical move and does
-    /// not clamp Right to an hmax (issue #274 — out of scope).
-    pub index: usize,
-    pub hscroll: u16,
+    /// Selection + row hscroll into `entries` (0 = current head; shared Pins/Gists policy,
+    /// issue #408).
+    pub cursor: ListCursor,
     /// File within the gist that preview/diff/restore target.
     pub target_file: String,
     /// Error from the commits-list fetch, if any.
@@ -1703,8 +1701,7 @@ impl AppState {
         self.enter(Screen::Revisions(Box::new(RevisionState {
             gist_id: Some(gist_id),
             target_file,
-            index: 0,
-            hscroll: 0,
+            cursor: ListCursor::default(),
             entries: None,
             fetch_error: None,
         })));

--- a/src/tui/mouse.rs
+++ b/src/tui/mouse.rs
@@ -54,6 +54,22 @@ pub enum RowTarget {
     Palette(usize),
 }
 
+impl RowTarget {
+    /// The row index for a hit on `PaneTarget::List`, or `None` for any other pane, a blank
+    /// area, or a Palette row. Shared by every single-list-pane screen's `click_select_*`
+    /// (Config, Help, Pins, Gists, Revisions; issue #408) — List and GistDetail have more than
+    /// one named pane and match `Pane { pane, index }` directly instead.
+    pub fn list_index(self) -> Option<usize> {
+        match self {
+            RowTarget::Pane {
+                pane: PaneTarget::List,
+                index,
+            } => index,
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HitTarget {
     PaletteClose,
@@ -111,6 +127,22 @@ impl MouseFrame {
     pub fn split(&self) -> Option<SplitHit> {
         self.hits.iter().rev().find_map(|hit| match hit {
             HitRegion::Rect(HitTarget::Divider(split), _) => Some(*split),
+            _ => None,
+        })
+    }
+
+    /// Resolve the semantic pane/index target at `(col, row)`, considering only
+    /// `register_pane` hits — never `Divider` or other whole-body `Rect` hits, which
+    /// register far wider than their visual grab zone and would otherwise mask every
+    /// row underneath them (issue #408). Panes never overlap, so at most one can match.
+    pub fn resolve_pane(&self, col: u16, row: u16) -> Option<RowTarget> {
+        self.hits.iter().rev().find_map(|hit| match *hit {
+            HitRegion::Pane(pane, hit, len) if point_in(hit.rect, col, row) => {
+                Some(RowTarget::Pane {
+                    pane,
+                    index: hit.index_at(row, len),
+                })
+            }
             _ => None,
         })
     }
@@ -219,6 +251,37 @@ mod tests {
             frame.resolve(2, 2),
             Some(HitTarget::Row(RowTarget::Palette(3)))
         );
+    }
+
+    #[test]
+    fn resolve_pane_ignores_a_wide_divider_rect_covering_the_pane() {
+        let mut frame = MouseFrame::default();
+        // Mirrors the List screen: Divider registers over the whole body, wider than its
+        // visual grab zone, while the pane occupies a narrower column within it.
+        frame.register(
+            HitTarget::Divider(SplitHit {
+                area: Rect::new(0, 0, 40, 10),
+                divider_x: 20,
+            }),
+            Rect::new(0, 0, 40, 10),
+        );
+        frame.register_pane(
+            PaneTarget::Local,
+            PaneHit {
+                rect: Rect::new(0, 0, 20, 10),
+                offset: 0,
+            },
+            3,
+        );
+        assert_eq!(
+            frame.resolve_pane(2, 1),
+            Some(RowTarget::Pane {
+                pane: PaneTarget::Local,
+                index: Some(0),
+            })
+        );
+        // Off every pane, even though it is still inside the Divider's wide rect.
+        assert_eq!(frame.resolve_pane(30, 1), None);
     }
 
     #[test]

--- a/src/tui/palette.rs
+++ b/src/tui/palette.rs
@@ -492,7 +492,7 @@ mod tests {
         state.screen = Screen::Revisions(Box::new(RevisionState {
             gist_id: Some("g1".into()),
             target_file: "a.txt".into(),
-            index: 0,
+            cursor: ListCursor::default(),
             entries: Some(vec![
                 GistRevision {
                     version: "v2".into(),
@@ -538,7 +538,7 @@ mod tests {
         // Off head (index 1): diff/restore become available; "Cycle target file" stays
         // disabled (still a single-file gist).
         if let Screen::Revisions(rev) = &mut state.screen {
-            rev.index = 1;
+            rev.cursor.index = 1;
         }
         let items = menu_items(&state);
         assert_eq!(

--- a/src/tui/render/list_pane.rs
+++ b/src/tui/render/list_pane.rs
@@ -406,8 +406,8 @@ mod tests {
             revision("aaa-FIRSTROW-marker"),
             revision("bbb-SECONDROW-marker"),
         ]);
-        rev.index = 1;
-        rev.hscroll = 8;
+        rev.cursor.index = 1;
+        rev.cursor.hscroll = 8;
 
         let text = render_state_size(&state, 40, 12);
         assert!(

--- a/src/tui/screens/config.rs
+++ b/src/tui/screens/config.rs
@@ -1,11 +1,11 @@
 //! `Screen::Config` (Settings) — key handling, view-model, paint, and palette items
 //! colocated in one file (issue #287, Phase 2).
 
-use crate::tui::keys::{point_in, NavAction};
+use crate::tui::keys::NavAction;
 use crate::tui::view_model::{ChromeVm, ConfigVm};
 use crate::tui::{
     AppState, ConfigField, HelpTopic, HitTarget, KeyOutcome, MouseFrame, PaneHit, PaneTarget,
-    Screen,
+    RowTarget, Screen,
 };
 use crossterm::event::KeyCode;
 use ratatui::{
@@ -101,19 +101,15 @@ impl AppState {
     }
 
     /// Select the clicked field row on `Screen::Config`. Returns `true` when a row was hit.
-    pub(crate) fn click_select_config(&mut self, col: u16, row: u16, layout: &MouseFrame) -> bool {
+    pub(crate) fn click_select_config(&mut self, target: RowTarget) -> bool {
+        let Some(idx) = target.list_index() else {
+            return false;
+        };
         let Screen::Config(cfg) = &mut self.screen else {
             return false;
         };
-        if let Some(hit) = layout.pane(PaneTarget::List) {
-            if point_in(hit.rect, col, row) {
-                if let Some(idx) = hit.index_at(row, ConfigField::ALL.len()) {
-                    cfg.index = idx;
-                    return true;
-                }
-            }
-        }
-        false
+        cfg.index = idx;
+        true
     }
 }
 

--- a/src/tui/screens/detail.rs
+++ b/src/tui/screens/detail.rs
@@ -3,13 +3,14 @@
 
 use crate::domain::GistComment;
 use crate::tui::bg::LoopFlow;
-use crate::tui::keys::{point_in, NavAction};
+use crate::tui::keys::NavAction;
 use crate::tui::text::comment_lines_count;
 use crate::tui::view_model::{
     ChromeVm, CommentLineVm, CommentsAffordance, CommentsPaneVm, GistDetailVm,
 };
 use crate::tui::{
     AppState, DetailFocus, HelpTopic, HitTarget, KeyOutcome, MouseFrame, PaneHit, PaneTarget,
+    RowTarget,
 };
 
 pub(crate) const HELP_TOPIC: HelpTopic = HelpTopic::GistDetail;
@@ -341,26 +342,25 @@ impl AppState {
 
     /// Select the clicked row on `Screen::GistDetail`'s Files tab, focusing it. Returns `true`
     /// when a row was hit (so a double-click should "open"/preview it).
-    pub(crate) fn click_select_detail(&mut self, col: u16, row: u16, layout: &MouseFrame) -> bool {
-        if let Some(hit) = layout.pane(PaneTarget::DetailFiles) {
-            if point_in(hit.rect, col, row) {
-                // Clicking the file list focuses the Files tab; a row also moves the cursor.
-                let count = self
-                    .detail()
-                    .and_then(|d| d.gist_id.as_deref())
-                    .map_or(0, |id| self.gist_filenames(id).len());
-                if let Some(d) = self.detail_mut() {
-                    d.focus = DetailFocus::Files;
-                }
-                if let Some(idx) = hit.index_at(row, count) {
-                    if let Some(d) = self.detail_mut() {
-                        d.file_cursor = idx;
-                    }
-                    return true;
-                }
-            }
+    pub(crate) fn click_select_detail(&mut self, target: RowTarget) -> bool {
+        let RowTarget::Pane {
+            pane: PaneTarget::DetailFiles,
+            index,
+        } = target
+        else {
+            return false;
+        };
+        // Clicking the file list focuses the Files tab; a row also moves the cursor.
+        if let Some(d) = self.detail_mut() {
+            d.focus = DetailFocus::Files;
         }
-        false
+        let Some(idx) = index else {
+            return false;
+        };
+        if let Some(d) = self.detail_mut() {
+            d.file_cursor = idx;
+        }
+        true
     }
 
     /// Switch the GistDetail tab if `col`/`row` lands on a tab header. Returns the outcome
@@ -1435,6 +1435,28 @@ mod tests {
                 ..
             } if f.gist_id == "g1" && f.filename == "b.txt"
         ));
+    }
+
+    /// A click in the file pane's blank area focuses Files without moving the cursor or
+    /// activating anything (issue #408).
+    #[test]
+    fn gist_detail_blank_pane_click_focuses_files_without_activating() {
+        let mut state = state_with_gists(); // g1: a.txt (0), b.txt (1)
+        state.screen = Screen::GistDetail(Box::default());
+        detail_mut(&mut state).gist_id = Some("g1".into());
+        detail_mut(&mut state).focus = DetailFocus::Comments;
+        detail_mut(&mut state).file_cursor = 0;
+        let hit = PaneHit {
+            rect: Rect::new(0, 0, 40, 10),
+            offset: 0,
+        };
+        let mut layout = MouseFrame::default();
+        layout.register_pane(PaneTarget::DetailFiles, hit, 2);
+        // Row 8 is inside the pane but past the two rendered rows.
+        let out = state.handle_mouse(MouseInput::Click { col: 5, row: 8 }, &layout);
+        assert_eq!(out, KeyOutcome::None);
+        assert_eq!(detail_ref(&state).focus, DetailFocus::Files);
+        assert_eq!(detail_ref(&state).file_cursor, 0);
     }
 
     #[test]

--- a/src/tui/screens/gists.rs
+++ b/src/tui/screens/gists.rs
@@ -1,12 +1,14 @@
 //! `Screen::Gists` — key handling, view-model, paint, and palette items colocated in one
 //! file (issue #287, Phase 2).
 
-use crate::tui::keys::{apply_list_cursor_nav, point_in, NavAction};
+use crate::tui::keys::{apply_list_cursor_nav, NavAction};
 use crate::tui::render::list_pane::render_list_pane;
 use crate::tui::view_model::{
     ChromeVm, GistsVm, ListPaneEmpty, ListPaneVm, PaneTitleVm, RowEmphasis, RowVm,
 };
-use crate::tui::{AppState, HelpTopic, HitTarget, KeyOutcome, MouseFrame, PaneTarget, Screen};
+use crate::tui::{
+    AppState, HelpTopic, HitTarget, KeyOutcome, MouseFrame, PaneTarget, RowTarget, Screen,
+};
 use crossterm::event::KeyCode;
 use ratatui::{
     layout::{Constraint, Direction, Layout},
@@ -122,19 +124,15 @@ impl AppState {
 
     /// Select the clicked row on `Screen::Gists`, moving the list cursor. Returns `true` when
     /// a row was hit.
-    pub(crate) fn click_select_gists(&mut self, col: u16, row: u16, layout: &MouseFrame) -> bool {
-        if let Some(hit) = layout.pane(PaneTarget::List) {
-            if point_in(hit.rect, col, row) {
-                let count = self.visible_gist_groups().len();
-                if let Some(idx) = hit.index_at(row, count) {
-                    if let Some(gm) = self.gist_manager_mut() {
-                        gm.cursor.select(idx);
-                        return true;
-                    }
-                }
-            }
-        }
-        false
+    pub(crate) fn click_select_gists(&mut self, target: RowTarget) -> bool {
+        let Some(idx) = target.list_index() else {
+            return false;
+        };
+        let Some(gm) = self.gist_manager_mut() else {
+            return false;
+        };
+        gm.cursor.select(idx);
+        true
     }
 }
 
@@ -593,6 +591,22 @@ mod tests {
         let by_mouse = state.handle_mouse(MouseInput::DoubleClick { col: 5, row: 2 }, &layout);
         assert_eq!(by_mouse, key_out);
         assert!(matches!(by_mouse, KeyOutcome::OpenGistDetail { .. }));
+    }
+
+    /// A click in the pane's blank area does nothing (issue #408).
+    #[test]
+    fn gists_blank_pane_click_is_a_noop() {
+        let mut state = gists_screen_state();
+        gists_mut(&mut state).cursor.index = 0;
+        let hit = PaneHit {
+            rect: Rect::new(0, 0, 40, 10),
+            offset: 0,
+        };
+        let mut layout = MouseFrame::default();
+        layout.register_pane(PaneTarget::List, hit, 2);
+        let out = state.handle_mouse(MouseInput::Click { col: 5, row: 8 }, &layout);
+        assert_eq!(out, KeyOutcome::None);
+        assert_eq!(gists_ref(&state).cursor.index, 0);
     }
 
     #[test]

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -1,10 +1,11 @@
 //! `Screen::Help` — key handling, view-model, paint, and palette items colocated in one
 //! file (issue #287, Phase 2).
 
-use crate::tui::keys::{point_in, NavAction, PAGE_SCROLL};
+use crate::tui::keys::{NavAction, PAGE_SCROLL};
 use crate::tui::view_model::{ChromeVm, HelpIndexItemVm, HelpModeVm, HelpVm};
 use crate::tui::{
-    AppState, HelpState, HelpTopic, HitTarget, KeyOutcome, MouseFrame, PaneHit, PaneTarget, Screen,
+    AppState, HelpState, HelpTopic, HitTarget, KeyOutcome, MouseFrame, PaneHit, PaneTarget,
+    RowTarget, Screen,
 };
 use crossterm::event::KeyCode;
 use ratatui::{
@@ -146,19 +147,15 @@ impl AppState {
     /// Select the clicked topic-index row on `Screen::Help`. Only set when the topic index is
     /// open (render_help), so this is a no-op while viewing a topic's body. Returns `true`
     /// when a row was hit.
-    pub(crate) fn click_select_help(&mut self, col: u16, row: u16, layout: &MouseFrame) -> bool {
+    pub(crate) fn click_select_help(&mut self, target: RowTarget) -> bool {
+        let Some(idx) = target.list_index() else {
+            return false;
+        };
         let Screen::Help(help) = &mut self.screen else {
             return false;
         };
-        if let Some(hit) = layout.pane(PaneTarget::List) {
-            if point_in(hit.rect, col, row) {
-                if let Some(idx) = hit.index_at(row, HelpTopic::all().len()) {
-                    help.index_sel = idx;
-                    return true;
-                }
-            }
-        }
-        false
+        help.index_sel = idx;
+        true
     }
 }
 

--- a/src/tui/screens/list.rs
+++ b/src/tui/screens/list.rs
@@ -2,14 +2,14 @@
 //! file (issue #287, Phase 2).
 
 use crate::ranking::MatchMark;
-use crate::tui::keys::{apply_filter_edit, diff_pair_previewable, point_in, FilterKey, NavAction};
+use crate::tui::keys::{apply_filter_edit, diff_pair_previewable, FilterKey, NavAction};
 use crate::tui::render::list_pane::{highlight_pane_divider, render_list_pane, MIN_PANE_CELLS};
 use crate::tui::view_model::{
     ChromeVm, ListFooterVm, ListPaneEmpty, ListPaneVm, ListVm, PaneTitleVm, RowEmphasis, RowVm,
 };
 use crate::tui::{
     AppState, FocusPane, GistView, HelpTopic, HitTarget, KeyOutcome, MouseFrame, PaneTarget,
-    PendingAction, Screen, SplitHit,
+    PendingAction, RowTarget, Screen, SplitHit,
 };
 use crossterm::event::KeyCode;
 
@@ -550,38 +550,39 @@ impl AppState {
     /// Select the clicked row on `Screen::List`, focusing its pane. Returns `true` when a row
     /// was hit (so a double-click should "open" it). A click in a pane's blank area or border
     /// focuses it but selects nothing (returns `false`); a click off every list returns `false`.
-    pub(crate) fn click_select_list(&mut self, col: u16, row: u16, layout: &MouseFrame) -> bool {
-        if let Some(hit) = layout.pane(PaneTarget::Local) {
-            if point_in(hit.rect, col, row) {
-                // A click anywhere in the pane (incl. blank/border) focuses it; a
-                // click on a row also selects it.
+    pub(crate) fn click_select_list(&mut self, target: RowTarget) -> bool {
+        let RowTarget::Pane { pane, index } = target else {
+            return false;
+        };
+        // A click anywhere in a pane (incl. blank/border) focuses it; a click on a row
+        // also selects it.
+        match pane {
+            PaneTarget::Local => {
                 self.focus = FocusPane::Local;
-                if let Some(idx) = hit.index_at(row, self.visible_locals().len()) {
-                    self.local_index = idx;
-                    self.local_hscroll = 0;
-                    if self.anchor == FocusPane::Local {
-                        self.reset_ranked_pane();
-                    }
-                    return true;
+                let Some(idx) = index else {
+                    return false;
+                };
+                self.local_index = idx;
+                self.local_hscroll = 0;
+                if self.anchor == FocusPane::Local {
+                    self.reset_ranked_pane();
                 }
-                return false;
+                true
             }
-        }
-        if let Some(hit) = layout.pane(PaneTarget::Gist) {
-            if point_in(hit.rect, col, row) {
+            PaneTarget::Gist => {
                 self.focus = FocusPane::Gist;
-                if let Some(idx) = hit.index_at(row, self.ranked_gists().len()) {
-                    self.gist_index = idx;
-                    self.gist_hscroll = 0;
-                    if self.anchor == FocusPane::Gist {
-                        self.reset_ranked_pane();
-                    }
-                    return true;
+                let Some(idx) = index else {
+                    return false;
+                };
+                self.gist_index = idx;
+                self.gist_hscroll = 0;
+                if self.anchor == FocusPane::Gist {
+                    self.reset_ranked_pane();
                 }
-                return false;
+                true
             }
+            PaneTarget::List | PaneTarget::DetailFiles => false,
         }
-        false
     }
 }
 

--- a/src/tui/screens/mod.rs
+++ b/src/tui/screens/mod.rs
@@ -10,7 +10,7 @@
 
 use super::keys::NavAction;
 use super::view_model::ScreenVm;
-use super::{AppState, HelpTopic, KeyOutcome, MouseFrame, Screen};
+use super::{AppState, HelpTopic, KeyOutcome, RowTarget, Screen};
 use crossterm::event::{KeyCode, KeyModifiers};
 
 pub(crate) mod config;
@@ -35,14 +35,14 @@ pub(crate) struct ScreenLookup {
     pub build_vm: fn(&AppState) -> ScreenVm,
     pub handle_key: fn(&mut AppState, KeyCode, KeyModifiers) -> KeyOutcome,
     pub apply_navigation: fn(&mut AppState, NavAction) -> bool,
-    pub click_select: fn(&mut AppState, u16, u16, &MouseFrame) -> bool,
+    pub click_select: fn(&mut AppState, RowTarget) -> bool,
 }
 
 fn ungated(_: &AppState, _: KeyCode) -> bool {
     true
 }
 
-fn no_click(_: &mut AppState, _: u16, _: u16, _: &MouseFrame) -> bool {
+fn no_click(_: &mut AppState, _: RowTarget) -> bool {
     false
 }
 fn scroll_navigation(state: &mut AppState, action: NavAction) -> bool {

--- a/src/tui/screens/pins.rs
+++ b/src/tui/screens/pins.rs
@@ -1,12 +1,14 @@
 //! `Screen::Pins` — key handling, view-model, paint, and palette items colocated in one
 //! file (issue #287, Phase 2).
 
-use crate::tui::keys::{apply_list_cursor_nav, point_in, NavAction};
+use crate::tui::keys::{apply_list_cursor_nav, NavAction};
 use crate::tui::render::list_pane::render_list_pane;
 use crate::tui::view_model::{
     ChromeVm, ListPaneEmpty, ListPaneVm, PaneTitleVm, PinsVm, RowEmphasis, RowVm,
 };
-use crate::tui::{AppState, HelpTopic, HitTarget, KeyOutcome, MouseFrame, PaneTarget, Screen};
+use crate::tui::{
+    AppState, HelpTopic, HitTarget, KeyOutcome, MouseFrame, PaneTarget, RowTarget, Screen,
+};
 use crossterm::event::KeyCode;
 use ratatui::{
     layout::{Constraint, Direction, Layout},
@@ -143,19 +145,15 @@ impl AppState {
 
     /// Select the clicked row on `Screen::Pins`, moving the list cursor. Returns `true` when
     /// a row was hit.
-    pub(crate) fn click_select_pins(&mut self, col: u16, row: u16, layout: &MouseFrame) -> bool {
-        if let Some(hit) = layout.pane(PaneTarget::List) {
-            if point_in(hit.rect, col, row) {
-                let count = self.visible_pin_indices().len();
-                if let Some(idx) = hit.index_at(row, count) {
-                    if let Some(pins) = self.pins_mut() {
-                        pins.cursor.select(idx);
-                        return true;
-                    }
-                }
-            }
-        }
-        false
+    pub(crate) fn click_select_pins(&mut self, target: RowTarget) -> bool {
+        let Some(idx) = target.list_index() else {
+            return false;
+        };
+        let Some(pins) = self.pins_mut() else {
+            return false;
+        };
+        pins.cursor.select(idx);
+        true
     }
 }
 
@@ -650,6 +648,24 @@ mod tests {
         let key_out = by_key.handle_key(KeyCode::Enter);
         let by_mouse = state.handle_mouse(MouseInput::DoubleClick { col: 5, row: 2 }, &layout);
         assert_eq!(by_mouse, key_out);
+    }
+
+    /// A click in the pane's blank area (below the rows) does nothing — Pins has no focus
+    /// concept to switch, unlike the dual-pane List screen (issue #408).
+    #[test]
+    fn pins_blank_pane_click_is_a_noop() {
+        let mut state = state_with_pins(&[("a.txt", "g1", "a.txt")]);
+        pins_mut(&mut state).cursor.select(0);
+        let hit = PaneHit {
+            rect: Rect::new(0, 0, 40, 10),
+            offset: 0,
+        };
+        let mut layout = MouseFrame::default();
+        layout.register_pane(PaneTarget::List, hit, 1);
+        // Row 5 is inside the pane rect but past the single rendered row.
+        let out = state.handle_mouse(MouseInput::Click { col: 5, row: 5 }, &layout);
+        assert_eq!(out, KeyOutcome::None);
+        assert_eq!(pins_ref(&state).cursor.index, 0);
     }
 
     #[test]

--- a/src/tui/screens/revisions.rs
+++ b/src/tui/screens/revisions.rs
@@ -3,12 +3,16 @@
 
 use crate::actions::SystemRunner;
 use crate::tui::bg::{revision_version_label, Jobs, LoopFlow};
-use crate::tui::keys::{point_in, NavAction, PAGE_SCROLL};
+use crate::tui::keys::{apply_list_cursor_nav, NavAction};
 use crate::tui::render::list_pane::render_list_pane;
+use crate::tui::text::hscroll_max_for_text;
 use crate::tui::view_model::{
     ChromeVm, ListPaneEmpty, ListPaneVm, PaneTitleVm, RevisionsVm, RowEmphasis, RowVm,
 };
-use crate::tui::{AppState, HelpTopic, HitTarget, KeyOutcome, MouseFrame, PaneTarget, Screen};
+use crate::tui::{
+    AppState, HelpTopic, HitTarget, KeyOutcome, ListCursor, MouseFrame, PaneTarget, RowTarget,
+    Screen,
+};
 use crossterm::event::KeyCode;
 use ratatui::{
     layout::{Constraint, Direction, Layout},
@@ -34,7 +38,7 @@ pub(crate) fn revisions_guard(state: &AppState, code: KeyCode) -> bool {
         .and_then(|r| r.entries.as_ref().map(|e| e.len()))
         .unwrap_or(0);
     let has_entries = entries_len > 0;
-    let not_head = rev.is_some_and(|r| r.index > 0);
+    let not_head = rev.is_some_and(|r| r.cursor.index > 0);
     let gist_id = rev.and_then(|r| r.gist_id.clone());
     let owned = gist_id
         .as_deref()
@@ -81,7 +85,7 @@ impl AppState {
             // check, so a non-previewable file off-head still gets this precise message
             // instead of falling to the (misleading, head-only) fallback below it.
             KeyCode::Char('D')
-                if entries_len > 0 && self.revision().is_some_and(|r| r.index > 0) =>
+                if entries_len > 0 && self.revision().is_some_and(|r| r.cursor.index > 0) =>
             {
                 return self.revision_diff_intent();
             }
@@ -94,7 +98,7 @@ impl AppState {
             KeyCode::Char('r') if entries_len <= 1 => {
                 self.set_status("only one revision — nothing to restore");
             }
-            KeyCode::Char('r') if self.revision().is_some_and(|r| r.index == 0) => {
+            KeyCode::Char('r') if self.revision().is_some_and(|r| r.cursor.index == 0) => {
                 self.set_status("already at current revision");
             }
             KeyCode::Char('F') if !self.cycle_revision_target_file() => {
@@ -130,7 +134,7 @@ impl AppState {
     fn selected_revision(&self) -> Option<&crate::domain::GistRevision> {
         let rev = self.revision()?;
         let entries = rev.entries.as_ref()?;
-        entries.get(rev.index)
+        entries.get(rev.cursor.index)
     }
 
     fn revision_diff_incremental_intent(&mut self) -> KeyOutcome {
@@ -141,7 +145,7 @@ impl AppState {
             return KeyOutcome::None;
         };
         let filename = rev.target_file.clone();
-        let index = rev.index;
+        let index = rev.cursor.index;
         let parent = rev
             .entries
             .as_ref()
@@ -257,60 +261,53 @@ impl AppState {
     }
 
     /// Arrow / hjkl / page-key navigation for `Screen::Revisions`: moves the entry cursor, or
-    /// scrolls it horizontally.
+    /// scrolls it horizontally. Precomputes len/hmax with `&self`, then mutates the cursor
+    /// (issue #274 pattern, applied here in #408: cannot hold `&mut RevisionState` from
+    /// `match &mut self.screen` while calling `&self` helpers).
     pub(crate) fn apply_navigation_revisions(&mut self, action: NavAction) -> bool {
+        let len = self
+            .revision()
+            .and_then(|r| r.entries.as_ref().map(|e| e.len()))
+            .unwrap_or(0);
+        if len == 0 {
+            return false;
+        }
+        let hmax = self.revisions_hscroll_max();
         let Screen::Revisions(rev) = &mut self.screen else {
             return false;
         };
-        let entries_len = rev.entries.as_ref().map(|e| e.len()).unwrap_or(0);
-        if entries_len == 0 {
-            return false;
-        }
-        match action {
-            NavAction::Down => {
-                rev.index = (rev.index + 1).min(entries_len - 1);
-            }
-            NavAction::Up => {
-                rev.index = rev.index.saturating_sub(1);
-            }
-            NavAction::PageDown => {
-                rev.index = (rev.index + PAGE_SCROLL as usize).min(entries_len - 1);
-            }
-            NavAction::PageUp => {
-                rev.index = rev.index.saturating_sub(PAGE_SCROLL as usize);
-            }
-            NavAction::Left => {
-                rev.hscroll = rev.hscroll.saturating_sub(1);
-            }
-            NavAction::Right => {
-                rev.hscroll = rev.hscroll.saturating_add(1);
-            }
-        }
+        apply_list_cursor_nav(&mut rev.cursor, action, len, hmax);
         true
     }
 
     /// Select the clicked row on `Screen::Revisions`, moving the entry cursor. Returns `true`
     /// when a row was hit.
-    pub(crate) fn click_select_revisions(
-        &mut self,
-        col: u16,
-        row: u16,
-        layout: &MouseFrame,
-    ) -> bool {
+    pub(crate) fn click_select_revisions(&mut self, target: RowTarget) -> bool {
+        let Some(idx) = target.list_index() else {
+            return false;
+        };
         let Screen::Revisions(rev) = &mut self.screen else {
             return false;
         };
-        if let Some(hit) = layout.pane(PaneTarget::List) {
-            if point_in(hit.rect, col, row) {
-                let count = rev.entries.as_ref().map_or(0, |e| e.len());
-                if let Some(idx) = hit.index_at(row, count) {
-                    rev.index = idx;
-                    rev.hscroll = 0;
-                    return true;
-                }
-            }
-        }
-        false
+        rev.cursor.select(idx);
+        true
+    }
+
+    /// Highest horizontal-scroll offset for the Revisions screen, bounded by the selected
+    /// row's complete rendered label (mirrors `gists_hscroll_max` / `pins_hscroll_max`;
+    /// issue #408 — Revisions previously had no bound and could overflow `u16`).
+    fn revisions_hscroll_max(&self) -> u16 {
+        let now = crate::tui::render::unix_now();
+        self.revision()
+            .and_then(|r| {
+                let entries = r.entries.as_ref()?;
+                let idx = r.cursor.index;
+                entries
+                    .get(idx)
+                    .map(|entry| revision_row_label(entry, idx, now))
+            })
+            .map(|label| hscroll_max_for_text(&label))
+            .unwrap_or(0)
     }
 }
 
@@ -385,7 +382,7 @@ pub(crate) fn build_revisions_vm(state: &AppState) -> RevisionsVm {
                     emphasis: RowEmphasis::None,
                 })
                 .collect();
-            (ListPaneEmpty::HasRows, None, rows, Some(rev.index))
+            (ListPaneEmpty::HasRows, None, rows, Some(rev.cursor.index))
         }
     };
 
@@ -401,7 +398,7 @@ pub(crate) fn build_revisions_vm(state: &AppState) -> RevisionsVm {
             empty,
             empty_message,
             rows,
-            hscroll: rev.hscroll,
+            hscroll: rev.cursor.hscroll,
             scrollbar: false,
         },
         footer,
@@ -470,6 +467,11 @@ pub(crate) fn on_revisions_fetched(
             let short = entries.len() <= 1;
             if let Some(rev) = state.revision_mut() {
                 rev.fetch_error = None;
+                let before = rev.cursor.index;
+                rev.cursor.clamp_len(entries.len());
+                if rev.cursor.index != before {
+                    rev.cursor.hscroll = 0;
+                }
                 rev.entries = Some(entries);
             }
             if short {
@@ -530,7 +532,7 @@ pub(crate) fn on_restore_revision_done(
                 state.screen = Screen::Revisions(Box::default());
             }
             let gist_id = state.revision_mut().and_then(|rev| {
-                rev.index = 0;
+                rev.cursor = ListCursor::default();
                 rev.entries = None;
                 rev.fetch_error = None;
                 rev.gist_id.clone()
@@ -592,7 +594,7 @@ mod tests {
         state.screen = Screen::Revisions(Box::default());
         revision_mut(&mut state).gist_id = Some("g1".into());
         revision_mut(&mut state).target_file = "a.txt".into();
-        revision_mut(&mut state).index = 0;
+        revision_mut(&mut state).cursor.index = 0;
         revision_mut(&mut state).entries = Some(vec![
             crate::domain::GistRevision {
                 version: "v2".into(),
@@ -617,7 +619,7 @@ mod tests {
         ]);
         assert_eq!(state.handle_key(KeyCode::Char('D')), KeyOutcome::None);
         assert_eq!(state.status.as_deref(), Some("already at current revision"));
-        revision_mut(&mut state).index = 1;
+        revision_mut(&mut state).cursor.index = 1;
         assert!(matches!(
             state.handle_key(KeyCode::Char('D')),
             KeyOutcome::RevisionDiff { .. }
@@ -630,7 +632,7 @@ mod tests {
         state.screen = Screen::Revisions(Box::default());
         revision_mut(&mut state).gist_id = Some("g1".into());
         revision_mut(&mut state).target_file = "a.txt".into();
-        revision_mut(&mut state).index = 0;
+        revision_mut(&mut state).cursor.index = 0;
         revision_mut(&mut state).entries = Some(vec![
             crate::domain::GistRevision {
                 version: "v2".into(),
@@ -657,7 +659,7 @@ mod tests {
             state.handle_key(KeyCode::Enter),
             KeyOutcome::RevisionDiffIncremental { .. }
         ));
-        revision_mut(&mut state).index = 1;
+        revision_mut(&mut state).cursor.index = 1;
         assert!(matches!(
             state.handle_key(KeyCode::Enter),
             KeyOutcome::RevisionDiffIncremental { .. }
@@ -713,7 +715,7 @@ mod tests {
         state.screen = Screen::Revisions(Box::default());
         revision_mut(&mut state).gist_id = Some("g1".into());
         revision_mut(&mut state).target_file = "a.txt".into();
-        revision_mut(&mut state).index = 0;
+        revision_mut(&mut state).cursor.index = 0;
         revision_mut(&mut state).entries = Some(vec![
             crate::domain::GistRevision {
                 version: "v2".into(),
@@ -744,7 +746,7 @@ mod tests {
         layout.register_pane(PaneTarget::List, hit, 2);
         let out = state.handle_mouse(MouseInput::Click { col: 5, row: 2 }, &layout);
         assert_eq!(out, KeyOutcome::None);
-        assert_eq!(revision_ref(&state).index, 1);
+        assert_eq!(revision_ref(&state).cursor.index, 1);
         let mut by_key = state.clone();
         let key_out = by_key.handle_key(KeyCode::Enter);
         let by_mouse = state.handle_mouse(MouseInput::DoubleClick { col: 5, row: 2 }, &layout);
@@ -753,6 +755,169 @@ mod tests {
             by_mouse,
             KeyOutcome::RevisionDiffIncremental { .. }
         ));
+    }
+
+    /// A click in the pane's blank area does nothing (issue #408).
+    #[test]
+    fn revisions_blank_pane_click_is_a_noop() {
+        let mut state = state_with_gists();
+        state.screen = Screen::Revisions(Box::default());
+        revision_mut(&mut state).entries = Some(vec![crate::domain::GistRevision {
+            version: "v1".into(),
+            committed_at: "2026-06-10T00:00:00Z".into(),
+            user: "u".into(),
+            change_status: crate::domain::GistRevisionChangeStatus {
+                total: 1,
+                additions: 1,
+                deletions: 0,
+            },
+        }]);
+        let hit = PaneHit {
+            rect: Rect::new(0, 0, 40, 10),
+            offset: 0,
+        };
+        let mut layout = MouseFrame::default();
+        layout.register_pane(PaneTarget::List, hit, 1);
+        let out = state.handle_mouse(MouseInput::Click { col: 5, row: 8 }, &layout);
+        assert_eq!(out, KeyOutcome::None);
+        assert_eq!(revision_ref(&state).cursor.index, 0);
+    }
+
+    /// Vertical/page navigation and row clicks reset horizontal scroll; Right stops at the
+    /// selected row's complete rendered label and cannot overflow (issue #408 — previously
+    /// unbounded, so a selected row could scroll entirely blank and `hscroll` could wrap).
+    #[test]
+    fn revisions_navigation_resets_hscroll_and_right_is_clamped() {
+        let mut state = state_with_gists();
+        state.screen = Screen::Revisions(Box::default());
+        let entries = vec![
+            crate::domain::GistRevision {
+                version: "v2".into(),
+                committed_at: "2026-06-10T00:00:00Z".into(),
+                user: "u".into(),
+                change_status: crate::domain::GistRevisionChangeStatus {
+                    total: 1,
+                    additions: 1,
+                    deletions: 0,
+                },
+            },
+            crate::domain::GistRevision {
+                version: "v1".into(),
+                committed_at: "2026-06-01T00:00:00Z".into(),
+                user: "u".into(),
+                change_status: crate::domain::GistRevisionChangeStatus {
+                    total: 2,
+                    additions: 2,
+                    deletions: 0,
+                },
+            },
+        ];
+        revision_mut(&mut state).entries = Some(entries.clone());
+        let label = revision_row_label(&entries[0], 0, crate::tui::render::unix_now());
+        let hmax = hscroll_max_for_text(&label);
+
+        // Right stops at the row's own max — many more presses than the label is long.
+        for _ in 0..hmax + 50 {
+            state.handle_key(KeyCode::Right);
+        }
+        assert_eq!(revision_ref(&state).cursor.hscroll, hmax);
+
+        // Down resets it.
+        state.handle_key(KeyCode::Down);
+        assert_eq!(revision_ref(&state).cursor.index, 1);
+        assert_eq!(revision_ref(&state).cursor.hscroll, 0);
+
+        state.handle_key(KeyCode::Right);
+        assert!(revision_ref(&state).cursor.hscroll > 0);
+        state.handle_key(KeyCode::Up);
+        assert_eq!(revision_ref(&state).cursor.hscroll, 0);
+
+        state.handle_key(KeyCode::Right);
+        state.handle_key(KeyCode::PageDown);
+        assert_eq!(revision_ref(&state).cursor.hscroll, 0);
+
+        state.handle_key(KeyCode::Right);
+        state.handle_key(KeyCode::PageUp);
+        assert_eq!(revision_ref(&state).cursor.hscroll, 0);
+
+        // A row click resets it too.
+        revision_mut(&mut state).cursor.hscroll = 5;
+        let hit = PaneHit {
+            rect: Rect::new(0, 0, 40, 10),
+            offset: 0,
+        };
+        let mut layout = MouseFrame::default();
+        layout.register_pane(PaneTarget::List, hit, 2);
+        state.handle_mouse(MouseInput::Click { col: 5, row: 1 }, &layout);
+        assert_eq!(revision_ref(&state).cursor.hscroll, 0);
+    }
+
+    /// A shrinking revision list clamps an out-of-range cursor and clears its stale
+    /// horizontal scroll; a cursor that stays in range keeps its horizontal scroll
+    /// (issue #408).
+    #[test]
+    fn on_revisions_fetched_clamps_an_out_of_range_cursor() {
+        let mut state = initial_state();
+        state.screen = Screen::Revisions(Box::new(RevisionState {
+            gist_id: Some("g1".into()),
+            cursor: ListCursor {
+                index: 3,
+                hscroll: 7,
+            },
+            ..Default::default()
+        }));
+        let entry = GistRevision {
+            version: "abc123".into(),
+            committed_at: "2026-01-01T00:00:00Z".into(),
+            user: "alice".into(),
+            change_status: crate::domain::GistRevisionChangeStatus {
+                total: 1,
+                additions: 1,
+                deletions: 0,
+            },
+        };
+
+        on_revisions_fetched(&mut state, "g1".into(), Ok(vec![entry.clone(), entry]));
+
+        assert_eq!(revision_ref(&state).cursor.index, 1, "clamped into range");
+        assert_eq!(
+            revision_ref(&state).cursor.hscroll,
+            0,
+            "stale hscroll cleared"
+        );
+    }
+
+    /// An in-range cursor is left untouched by a fetch (issue #408).
+    #[test]
+    fn on_revisions_fetched_preserves_an_in_range_cursor() {
+        let mut state = initial_state();
+        state.screen = Screen::Revisions(Box::new(RevisionState {
+            gist_id: Some("g1".into()),
+            cursor: ListCursor {
+                index: 1,
+                hscroll: 4,
+            },
+            ..Default::default()
+        }));
+        let entry = GistRevision {
+            version: "abc123".into(),
+            committed_at: "2026-01-01T00:00:00Z".into(),
+            user: "alice".into(),
+            change_status: crate::domain::GistRevisionChangeStatus {
+                total: 1,
+                additions: 1,
+                deletions: 0,
+            },
+        };
+
+        on_revisions_fetched(
+            &mut state,
+            "g1".into(),
+            Ok(vec![entry.clone(), entry.clone(), entry]),
+        );
+
+        assert_eq!(revision_ref(&state).cursor.index, 1);
+        assert_eq!(revision_ref(&state).cursor.hscroll, 4);
     }
 
     #[test]
@@ -853,7 +1018,10 @@ mod tests {
         let mut state = initial_state();
         state.screen = Screen::Revisions(Box::new(RevisionState {
             gist_id: Some("g1".into()),
-            index: 3,
+            cursor: ListCursor {
+                index: 3,
+                ..Default::default()
+            },
             entries: Some(Vec::new()),
             fetch_error: Some("old".into()),
             ..Default::default()
@@ -877,7 +1045,7 @@ mod tests {
         assert_eq!(state.revisions_stale.as_deref(), Some("g1"));
         assert!(state.screen.is_revisions());
         let rev = state.revision().unwrap();
-        assert_eq!(rev.index, 0);
+        assert_eq!(rev.cursor.index, 0);
         assert!(rev.entries.is_none());
         assert!(rev.fetch_error.is_none());
         assert_eq!(

--- a/src/tui/view_model.rs
+++ b/src/tui/view_model.rs
@@ -1051,7 +1051,7 @@ mod tests {
                     deletions: 0,
                 },
             }]);
-            r.index = 0;
+            r.cursor.index = 0;
         }
         match build_view_model(&state).screen {
             ScreenVm::Revisions(r) => {


### PR DESCRIPTION
## Summary
- Screen selection (`ScreenLookup::click_select`) now consumes a resolved `MouseFrame::resolve_pane` → `RowTarget::Pane { pane, index }`, never raw `(col, row, &MouseFrame)`. List/Pins/Gists/Revisions/GistDetail (plus Help/Config, mechanically) route through it; List keeps its Local/Gist focus + anchor re-ranking policy, GistDetail keeps its blank-pane-focuses-Files behavior.
- `RevisionState` now carries a `ListCursor` (the shared Pins/Gists selection+hscroll policy) instead of ad-hoc `index`/`hscroll` fields: vertical/page navigation and row clicks reset horizontal scroll, `Right` clamps to the selected row's rendered label instead of growing unbounded, and a revision fetch clamps an out-of-range cursor after the list shrinks (clearing hscroll only when the clamp actually moves the selection).
- Fixes a latent trap in `MouseFrame::resolve`: the List screen's `Divider` hit registers over the *entire* body (used only by `MouseFrame::split`, which ignores point containment), which would have silently masked every pane row underneath it had `resolve` been reused for row selection. `resolve_pane` walks only `register_pane` hits instead.

Closes #408.

## Test plan
- [x] `mise run check` (fmt, clippy `-D warnings`, full test suite, `cargo check`) — 766 tests passing, +7 new for this change.
- [x] New/adapted tests cover: blank-pane no-ops on Pins/Gists/Revisions, GistDetail blank-pane focus-without-activate, Revisions hscroll reset on Up/Down/PageUp/PageDown/click, Revisions Right clamp, revision-fetch cursor clamp (both shrink and in-range preserve cases), and a `resolve_pane` unit test proving the wide `Divider` rect no longer masks pane rows.
- [x] Two-axis code review (Standards + Spec sub-agents) run against the diff; both came back clean — the two judgement-call smells raised (duplicated `RowTarget` match + stale `ListCursor` doc comments) were fixed by adding `RowTarget::list_index()` and updating the docs.