### PR TITLE
Restore the rule against PII in pull request attachments

### DIFF
--- a/docs/agents/pull-request.md
+++ b/docs/agents/pull-request.md
@@ -38,6 +38,10 @@ on structure; what follows adds what it does not say. Release-note labels, miles
 3. A collapsed `<details>` trailer holding affected paths, implementation notes, verification
    commands, and log excerpts.
 
+**No personally identifiable information in any attachment**, whatever ends up attached. Gist
+titles, filenames, and usernames from a real account count; the capture rules in
+[`verification.md`](verification.md) say what to do instead.
+
 ## Tests land with the behaviour
 
 - **Product logic** — everything under `src/`. A change here lands with its tests in the same


### PR DESCRIPTION
## Summary

The `setup-agent-ready-repo` skill now ships a check that reports which guarantees an installed
agent document no longer carries. Running it against this repo found that
`docs/agents/pull-request.md` had lost the rule forbidding personally identifiable information
in attachments. This restores it in the repo's own wording rather than by pasting template prose.

## Changes

- The description shape now forbids personally identifiable information in any attachment, and
  points at the capture rules in `verification.md` for what to do instead. The rule existed only
  on the `verification.md` side, so a reader of the pull request document alone never met it.

The repo's own labels, paths, and gate commands are untouched.

## Testing

- [x] `cargo fmt --check`
- [x] `cargo test`
- [x] `cargo check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] Manually verified in the TUI (if applicable) — documentation only, no runtime behaviour

<details>
<summary>Technical trailer</summary>

Affected path: `docs/agents/pull-request.md` only, four added lines.

Verification, per `docs/agents/verification.md`:

```
mise run check   # exit 0, the four-step gate
bash ~/code/agent-skills/skills/setup-agent-ready-repo/scripts/install-templates.sh --check .
# documents are English, carry no unresolved placeholder, and are level
# with every guarantee the current templates pin
```

`cargo run -- --check` was not run: no `gh` behaviour changed here.

</details>
