### PR TITLE
Expand issue tracker conventions and settle the PR title rule

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -84,8 +84,6 @@ already exist; a genuinely missing one is a conversation with the maintainer, ne
 - **Disposition** — `question` for a support request, `duplicate` alongside a comment pointing
   at the original, `invalid` for a report that is not one.
 - **Automated** — `dependencies`, `rust`, and `github_actions` are Dependabot's. Leave them to it.
-- **Wayfinding** — the `wayfinder:*` labels named below are not in the live set. `/wayfinder`
-  needs the maintainer to create them first.
 
 ## Pull requests as a triage surface
 
@@ -106,14 +104,3 @@ Create a GitHub issue.
 ## When a skill says "fetch the relevant ticket"
 
 Run `gh issue view <number> --comments`.
-
-## Wayfinding operations
-
-Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
-
-- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
-- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
-- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
-- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
-- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
-- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -15,6 +15,78 @@ Write issue titles and bodies in **English**, matching the existing tracker and 
 
 Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
 
+## Description shape
+
+1. Open with what a maintainer or a new contributor would observe — the symptom, or the thing
+   they want to be able to do — in plain language. Skip file paths and module names unless the
+   reader cannot otherwise locate the issue.
+2. Add a visual the forge renders inline: stills for anything on screen, a short recording for
+   a multi-step interaction, a Mermaid `flowchart`/`stateDiagram` for a state or job change.
+   No attachment carries personally identifiable information — gist titles, filenames, and
+   usernames from a real account count, so record against a throwaway account or crop. Upload
+   with `gh issue create --attach './bug.png#alt text'`. The flag also works on
+   `gh issue comment` and `gh issue edit`, so a visual can land after the issue is open.
+3. Close with a collapsed trailer, so the technical detail does not push the human summary
+   below the fold:
+
+   ```markdown
+   <details><summary>Technical details</summary>
+
+   Version, platform, `gh` version, affected paths, log excerpts.
+
+   </details>
+   ```
+
+## Spec issues
+
+An issue an agent implements from inverts that priority. Acceptance criteria, scope, and how
+to verify sit above the fold; `<details>` holds only background.
+
+```markdown
+## Acceptance criteria
+
+- [ ] One observable outcome per line.
+
+## Scope
+
+- **In**: the screens, modules, or commands this change may touch.
+- **Out**: what it must leave alone.
+
+## How to verify
+
+The gate, plus the per-change calls the touched paths ask for.
+
+<details><summary>Background</summary>
+
+Why this came up, prior attempts, links.
+
+</details>
+```
+
+An issue with unanswered open questions is not ready to implement. Ask in a comment and leave
+it in triage until the answers land.
+
+## Labels
+
+Read the live set with `gh label list --limit 100`. The CLI defaults to 30 and presents that
+page as the whole set, so a label past the first page reads as absent. Apply only labels that
+already exist; a genuinely missing one is a conversation with the maintainer, never a
+`gh label create`.
+
+- **Triage state** — [`triage-labels.md`](triage-labels.md) owns the canonical roles and their
+  label strings. It is their only home here.
+- **Priority** — one of `P0` critical, `P1` current cycle, `P2` soon, `P3` nice to have,
+  `P4` backlog. An issue carries at most one.
+- **Release notes** — every pull request carries exactly one category label; the set and the
+  rule live in [`conventions.md`](conventions.md).
+- **Invitation** — `good first issue` and `help wanted`, on work a maintainer wants outside
+  hands on.
+- **Disposition** — `question` for a support request, `duplicate` alongside a comment pointing
+  at the original, `invalid` for a report that is not one.
+- **Automated** — `dependencies`, `rust`, and `github_actions` are Dependabot's. Leave them to it.
+- **Wayfinding** — the `wayfinder:*` labels named below are not in the live set. `/wayfinder`
+  needs the maintainer to create them first.
+
 ## Pull requests as a triage surface
 
 **PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_

--- a/docs/agents/pull-request.md
+++ b/docs/agents/pull-request.md
@@ -10,8 +10,8 @@ on structure; what follows adds what it does not say. Release-note labels, miles
 ## Preparing
 
 - Work from a feature branch, `feat/<topic>` or `fix/issue-<n>`.
-- Title carries a Conventional Commit prefix, as the merged history does. Where one request
-  holds more than one kind of change, the prefix names the dominant one.
+- Title carries **no** Conventional Commit prefix. Commit subjects do; the title reads as a
+  plain sentence naming the change, because release notes group by label, not by prefix.
 - **Open a pull request, draft included, only when asked.**
 
 ## Description shape


### PR DESCRIPTION
## Summary

`docs/agents/issue-tracker.md` told an agent how to call `gh` but not what to put in an issue. Three sections now sit between the `gh` conventions and the triage-surface flag: how a human-facing issue is shaped, how a spec issue an agent implements from inverts that shape, and which labels this repo actually has. Two follow-ups settle questions the first commit surfaced.

## Changes

- **Description shape** — the human summary opens the body, a visual the forge renders inline follows, and the technical trailer goes in a collapsed `<details>` so it cannot push the summary below the fold. Attachments carry no personally identifiable information, matching the rule already in `verification.md`.
- **Spec issues** — a fenced sample body where acceptance criteria, scope in and out, and how to verify sit above the fold and `<details>` holds only background. An issue with unanswered open questions is not ready to implement.
- **Labels** — read against `gh label list --limit 100`, since the CLI's default page of 30 presents itself as the whole set. Triage roles stay owned by `triage-labels.md` and are referenced, not restated, so a rename has one place to land. The section covers only what that file does not own: the `P0`–`P4` priorities, the invitation and disposition labels, and Dependabot's.
- **PR titles** — `pull-request.md` now forbids a Conventional Commit prefix on the title. Commit subjects keep theirs. Release notes group by label, so the prefix bought nothing and only had to be kept consistent by hand. This PR's own title follows the new rule.
- **Wayfinding** — the Wayfinding operations section is gone. It described a `/wayfinder` workflow resting on `wayfinder:map` and `wayfinder:<type>` labels that this repo does not have, so it was instruction budget spent on a path no agent could take.

Nothing was created or invented in the tracker. `docs/agents/issue-tracker.md` is 106 lines, so it stays cheap to load on every turn through the `AGENTS.md` pointer.

## Testing

- [x] `cargo fmt --check`
- [x] `cargo test`
- [x] `cargo check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] Manually verified in the TUI (if applicable) — N/A, documentation only

<details><summary>Technical details</summary>

Documentation only: no `src/` path is touched, so the tests-land-with-behaviour rule in `pull-request.md` exempts it, and `cargo run -- --check` is not called because no `gh` behaviour changed.

The macOS CI failure on this branch is not from these commits. It is a pre-existing path collision in `ScratchDir::create`, fixed separately in #442. Merge that first; this branch goes green on a rebase. `mise run check` passes locally here.

`triage-labels.md` was audited against `gh label list` in the same pass. All five roles it maps (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`) exist with matching descriptions, so it needed no correction and gets no commit.

`CONTRIBUTING.md` line 58 still points humans at Conventional Commits. That is the commit rule, not the title rule, so it stands unchanged.

Three commits, one concern each.

</details>

## Related Issues

None — no tracking issue. Depends on #442 for green CI.