### PR TITLE
Standardize agent pointers and restore verification guarantee

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,22 +4,22 @@
 
 ## Pointers
 
-- Product design — voice, product language, row/column layout, the mark vocabulary, README scope: `@docs/agents/design.md`
-- Architecture, state-machine, jobs, IO boundaries, safety seams, truncation, and GistFile constructors: `@docs/agents/architecture.md`
-- Agent-only contribution and release conventions: `@docs/agents/conventions.md`
-- Pull request shape, tests-land-with-behaviour paths, review readiness: `@docs/agents/pull-request.md`
-- Verification gate, commands, evidence, and known gaps: `@docs/agents/verification.md`
-- Human contribution flow: `@CONTRIBUTING.md`
-- Release runbook: `@RELEASING.md`
-- Configuration schema (metadata only): `@config.example.toml`
-- Issue tracker workflow: `@docs/agents/issue-tracker.md`
-- Triage labels: `@docs/agents/triage-labels.md`
-- Domain and ADR discovery: `@docs/agents/domain.md`
+- Product design — voice, product language, row/column layout, the mark vocabulary, README scope: `docs/agents/design.md`
+- Architecture, state-machine, jobs, IO boundaries, safety seams, truncation, and GistFile constructors: `docs/agents/architecture.md`
+- Agent-only contribution and release conventions: `docs/agents/conventions.md`
+- Pull request shape, tests-land-with-behaviour paths, review readiness: `docs/agents/pull-request.md`
+- Verification gate, commands, evidence, and known gaps: `docs/agents/verification.md`
+- Human contribution flow: `CONTRIBUTING.md`
+- Release runbook: `RELEASING.md`
+- Configuration schema (metadata only): `config.example.toml`
+- Issue tracker workflow: `docs/agents/issue-tracker.md`
+- Triage labels: `docs/agents/triage-labels.md`
+- Domain and ADR discovery: `docs/agents/domain.md`
 
 ## Prevent Recurrence
 
 - **Candidate**: Name who hits this again, in which file, on what change. No such scenario, nothing to propose.
-- **Promote**: Offer the first tier that reaches them and only that one, pending confirmation — enforce it (assert/type/test) with its size quoted, else a comment at that site, else an agent-facing doc (`docs/agents/<topic>.md`, else `docs/agents/lessons-learned.md`) with one `@path` line under Pointers and one sentence on why the tiers above cannot hold it. Never both.
+- **Promote**: Offer the first tier that reaches them and only that one, pending confirmation — enforce it (assert/type/test) with its size quoted, else a comment at that site, else an agent-facing doc (`docs/agents/<topic>.md`, else `docs/agents/lessons-learned.md`) with one backtick-path line under Pointers and one sentence on why the tiers above cannot hold it. Never both.
 - **Prune**: When adding to a file, audit the rest of it in the same pass. Drop entries once stale (obsolete version, now enforced, duplicated, or a transcript) — not by a fixed count.
 
 ## Claude Code Compatibility

--- a/docs/agents/verification.md
+++ b/docs/agents/verification.md
@@ -105,3 +105,7 @@ change touches.
   running binary. Verify by hand after a release cut.
 - The release and publish workflows: only a tag push exercises them, so a change there is
   verified at the next cut. See [`RELEASING.md`](../../RELEASING.md).
+
+A gap you could have closed is not a gap. Run the check whose dependency
+you have already seen running, and report a check you skipped as untried,
+rather than recording it here as one this repo cannot run.


### PR DESCRIPTION
## Summary

Audited `AGENTS.md` and repository agent configurations via `/agents-md` and `/setup-agent-ready-repo`:
1. Standardized pointers in `AGENTS.md` to standard backtick paths rather than `@path` notation.
2. Restored the verification guarantee in `docs/agents/verification.md` that dependencies you can close are not gaps.

## Changes

- `AGENTS.md`: converted `@path` pointer references to backtick paths (`path`) and updated the `Prevent Recurrence` promote line accordingly.
- `docs/agents/verification.md`: added the template guarantee statement under `## Not verified`.

## Testing

- [x] `cargo fmt --check`
- [x] `cargo test`
- [x] `cargo check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] Manually verified in the TUI (if applicable) — documentation only, no runtime behaviour

<details>
<summary>Technical trailer</summary>

Affected paths: `AGENTS.md`, `docs/agents/verification.md`.

Verification commands:
- `mise run check` (all 844 tests passed, lint/format clean)
- `cargo run -- --check` (readiness check passed)
- `install-templates.sh --check` (exit 0)
- `check-drift.sh` (exit 0)

</details>