### PR TITLE
refactor(tui): narrow dispatch_outcome to AppState and Jobs

### DIFF
--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -58,11 +58,16 @@ Fields stay `pub`. No `#[serde(default)]` on the struct.
 ## Key path (pure intent → impure dispatch)
 
 ```
-handle_key (pure) → KeyOutcome → run_loop / dispatch_outcome (IO)
+handle_key (pure) → KeyOutcome → run_loop / dispatch_outcome (IO) → route_outcome
 ```
 
+**On the `KeyOutcome` path, only `dispatch_outcome` touches the `Terminal`** (issue #421) —
+`run_loop` still owns it for setup and `draw`. `dispatch_outcome` holds the arms that need one
+(`EditUpload`, `EditLocal`, `PersistSettings`'s mouse-capture effect) and delegates every other
+outcome to `route_outcome`, which takes `&mut AppState` and `&mut Jobs` and nothing else.
+
 Before a fetch/action is spawned, its owning screen's `stage_*` function performs any
-branching state work and returns the values dispatch needs. `dispatch_outcome` then only
+branching state work and returns the values dispatch needs. `route_outcome` then only
 routes that payload to `Jobs`; it does not restage labels, return paths, caches, or loading flags.
 
 - New key logic → `AppState::handle_key` (testable).
@@ -97,7 +102,7 @@ Help topics and `README.md` stay hand-written — the List topic is fifty lines 
 - Call sites start work via `Jobs` methods (`spawn_action`, `request_local_scan`, …) or `screens::revisions::request_revisions` — do not own ad-hoc channel fields on `AppState`.
 - `run_loop` only **polls** `jobs.absorb`.
 - **Action jobs carry their apply** (issue #375, ADR-0002's async-response half): `spawn_action(run, apply)` runs `run` off-thread and boxes `apply(value)` for the event-loop tick. There is no `BgTaskOutcome` enum. `ActionApply` is `FnOnce(&mut AppState) -> LoopFlow`. `on_action_outcome` is a generation-guard shell that calls the closure. `KeyOutcome` / `dispatch_outcome` stay plain data (ADR-0002).
-- **`on_*` is the apply seam** (#298, #375, #383): named handlers are the apply bodies and the unit-test surface. They do not live on `Jobs`. `dispatch_outcome` needs a `Terminal`, so it is not one. A new action is a spawn site plus an `on_*` when the apply is worth testing.
+- **`on_*` is the apply seam** (#298, #375, #383): named handlers are the apply bodies and the unit-test surface. They do not live on `Jobs`. `dispatch_outcome` / `route_outcome` sit on the spawn side, not the apply side, so neither is one. A new action is a spawn site plus an `on_*` when the apply is worth testing.
 - **Shared spawn payload** (#375): a value both `run` and `apply` need is part of `run`'s return, unpacked by `apply`. That is how identity (`gist_id`, `fetch_id`, labels) crosses the thread boundary without a second clone.
 
 ## Pin-sync presentation (`@src/tui/pin_sync.rs`)

--- a/src/tui/dispatch.rs
+++ b/src/tui/dispatch.rs
@@ -693,3 +693,140 @@ fn apply_sync_status(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{GistFile, LocalCandidate, PinnedMapping};
+    use crate::tui::test_support::idle_jobs;
+    use std::path::PathBuf;
+
+    /// A pinned `/cwd/a.txt` ↔ `g1:a.txt` pair. `local_mtime` and `remote_updated_at`
+    /// are the only inputs `compute_pin_sync_status` reads for a hash-less mapping, so
+    /// varying them alone walks `apply_sync_status` through its non-spawning arms.
+    fn state_with_one_pin(
+        cwd: PathBuf,
+        local_mtime: Option<u64>,
+        remote_updated_at: Option<&str>,
+    ) -> AppState {
+        let mut state = initial_state();
+        state.cwd = cwd;
+        state.pinned = vec![PinnedMapping {
+            local_path: PathBuf::from("a.txt"),
+            gist_id: "g1".into(),
+            gist_filename: "a.txt".into(),
+            direction: None,
+            last_seen_hash: None,
+        }];
+        if let Some(modified) = local_mtime {
+            state.locals = vec![LocalCandidate {
+                path: PathBuf::from("a.txt"),
+                modified: Some(modified),
+            }];
+        }
+        if let Some(updated_at) = remote_updated_at {
+            state.gist_catalog.owned = vec![GistFile {
+                updated_at: updated_at.into(),
+                ..GistFile::fixture("g1", "a.txt")
+            }];
+        }
+        state
+    }
+
+    fn route(state: &mut AppState, outcome: KeyOutcome) -> LoopFlow {
+        route_outcome(outcome, state, &mut idle_jobs())
+    }
+
+    // ---- apply_sync_status's non-spawning arms ---------------------------
+
+    #[test]
+    fn sync_pin_auto_reports_in_sync_when_both_sides_share_an_mtime() {
+        let updated_at = "2026-06-10T00:00:00Z";
+        let ts = crate::domain::parse_rfc3339_to_unix(updated_at).unwrap();
+        let mut state = state_with_one_pin(PathBuf::from("/cwd"), Some(ts), Some(updated_at));
+        let entry = state.defer_entry();
+
+        route(&mut state, KeyOutcome::SyncPinAuto { entry, index: 0 });
+
+        assert_eq!(state.status.as_deref(), Some("already in sync"));
+        assert!(state.bg_task_msg.is_none(), "InSync must not spawn");
+    }
+
+    #[test]
+    fn sync_pin_auto_reports_a_missing_local_file() {
+        // `pin_mtimes` falls back to stat-ing the path when `locals` has no match, so the
+        // cwd must really be empty rather than merely improbable — hence a temp dir.
+        let cwd = tempfile::tempdir().unwrap();
+        let mut state =
+            state_with_one_pin(cwd.path().to_path_buf(), None, Some("2026-06-10T00:00:00Z"));
+        let entry = state.defer_entry();
+
+        route(&mut state, KeyOutcome::SyncPinAuto { entry, index: 0 });
+
+        assert_eq!(
+            state.status.as_deref(),
+            Some("local file is missing — use d to pull it back")
+        );
+        assert!(state.bg_task_msg.is_none(), "Missing must not spawn");
+    }
+
+    #[test]
+    fn sync_pin_auto_reports_unknown_when_the_gist_side_is_absent() {
+        let mut state = state_with_one_pin(PathBuf::from("/cwd"), Some(1_780_000_000), None);
+        let entry = state.defer_entry();
+
+        route(&mut state, KeyOutcome::SyncPinAuto { entry, index: 0 });
+
+        assert_eq!(
+            state.status.as_deref(),
+            Some("can't tell which side is newer — use u to push or d to pull")
+        );
+        assert!(state.bg_task_msg.is_none(), "Unknown must not spawn");
+    }
+
+    // ---- early returns ----------------------------------------------------
+
+    #[test]
+    fn fork_gist_on_an_owned_gist_returns_before_spawning() {
+        let mut state = test_support::state_with_gists();
+
+        route(
+            &mut state,
+            KeyOutcome::ForkGist {
+                gist_id: "g1".into(),
+            },
+        );
+
+        assert_eq!(
+            state.status.as_deref(),
+            Some("already yours — no fork needed")
+        );
+        assert!(
+            state.bg_task_msg.is_none(),
+            "an owned gist must not be forked"
+        );
+    }
+
+    /// The listed-not-wildcarded arm guards new variants; this guards the other
+    /// direction, where an arm is dropped from `dispatch_outcome` and would otherwise
+    /// become a silent no-op.
+    #[test]
+    #[should_panic(expected = "must keep its arm")]
+    fn a_terminal_bearing_outcome_reaching_route_outcome_trips_the_assert() {
+        let mut state = initial_state();
+        route(&mut state, KeyOutcome::EditUpload);
+    }
+
+    #[test]
+    fn execute_delete_without_a_pending_action_spawns_nothing() {
+        let mut state = test_support::state_with_gists();
+
+        route(&mut state, KeyOutcome::ExecuteDelete);
+
+        assert!(state.pending_action().is_none());
+        assert!(
+            state.bg_task_msg.is_none(),
+            "a delete with nothing pending must not reach gh"
+        );
+    }
+}

--- a/src/tui/dispatch.rs
+++ b/src/tui/dispatch.rs
@@ -15,7 +15,34 @@ pub(super) fn dispatch_outcome(
     jobs: &mut Jobs,
 ) -> Result<LoopFlow> {
     match outcome {
-        KeyOutcome::Quit => return Ok(LoopFlow::Quit),
+        KeyOutcome::EditUpload => {
+            edit_upload_buffer(terminal, state, jobs)?;
+        }
+        KeyOutcome::EditLocal { path } => edit_local_path(terminal, state, &path)?,
+        KeyOutcome::PersistSettings {
+            effect,
+            success_message,
+        } => {
+            persist_settings(state, success_message);
+            if effect == Some(SettingsEffect::SyncMouseCapture) {
+                sync_mouse_capture(terminal, state.settings.mouse_enabled())?;
+            }
+        }
+        terminal_free => return Ok(route_outcome(terminal_free, state, jobs)),
+    }
+    Ok(LoopFlow::Proceed)
+}
+
+/// Every `KeyOutcome` that does not need a `Terminal` (issue #421). `dispatch_outcome`
+/// above keeps the ones that do and delegates the rest here, so this layer is reachable
+/// from a unit test with nothing but an `AppState` and a `Jobs`.
+///
+/// The seam stops at the spawn call. `Jobs::spawn_action` starts its thread inline
+/// (`@src/tui/bg.rs`), so the arms that spawn still cannot be asserted on from a test —
+/// only the ones that resolve entirely in `AppState`. Tracked as issue #422.
+fn route_outcome(outcome: KeyOutcome, state: &mut AppState, jobs: &mut Jobs) -> LoopFlow {
+    match outcome {
+        KeyOutcome::Quit => return LoopFlow::Quit,
         KeyOutcome::PreviewDiff {
             entry,
             local_path,
@@ -90,7 +117,7 @@ pub(super) fn dispatch_outcome(
         }
         KeyOutcome::FetchComments { gist_id } => {
             let Some(fetch_id) = screens::detail::stage_fetch_comments(state, gist_id) else {
-                return Ok(LoopFlow::Proceed);
+                return LoopFlow::Proceed;
             };
             jobs.spawn_action(
                 state,
@@ -107,7 +134,7 @@ pub(super) fn dispatch_outcome(
         KeyOutcome::LoadOlderComments { gist_id, page } => {
             let Some(fetch_id) = screens::detail::stage_load_older_comments(state, gist_id, page)
             else {
-                return Ok(LoopFlow::Proceed);
+                return LoopFlow::Proceed;
             };
             jobs.spawn_action(
                 state,
@@ -222,7 +249,7 @@ pub(super) fn dispatch_outcome(
                 local_path: _,
             }) = state.pending_action().cloned()
             else {
-                return Ok(LoopFlow::Proceed);
+                return LoopFlow::Proceed;
             };
 
             let upload_content = state.content_to_upload();
@@ -236,7 +263,7 @@ pub(super) fn dispatch_outcome(
                 "temp file",
                 upload_content.as_bytes(),
             ) else {
-                return Ok(LoopFlow::Proceed);
+                return LoopFlow::Proceed;
             };
 
             let has_same_name = state
@@ -266,12 +293,9 @@ pub(super) fn dispatch_outcome(
                 move |result, state| gist_mutation::on_upload_replace(state, result, file),
             );
         }
-        KeyOutcome::EditUpload => {
-            edit_upload_buffer(terminal, state, jobs)?;
-        }
         KeyOutcome::Create(public) => {
             let Some(PendingAction::Create { local_path }) = state.pending_action().cloned() else {
-                return Ok(LoopFlow::Proceed);
+                return LoopFlow::Proceed;
             };
             let description = state.description_input.to_string();
             let plan = crate::actions::create_command(&local_path, public, &description);
@@ -326,11 +350,10 @@ pub(super) fn dispatch_outcome(
         }
         KeyOutcome::CopyGistUrl { gist_id } => copy_gist_url_id(state, &gist_id),
         KeyOutcome::CopyPreviewContent => copy_preview_content(state),
-        KeyOutcome::EditLocal { path } => edit_local_path(terminal, state, &path)?,
         KeyOutcome::ExecuteDelete => {
             let Some(PendingAction::Delete { gist_id, .. }) = state.pending_action().cloned()
             else {
-                return Ok(LoopFlow::Proceed);
+                return LoopFlow::Proceed;
             };
             let plan = crate::actions::delete_command(&gist_id);
             state.cancel_confirm_after_delete();
@@ -351,7 +374,7 @@ pub(super) fn dispatch_outcome(
                 gist_id, filename, ..
             }) = state.pending_action().cloned()
             else {
-                return Ok(LoopFlow::Proceed);
+                return LoopFlow::Proceed;
             };
             let plan = crate::actions::remove_file_command(&gist_id, &filename);
             state.back_to_list();
@@ -376,7 +399,7 @@ pub(super) fn dispatch_outcome(
                 count,
             }) = state.pending_action().cloned()
             else {
-                return Ok(LoopFlow::Proceed);
+                return LoopFlow::Proceed;
             };
             state.cancel_confirm();
 
@@ -427,7 +450,7 @@ pub(super) fn dispatch_outcome(
             });
             let Some(idx) = idx else {
                 state.set_status("pair is not pinned — press p to pin first");
-                return Ok(LoopFlow::Proceed);
+                return LoopFlow::Proceed;
             };
             let m = state.pinned[idx].clone();
             let status = state.compute_pin_sync_status(idx);
@@ -445,7 +468,7 @@ pub(super) fn dispatch_outcome(
         }
         KeyOutcome::SyncPinAuto { entry, index } => {
             let Some(m) = state.pinned.get(index).cloned() else {
-                return Ok(LoopFlow::Proceed);
+                return LoopFlow::Proceed;
             };
             let status = state.compute_pin_sync_status(index);
             apply_sync_status(state, jobs, &m, status, entry);
@@ -453,15 +476,6 @@ pub(super) fn dispatch_outcome(
         KeyOutcome::PreviewPinDiff { entry, index } => {
             if let Some(m) = state.pinned.get(index).cloned() {
                 spawn_pin_diff(state, jobs, &m, entry);
-            }
-        }
-        KeyOutcome::PersistSettings {
-            effect,
-            success_message,
-        } => {
-            persist_settings(state, success_message);
-            if effect == Some(SettingsEffect::SyncMouseCapture) {
-                sync_mouse_capture(terminal, state.settings.mouse_enabled())?;
             }
         }
         KeyOutcome::FetchRevisions { gist_id } => {
@@ -567,7 +581,7 @@ pub(super) fn dispatch_outcome(
                 ..
             }) = state.pending_action().cloned()
             else {
-                return Ok(LoopFlow::Proceed);
+                return LoopFlow::Proceed;
             };
             // ScratchDir owns cleanup: `write_scratch_file` drops it on early failure; on
             // success ownership moves into the bg job that consumes the JSON payload
@@ -580,7 +594,7 @@ pub(super) fn dispatch_outcome(
                 "restore payload",
                 body.as_bytes(),
             ) else {
-                return Ok(LoopFlow::Proceed);
+                return LoopFlow::Proceed;
             };
             let plan = crate::actions::restore_revision_command(&gist_id, &json_path);
             jobs.spawn_action(
@@ -625,7 +639,7 @@ pub(super) fn dispatch_outcome(
         KeyOutcome::ForkGist { gist_id } => {
             if state.gist_is_owned(&gist_id) {
                 state.set_status("already yours — no fork needed");
-                return Ok(LoopFlow::Proceed);
+                return LoopFlow::Proceed;
             }
             let plan = crate::actions::fork_gist_command(&gist_id);
             jobs.spawn_action(
@@ -640,8 +654,21 @@ pub(super) fn dispatch_outcome(
             );
         }
         KeyOutcome::None => {}
+        // Handled by `dispatch_outcome`'s shell above, so unreachable here. Listed
+        // rather than wildcarded to guard the forward direction: a *new* variant nobody
+        // routes fails to compile. The assert guards the backward one — an arm dropped
+        // from the shell would otherwise arrive via `terminal_free` and quietly do
+        // nothing, which no compiler check and no test would catch.
+        KeyOutcome::EditUpload
+        | KeyOutcome::EditLocal { .. }
+        | KeyOutcome::PersistSettings { .. } => {
+            debug_assert!(
+                false,
+                "a terminal-bearing outcome reached route_outcome — dispatch_outcome must keep its arm"
+            );
+        }
     }
-    Ok(LoopFlow::Proceed)
+    LoopFlow::Proceed
 }
 
 /// What to do for each [`crate::domain::SyncStatus`] arm of a pinned mapping (issue #320):

--- a/src/tui/test_support.rs
+++ b/src/tui/test_support.rs
@@ -228,3 +228,12 @@ pub(super) fn pins_state_with_long_home_path() -> AppState {
     pins_mut(&mut state).cursor.index = 0;
     state
 }
+
+/// An idle [`Jobs`] for tests that call into `dispatch`'s routing layer (issue #421).
+///
+/// `Jobs::startup`'s `fetch_gists` flag is what keeps `GistRefresh::new` from calling
+/// `start` — pass `false` and no thread is spawned, so a test can hand a real `Jobs` to
+/// `route_outcome` and still assert that an arm returned early without starting work.
+pub(super) fn idle_jobs() -> super::bg::Jobs {
+    super::bg::Jobs::startup(None, false, &crate::domain::GistCatalog::default())
+}


### PR DESCRIPTION
Closes #421.

## What

`dispatch_outcome` took a `&mut Terminal<CrosstermBackend<Stdout>>` that only three of its
`KeyOutcome` arms used — `EditUpload`, `EditLocal`, and `PersistSettings`' mouse-capture
effect. Every other arm inherited the dependency and was therefore unreachable from a unit
test.

`dispatch_outcome` now keeps those three and delegates the rest to `route_outcome`, which
takes `&mut AppState` and `&mut Jobs`. With the terminal gone no `?` remains, so
`route_outcome` returns `LoopFlow` rather than `Result<LoopFlow>`. The name is the one
`docs/agents/architecture.md` already used — "`dispatch_outcome` then only **routes** that
payload to `Jobs`".

## What this does not buy

**Not coverage.** `Jobs::spawn_action` calls `std::thread::spawn` in its body, so the arms
that spawn are still untestable — a test that reaches one starts a real thread running `gh`.
That is #422, and `route_outcome`'s doc comment says so at the seam so the boundary is not
mistaken for an oversight. The win here is interface width.

## Exhaustiveness, both directions

- **Forward** — `route_outcome` lists the three terminal variants rather than wildcarding
  them, so a new `KeyOutcome` variant nobody routes fails to compile.
- **Backward** — that arm carries a `debug_assert`. An arm *dropped* from the shell would
  otherwise arrive through `terminal_free` and quietly become a no-op, which no compiler
  check catches. A test asserts the panic fires, so the guard cannot rot.

The shell's own `terminal_free =>` catch-all is a safe default: a variant nobody adds to the
shell belongs in `route_outcome`. This is the opposite of the wildcards removed in #417,
where falling through produced the wrong destructive prompt.

## Tests

Six, one per shape that resolves entirely in `AppState`:

- `apply_sync_status`' `InSync` / `Missing` / `Unknown` arms via `SyncPinAuto` — three
  user-visible status strings governed by `docs/design.md`. `Push`/`Pull` spawn, so they stay out.
- `ForkGist` on an owned gist, and `ExecuteDelete` with nothing pending — early returns.
- The backward-guard panic described above.

Each non-panicking test asserts `bg_task_msg` is `None`, which is what proves the arm returned
*before* `spawn_action` rather than merely setting a status. `test_support` gains `idle_jobs()`
(`Jobs::startup` with `fetch_gists: false`, the flag that keeps `GistRefresh::new` from
spawning). The `Missing` case builds its cwd from `tempfile::tempdir()` so it is hermetic
rather than relying on `/cwd/a.txt` being absent.

## Docs

`architecture.md`'s key-path diagram gains the second layer. The `Terminal` rule is scoped to
the `KeyOutcome` path — `run_loop` still owns the terminal for setup and `draw`. The `on_*`
apply-seam entry kept its conclusion but lost its reason: dispatch is excluded for sitting on
the spawn side, not for needing a `Terminal`.

No ADR. ADR-0002 governs `KeyOutcome` staying plain data; this changes the shape of the
function consuming it, not the enum.

## Known trade-off

`PersistSettings` stays whole in the shell, so its pure-state half (`persist_settings`) is not
reachable from a `route_outcome` test. Accepted — `src/tui/screens/config.rs:230` already
covers it at the `KeyOutcome`-producing end.

## Verification

`mise run check` — 791 passed, 0 failed; clippy and fmt clean.