### PR TITLE
Stop concurrent scratch dirs colliding on one temp path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Two scratch-directory operations started in the same instant (upload, restore revision, or
+  compact) no longer collide on one temp path, where finishing the second deleted the first's
+  payload out from under it.
+
 ## [0.20.0] — 2026-09-02
 
 - A pin sync that cannot be written to `config.toml` now says so on the status line

--- a/src/temp_dir.rs
+++ b/src/temp_dir.rs
@@ -10,6 +10,7 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// RAII unique scratch directory under the system temp dir.
@@ -22,11 +23,22 @@ pub struct ScratchDir {
 }
 
 impl ScratchDir {
-    /// Create a unique empty directory named `.gistui_{kind}_{pid}_{stamp}`.
+    /// Create a unique empty directory named `.gistui_{kind}_{pid}_{stamp}_{seq}`.
+    ///
+    /// `create_dir` refuses an existing directory rather than adopting it, so two
+    /// live `ScratchDir`s can never share a path — otherwise one's Drop deletes the
+    /// other's files. The timestamp alone did not guarantee that: two calls with the
+    /// same `kind` inside one clock tick produced the same name.
     pub fn create(kind: &str) -> std::io::Result<Self> {
-        let path = unique_path(kind);
-        fs::create_dir_all(&path)?;
-        Ok(Self { path })
+        loop {
+            let path = unique_path(kind);
+            match fs::create_dir(&path) {
+                Ok(()) => return Ok(Self { path }),
+                // A fresh `seq` every pass, so the retry cannot spin.
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(e) => return Err(e),
+            }
+        }
     }
 
     pub fn path(&self) -> &Path {
@@ -57,6 +69,9 @@ where
     f(dir.path())
 }
 
+/// Per-process counter, so uniqueness does not rest on the clock's resolution.
+static SEQ: AtomicU64 = AtomicU64::new(0);
+
 fn unique_path(kind: &str) -> PathBuf {
     let stamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -71,7 +86,11 @@ fn unique_path(kind: &str) -> PathBuf {
     } else {
         safe.as_str()
     };
-    std::env::temp_dir().join(format!(".gistui_{kind}_{}_{stamp}", std::process::id()))
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!(
+        ".gistui_{kind}_{}_{stamp}_{seq}",
+        std::process::id()
+    ))
 }
 
 #[cfg(test)]
@@ -141,5 +160,41 @@ mod tests {
         let a = ScratchDir::create("uniq").expect("create a");
         let b = ScratchDir::create("uniq").expect("create b");
         assert_ne!(a.path(), b.path());
+    }
+
+    #[test]
+    fn concurrent_creates_of_one_kind_do_not_share_a_path() {
+        // Regression: the name was pid + timestamp only, so two `restore` scratch
+        // dirs created inside one clock tick landed on the same path. The second
+        // adopted the first's directory, and its Drop deleted the first's payload
+        // out from under a live job. Same kind, same instant, on purpose.
+        const THREADS: usize = 16;
+        let start = std::sync::Arc::new(std::sync::Barrier::new(THREADS));
+
+        let paths: Vec<PathBuf> = (0..THREADS)
+            .map(|i| {
+                let start = std::sync::Arc::clone(&start);
+                std::thread::spawn(move || {
+                    start.wait();
+                    let scratch = ScratchDir::create("same").expect("create");
+                    let path = scratch.path().join("payload.txt");
+                    fs::write(&path, i.to_string().as_bytes()).expect("write");
+                    // Every other thread's dir is still live at this point, so a
+                    // shared path shows up as a lost or overwritten payload.
+                    assert_eq!(fs::read_to_string(&path).expect("read"), i.to_string());
+                    scratch.path().to_path_buf()
+                })
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+            .map(|h| h.join().expect("thread"))
+            .collect();
+
+        let distinct: std::collections::HashSet<&PathBuf> = paths.iter().collect();
+        assert_eq!(
+            distinct.len(),
+            THREADS,
+            "every scratch dir needs its own path"
+        );
     }
 }


### PR DESCRIPTION
## Summary

`ScratchDir::create` named its directory from the process id and a `SystemTime` nanosecond stamp alone. Two calls with the same `kind` inside one clock tick produced the same path, and `create_dir_all` adopted the existing directory instead of refusing it. The second `ScratchDir` then shared the first's path, so its `Drop` ran `remove_dir_all` over a payload the first one was still using.

Upload, restore-revision, and compact all take a scratch directory, so two of them started together could lose each other's files. It surfaced as a flaky macOS CI failure: the two `write_scratch_file` tests in `src/tui/bg.rs` both use the label `restore`, and when they landed in the same tick one deleted the other's file mid-assert.

## Changes

- `ScratchDir::create` now uses `fs::create_dir`, which refuses an existing directory rather than adopting it, and retries on `AlreadyExists`.
- `unique_path` appends a process-wide atomic counter, so uniqueness no longer rests on the clock's resolution and the retry cannot spin.
- A regression test creates 16 scratch dirs of one `kind` from 16 threads released off a barrier, then asserts every path is distinct and every payload survives while the others are live.

## Testing

- [x] `cargo fmt --check`
- [x] `cargo test`
- [x] `cargo check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] Manually verified in the TUI (if applicable) — covered by the new test instead

<details><summary>Technical details</summary>

`mise run check` passes all four steps; 844 unit tests and 12 `gh` integration tests green.

The new test was checked against the old implementation before the fix landed: it failed 5 runs out of 5 with `create_dir_all` and no counter, and passes 5 out of 5 with the fix. The pre-existing `unique_paths_differ_across_calls` never caught this, because two sequential calls almost always straddle a clock tick.

Reproducing the original CI failure locally needs the narrow filter, which pairs the two `restore` tests alone and makes the collision likely:

```sh
cargo test --locked --lib write_scratch          # failed intermittently before
cargo test --locked --lib write_scratch -- --test-threads=1   # always passed
```

`src/temp_dir.rs` is a pure module, so it is unit-tested directly and needs no demo media.

</details>

## Related Issues

None — found while CI ran on #441.