### PR TITLE
docs: add agent verification and pull request conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,20 +2,13 @@
 
 `gistui` is a Rust 2021 TUI for browsing, comparing, and managing GitHub Gists through `gh`.
 
-## Commands
-
-Toolchains and task wrappers live in [`mise.toml`](mise.toml); run `mise install` once. `gh` is a user runtime dependency and is not pinned.
-
-- Verification gate: `mise run check`
-- Single test: `cargo test <name_filter>`
-- Non-TTY readiness check: `cargo run -- --check`
-- Demo regeneration: `mise run demo` (see `@docs/demo.md`)
-
 ## Pointers
 
 - Product design — voice, product language, row/column layout, the mark vocabulary, README scope: `@docs/agents/design.md`
 - Architecture, state-machine, jobs, IO boundaries, safety seams, truncation, and GistFile constructors: `@docs/agents/architecture.md`
 - Agent-only contribution and release conventions: `@docs/agents/conventions.md`
+- Pull request shape, tests-land-with-behaviour paths, review readiness: `@docs/agents/pull-request.md`
+- Verification gate, commands, evidence, and known gaps: `@docs/agents/verification.md`
 - Human contribution flow: `@CONTRIBUTING.md`
 - Release runbook: `@RELEASING.md`
 - Configuration schema (metadata only): `@config.example.toml`

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -2,6 +2,8 @@
 
 Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
 
+Write issue titles and bodies in **English**, matching the existing tracker and release notes.
+
 ## Conventions
 
 - **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.

--- a/docs/agents/pull-request.md
+++ b/docs/agents/pull-request.md
@@ -1,0 +1,59 @@
+# Pull requests
+
+Write pull request titles, descriptions, and comments in **English**. Commit messages are
+English too — Conventional Commits, imperative, subject under 72 characters.
+
+[`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md) is authoritative
+on structure; what follows adds what it does not say. Release-note labels, milestones, and the
+`CHANGELOG.md` rule live in [`conventions.md`](conventions.md).
+
+## Preparing
+
+- Work from a feature branch, `feat/<topic>` or `fix/issue-<n>`.
+- Title carries a Conventional Commit prefix, as the merged history does. Where one request
+  holds more than one kind of change, the prefix names the dominant one.
+- **Open a pull request, draft included, only when asked.**
+
+## Description shape
+
+1. A plain-language opening: what changed and why, for a reviewer who did not write it.
+2. A visual GitHub renders inline, chosen by what changed:
+
+   | Change | Visual |
+   | --- | --- |
+   | Screen, row/column layout, or mark vocabulary | Before/after stills |
+   | Multi-step key or mouse interaction | Short recording |
+   | State transition or background job lifecycle | Mermaid `flowchart` / `stateDiagram` |
+   | `gh` call sequence | Mermaid `sequenceDiagram` |
+   | Pure module, config, or dependency only | None — test output instead |
+
+   Pair before with after. At most one diagram unless it is such a pair.
+
+   `--attach '<file>#<alt text>'` works on `gh pr create`, `edit`, and `comment`, and on the
+   `gh issue` equivalents, so a visual can land after the request is open. `gh` is unpinned
+   here, so `--help` carries the current limits. Stills come from `mise run demo`
+   (`website/*.png`) or a one-off `tcut` recording. Where capture is impossible,
+   `<!-- screenshot pending: after -->` keeps the gap visible. What an attachment may hold is
+   in [`verification.md`](verification.md).
+3. A collapsed `<details>` trailer holding affected paths, implementation notes, verification
+   commands, and log excerpts.
+
+## Tests land with the behaviour
+
+- **Product logic** — everything under `src/`. A change here lands with its tests in the same
+  request. Which module owns which test is in [`conventions.md`](conventions.md).
+- **Exempt** — `docs/`, `*.md`, `.github/`, `mise.toml`, `scripts/`, and dependency bumps
+  with no behaviour change.
+- **The two seams** — `src/tui/run_loop.rs` and `src/gh/mod.rs` are not unit-tested by design.
+  A change there says so in the description and names what covers it instead.
+
+No coverage threshold. The reviewer judges whether the new behaviour is actually exercised.
+
+## Review readiness
+
+Nothing unverified enters review: `mise run check` passes, and a change touching `gh`
+behaviour passes `cargo run -- --check` too. [`verification.md`](verification.md) holds both,
+the paths that must be exercised rather than only tested, and the gaps worth declaring.
+
+Verification is local, so a request opens ready rather than as a draft awaiting a pipeline.
+State in the description which paths were verified and which were not, with the reason.

--- a/docs/agents/verification.md
+++ b/docs/agents/verification.md
@@ -1,0 +1,107 @@
+# Verification
+
+How an agent exercises a change before it reaches review. Human setup narrative lives in
+[`CONTRIBUTING.md`](../../CONTRIBUTING.md); this file holds only what an agent needs.
+
+## Readiness check
+
+```sh
+cargo run -- --check
+```
+
+<!-- drift:forge github -->
+<!-- drift:entrypoint-cmd cargo run -- --check -->
+
+**Proof it came up**: exit 0 and `gh is installed and authenticated` on stdout. A missing or
+unauthenticated `gh` exits non-zero naming the prerequisite. It never launches the TUI.
+
+The TUI itself needs a TTY, so an agent verifies through `--check` and, where a pane is
+available, through the herdr section below. `mise run run` belongs to a person at a terminal.
+
+## Checks
+
+| What | Command |
+| --- | --- |
+| Full gate — all must pass | `mise run check` |
+| One test | `cargo test <name_filter>` |
+| Demo media | `mise run demo` (see [`docs/demo.md`](../demo.md)) |
+
+The gate's four steps live in `mise.toml`; `mise tasks` lists them.
+
+<!-- drift:file mise.toml -->
+<!-- drift:file tests/fixtures/gh/gist-list.json -->
+
+## Human prerequisites
+
+Run once, by a person. The commands above fail until they are done.
+
+- [ ] `mise install` — provisions the Rust toolchain and `tcut`.
+- [ ] Install `gh` and run `gh auth login`. It prompts, so it belongs to a person.
+
+## Interactive keypaths, through a herdr pane
+
+Where the session runs inside a `herdr` pane, drive the real binary in a sibling pane. Check
+availability first; without it the keypaths stay unverified.
+
+```sh
+test "${HERDR_ENV:-}" = 1 && command -v herdr >/dev/null
+```
+
+When that holds:
+
+```sh
+cargo build
+PANE=$(herdr pane split --current --direction right --cwd "$PWD" --no-focus \
+  | python3 -c 'import sys,json;print(json.load(sys.stdin)["result"]["pane"]["pane_id"])')
+herdr pane run "$PANE" "./target/debug/gistui --no-update-check"
+herdr pane send-text "$PANE" '?'                        # a printable key
+herdr pane send-keys "$PANE" escape                     # a named key
+herdr pane read  "$PANE" --source visible --lines 60    # assert on the frame
+herdr pane close "$PANE"
+```
+
+Assert on row 2 of each read — the pane title carries the screen identity. `--no-update-check`
+keeps the release probe off the wire. Quitting takes `q` twice; the first arms the latch. A key
+the screen does not own is ignored silently and reads like a hang: `g` opens the gist manager
+from the list screen only, so check `src/tui/keymap.rs` before calling a swallowed key a defect.
+
+A pane read holds the user's own gist titles, filenames, and descriptions. Treat it as
+personally identifiable: assert on the frame or a marker glyph, and keep it out of issues,
+pull requests, and transcripts.
+
+## Exercised, not only tested
+
+`mise run check` covers neither of these. Both are per-change calls, made from the paths the
+change touches.
+
+- `src/tui/mod.rs`, `src/tui/bg.rs`, `src/tui/run_loop.rs`, `src/tui/render/` — the terminal
+  seam: raw mode, the alternate screen, mouse capture. Run `mise run demo`; it drives the real
+  binary against `scripts/demo/fake-gh`, reproducible and account-free. Every run rewrites
+  `website/demo.gif`, `website/gist-manager.png`, and `website/revisions.png` whether or not
+  anything looked different, so stage only the media whose appearance changed and
+  `git checkout --` the rest.
+- `src/gh/`, `src/update_check.rs` — only a real account reaches these; `tests/gh_integration.rs`
+  covers the plans and the parsing through a fake runner. Where `HERDR_ENV=1`, smoke them in a
+  pane as above; otherwise record them in the request's unverified list.
+
+## Capturing evidence
+
+- Recording and stills: `mise run demo`, wrapping `tcut scripts/demo.video.ts` and
+  `tcut scripts/demo.stills.ts`. See [`docs/demo.md`](../demo.md).
+- A screen-visible change goes into the pull request as a still or a short recording; a
+  pure-module change goes in as test output.
+- Attachments carry no personally identifiable information. Gist titles, filenames, and
+  usernames from a real account count — record against a throwaway account or crop.
+
+<!-- drift:file scripts/demo.video.ts -->
+
+## Not verified
+
+- Interactive keypaths outside a herdr pane: no TTY. Covered by unit tests in
+  `src/tui/screens/`, `src/tui/keys.rs`, and `src/tui/dispatch.rs`.
+- `src/tui/run_loop.rs` and `src/gh/mod.rs`: the seams themselves, not unit-tested by design.
+  See [`architecture.md`](architecture.md).
+- `src/upgrade.rs`: exercising it calls the real GitHub Releases API and can replace the
+  running binary. Verify by hand after a release cut.
+- The release and publish workflows: only a tag push exercises them, so a change there is
+  verified at the next cut. See [`RELEASING.md`](../../RELEASING.md).

--- a/mise.toml
+++ b/mise.toml
@@ -12,7 +12,7 @@
 rust = { version = "stable", components = "rustfmt,clippy" }
 "github:AmanVarshney01/tcut" = "latest"
 
-# Tasks mirror the AGENTS.md verification gate and demo harness so the same
+# Tasks mirror the docs/agents/verification.md gate and demo harness so the same
 # commands run locally and in CI. List them with `mise tasks`.
 
 [tasks.fmt]


### PR DESCRIPTION
## Summary

Agents had no single place to look up how to verify a change or how to shape a pull request. The gate commands were restated in `AGENTS.md`, `CONTRIBUTING.md` and `mise.toml`, and nothing recorded which language issue and pull request bodies use. This gives each of those one home and points the index at them.

Documentation only. No behaviour change, so the evidence is the gate output rather than a diagram.

## Changes

- `docs/agents/verification.md` (new): the readiness check, the gate table, human prerequisites, evidence capture, which paths must be exercised rather than only unit-tested, and an explicit list of what stays unverified. Carries `drift:` markers so `check-drift.sh` can compare it against the repo.
- `docs/agents/pull-request.md` (new): request shape, the paths whose changes land with tests, and review readiness, plus how an agent actually attaches a still or a recording. `.github/PULL_REQUEST_TEMPLATE.md` stays authoritative on structure; labels and milestones stay in `conventions.md`.
- `docs/agents/issue-tracker.md`: records English as the language for issue titles and bodies.
- `AGENTS.md`: drops the `## Commands` section, now held by `verification.md`, and adds the two pointers.
- `mise.toml`: the comment naming the gate now points at `verification.md`.

## Testing

- [x] `cargo fmt --check`
- [x] `cargo test`
- [x] `cargo check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Manually verified in the TUI (if applicable)

<details>
<summary>Verification detail</summary>

`mise run check` passed all four gates. `cargo run -- --check` exits 0 with `gh is installed and authenticated`.

The interactive keypaths documented in the new herdr section were exercised against the real binary in a herdr pane: `?` opens Help, `Esc` returns to the list, `C` opens Settings, `P` opens Pinned Mappings, `g` opens the gist manager, `Tab` and `j` move focus and cursor, and `q` twice arms the quit latch before exiting cleanly.

`g` is silently ignored on the Settings and Pins screens. That is by design, not a defect: `src/tui/keymap.rs:177` marks it guarded and only `src/tui/screens/list.rs:285` handles it, with `src/tui/screens/gists.rs:402` already asserting `KeyOutcome::None` elsewhere. The new document says so, so the next agent does not read the silence as a hang.

A herdr pane runs against the real `gh` account, so pane reads hold private gist data. The document treats them as personally identifiable and none appear in this request.

`scripts/check-drift.sh` from the `setup-agent-ready-repo` skill reports no drift.

</details>

## Related Issues

None.
