### PR TITLE
Release 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] — 2026-08-29
+
 - The interface drops its emoji (GitHub's release-note categories keep theirs). Gist rows now read `3 files`, `1 comment`, and a trailing
   age instead of picture glyphs, so their columns no longer drift out of alignment; the
   anchor pane is marked `⚑`, a pinned pair `↔`, and empty lists and the update notice say
@@ -18,10 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on their own lines, then the keys that resolve it, each labelled with the verb it performs
   (`y  delete`, `y  upload`) instead of a bare `(y/n)`. Destructive confirms lead with
   `n  cancel` and say what cannot be undone.
-- The README is rebuilt around installing and completing one gist operation; the mouse and
-  configuration reference now live in `?` Help and `config.example.toml` rather than being
-  duplicated on the front page. The project page is rebuilt the same way, around the demo and
-  the actual keymap.
+- The README is rebuilt around installing and completing one gist operation, and is now a
+  tagline, one paragraph on why the tool exists, the demo, one install path, one quick start
+  and a list of links. The keymap, the mouse table and the configuration reference live in
+  `?` Help, the project page and `config.example.toml` rather than being duplicated on the
+  front page; `NO_COLOR` and what the update check does and does not send moved to
+  `docs/SAFETY.md`.
+- The project page is rebuilt around the demo, then why the tool exists, then the keys. Its
+  two screenshots were unreadable — two full-width terminal stills squeezed side by side into
+  the text column and cropped past their own footer — and are now one frame switched by the
+  key that opens each screen in the app, wide enough to read and pannable on a phone.
 - Deleting a Gist no longer leaves its files available through the preview cache, and a failed
   preview refresh keeps the last usable cached content for the next preview.
 - Settings now reliably remember the "Show full diff" choice alongside the other preferences.
@@ -243,7 +251,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Off-thread loading with an on-disk cache.
 - Overwrite-confirm safety gate.
 
-[unreleased]: https://github.com/akunzai/gistui/compare/v0.18.0...HEAD
+[unreleased]: https://github.com/akunzai/gistui/compare/v0.19.0...HEAD
+[0.19.0]: https://github.com/akunzai/gistui/releases/tag/v0.19.0
 [0.18.0]: https://github.com/akunzai/gistui/releases/tag/v0.18.0
 [0.17.1]: https://github.com/akunzai/gistui/releases/tag/v0.17.1
 [0.17.0]: https://github.com/akunzai/gistui/releases/tag/v0.17.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "gistui"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gistui"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 license = "MIT"
 description = "A terminal UI for managing GitHub Gists"
@@ -16,6 +16,7 @@ exclude = [
     "/.github",
     "/docs",
     "/scripts",
+    "/website",
     "/install.sh",
     "/install.ps1",
     "/AGENTS.md",


### PR DESCRIPTION
Cuts 0.19.0 per [RELEASING.md](RELEASING.md) steps 1–2, and fixes a packaging gap found
while validating the tarball.

## Release

- `Cargo.toml` / `Cargo.lock` — `version` 0.18.0 → 0.19.0
- `CHANGELOG.md` — `[Unreleased]` dated as `## [0.19.0] — 2026-08-29` (12 entries), a fresh
  empty `[Unreleased]` left above it, `[0.19.0]` link reference added and `[unreleased]`
  repointed at `compare/v0.19.0...HEAD`

The README and project-page entry was written before the Screens rework landed, so it is
split in two and restated in the shape that actually shipped.

## Packaging fix

`exclude` never named `/website`, even though its own comment already claimed site assets
were kept out of the tarball. Every publish since carried `demo.gif` and the two stills; the
README references its demo by absolute URL, so crates.io renders it either way.

| | files | packaged |
|---|---|---|
| before | 80 | 3.2 MiB |
| after | 76 | 1.3 MiB (296.7 KiB compressed) |

The same gap existed in [duodiff](https://github.com/akunzai/duodiff/pull/281), fixed there
in a separate PR.

## Verification

- `mise run check` — 781 + 12 tests pass, fmt/clippy/check clean
- `cargo publish --dry-run` — clean at 0.19.0; `cargo package --list` has no `website/` entry

## After merge

`git tag v0.19.0 && git push origin v0.19.0`, then verify the release binaries, crates.io,
and the `chore: bump gistui to v0.19.0` commit on the tap and bucket.